### PR TITLE
[docs] fix a small typo (`ligthning` -> `lightning`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## ast-grep(sg)
 
-ast-grep(sg) is a ligthning fast and user friendly tool for code searching, linting, rewriting at large scale.
+ast-grep(sg) is a lightning fast and user friendly tool for code searching, linting, rewriting at large scale.
 
 ## Introduction
 ast-grep is a AST-based tool to search code by pattern code. Think it as your old-friend `grep` but it matches AST node instead of text.

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -11,9 +11,9 @@ gtag('config', 'G-EZSJ3YF2RG');
 export default defineConfig({
   lang: 'en-US',
   title: 'ast-grep',
-  titleTemplate: 'ligthning fast code tool',
+  titleTemplate: 'lightning fast code tool',
   base: '/ast-grep/',
-  description: 'ast-grep(sg) is a ligthning fast and user friendly tool for code searching, linting, rewriting at large scale.',
+  description: 'ast-grep(sg) is a lightning fast and user friendly tool for code searching, linting, rewriting at large scale.',
   head: [
     ['script', {async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-EZSJ3YF2RG'}],
     ['script', {}, gaScript],

--- a/website/guide/introduction.md
+++ b/website/guide/introduction.md
@@ -23,7 +23,7 @@ In comparison to Babel, you can complete this hello-world task in ast-grep
 console.log
 ```
 
-See [playground](https://herringtondarkholme.github.io/ast-grep/playground.html) in action!
+See [playground](https://ast-grep.github.io/ast-grep/playground.html) in action!
 
 Upon the simple pattern code, we can build a series of operators to compose complex matching rules for various scenarios.
 

--- a/website/index.md
+++ b/website/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: AST-GREP
   text: Write Code to Match Code
-  tagline: ast-grep(sg) is a ligthning fast and user friendly tool for code searching, linting, rewriting at large scale.
+  tagline: ast-grep(sg) is a lightning fast and user friendly tool for code searching, linting, rewriting at large scale.
   image:
     src: ./logo.svg
     alt: ast-grep 


### PR DESCRIPTION
(๑>؂<๑）