### PR TITLE
Fix code style and `online playground` css style

### DIFF
--- a/crates/cli/src/print.rs
+++ b/crates/cli/src/print.rs
@@ -22,12 +22,12 @@ pub struct ErrorReporter {
 }
 
 arg_enum! {
-    #[derive(Debug)]
-    pub enum ReportStyle {
-        Rich,
-        Medium,
-        Short,
-    }
+  #[derive(Debug)]
+  pub enum ReportStyle {
+    Rich,
+    Medium,
+    Short,
+  }
 }
 
 impl ErrorReporter {
@@ -82,7 +82,7 @@ impl ErrorReporter {
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
-    p.as_ref().display().to_string()
+  p.as_ref().display().to_string()
 }
 
 #[cfg(target_os = "windows")]

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -4,4 +4,9 @@
   --vp-c-brand-lighter: #f2de32;
   --vp-c-brand-dark: #a89f2a;
   --vp-c-brand-darker: #918623;
+  --vp-custom-selctor-option-text: #213547;
+}
+
+.dark {
+  --vp-custom-selctor-option-text: #213547;
 }

--- a/website/guide/introduction.md
+++ b/website/guide/introduction.md
@@ -53,5 +53,5 @@ It is written in Rust, a native language and utilize multiple cores. (It can eve
 You can start from writing a oneliner to rewrite code at command line with minimal investment. Later if you see some code smell recurrently appear in your projects, you can write a linter rule in YAML with a few patterns combined. Finally if you are a library author or framework designer, astgrep provide programmatic interface to rewrite or transpile code efficiently.
 
 ### Pragmatism
-ast-grep comes with batteries included. Interactive code modification is available .Linter and language server work out of box when you install the command line tool. Astgrep is also shipped with test à for rule authors.
+ast-grep comes with batteries included. Interactive code modification is available. Linter and language server work out of box when you install the command line tool. Astgrep is also shipped with test à for rule authors.
 

--- a/website/src/components/SelectLang.vue
+++ b/website/src/components/SelectLang.vue
@@ -26,7 +26,7 @@ function onChange(event: Event) {
   <div class="selector">
     Language:
     <select :value="modelValue" @change="onChange">
-      <option v-for="val, key in languages" :value="key">{{val}}</option>
+      <option class="selector-op-text" v-for="val, key in languages" :value="key">{{val}}</option>
     </select> ▿
     </div>
 </template>
@@ -40,5 +40,8 @@ select {
   padding: 0.5em 0 0.5em 0.5em;
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   cursor: pointer;
+}
+.selector-op-text {
+  color: var(--vp-custom-selctor-option-text);
 }
 </style>


### PR DESCRIPTION
**5b924f5821fdc0f3e3e44e529bf9bfa6c5ccb7df** details are:

In dark mode, langages text is displayed as

![image](https://user-images.githubusercontent.com/28618801/191964796-8a856842-fa80-4cdf-989b-d1087d78cf6a.png)

Now:

![image](https://user-images.githubusercontent.com/28618801/191965324-b17ca987-e7d8-4192-8926-7d11238738dc.png)

