### PR TITLE
feat: add contingent rules with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ name = "ast-grep-config"
 version = "0.1.7"
 dependencies = [
  "ast-grep-core",
+ "globset",
  "regex",
  "serde",
  "serde_yaml",

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -137,9 +137,6 @@ pub fn run_with_config(args: ScanArg) -> Result<()> {
           if from_extension(path).filter(|&n| n == lang).is_none() {
             continue;
           }
-          if !config.matches_path(path) {
-            continue;
-          }
           let ret = filter_file_interactive(path, lang, &matcher);
           if ret.is_some() {
             return ret;
@@ -264,9 +261,6 @@ fn match_rule_on_file(
   rule: &RuleConfig<SupportLang>,
   reporter: &ErrorReporter,
 ) {
-  if !rule.matches_path(path) {
-    return;
-  }
   let matcher = rule.get_matcher();
   let file_content = match read_to_string(path) {
     Ok(content) => content,

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -137,6 +137,9 @@ pub fn run_with_config(args: ScanArg) -> Result<()> {
           if from_extension(path).filter(|&n| n == lang).is_none() {
             continue;
           }
+          if !config.matches_path(path) {
+            continue;
+          }
           let ret = filter_file_interactive(path, lang, &matcher);
           if ret.is_some() {
             return ret;
@@ -261,6 +264,9 @@ fn match_rule_on_file(
   rule: &RuleConfig<SupportLang>,
   reporter: &ErrorReporter,
 ) {
+  if !rule.matches_path(path) {
+    return;
+  }
   let matcher = rule.get_matcher();
   let file_content = match read_to_string(path) {
     Ok(content) => content,

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -137,6 +137,9 @@ pub fn run_with_config(args: ScanArg) -> Result<()> {
           if from_extension(path).filter(|&n| n == lang).is_none() {
             continue;
           }
+          if !config.matches_path(path) {
+            continue;
+          }
           let ret = filter_file_interactive(path, lang, &matcher);
           if ret.is_some() {
             return ret;
@@ -261,6 +264,9 @@ fn match_rule_on_file(
   rule: &RuleConfig<SupportLang>,
   reporter: &ErrorReporter,
 ) {
+  if !rule.matches_path(path) {
+    return;
+  }
   let matcher = rule.get_matcher();
   let file_content = match read_to_string(path) {
     Ok(content) => content,
@@ -355,6 +361,7 @@ rule:
     assert!(config.ignores.iter().count() == 1);
     assert!(!config.matches_path(Path::new("manage.py")));
     assert!(!config.matches_path(Path::new("src/test.py")));
+    assert!(config.matches_path(Path::new("src/app.py")));
   }
 
   #[test]
@@ -370,5 +377,6 @@ rule:
     assert!(config.files.iter().count() == 1);
     assert!(config.matches_path(Path::new("manage.py")));
     assert!(config.matches_path(Path::new("src/test.py")));
+    assert!(config.matches_path(Path::new("src/app.py")));
   }
 }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -352,31 +352,31 @@ fix: ($B, lifecycle.update(['$A']))",
   fn test_ignore_rule() {
     let src = r#"
 ignores:
-  - manage.py
+  - ./manage.py
   - "**/test*"
 rule:
   all:
 "#;
     let config = make_rule(src);
     assert!(config.ignores.iter().count() == 1);
-    assert!(!config.matches_path(Path::new("manage.py")));
-    assert!(!config.matches_path(Path::new("src/test.py")));
-    assert!(config.matches_path(Path::new("src/app.py")));
+    assert!(!config.matches_path(Path::new("./manage.py")));
+    assert!(!config.matches_path(Path::new("./src/test.py")));
+    assert!(config.matches_path(Path::new("./src/app.py")));
   }
 
   #[test]
   fn test_files_rule() {
     let src = r#"
 files:
-  - manage.py
+  - ./manage.py
   - "**/test*"
 rule:
   all:
 "#;
     let config = make_rule(src);
     assert!(config.files.iter().count() == 1);
-    assert!(config.matches_path(Path::new("manage.py")));
-    assert!(config.matches_path(Path::new("src/test.py")));
-    assert!(!config.matches_path(Path::new("src/app.py")));
+    assert!(config.matches_path(Path::new("./manage.py")));
+    assert!(config.matches_path(Path::new("./src/test.py")));
+    assert!(!config.matches_path(Path::new("./src/app.py")));
   }
 }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -377,6 +377,6 @@ rule:
     assert!(config.files.iter().count() == 1);
     assert!(config.matches_path(Path::new("manage.py")));
     assert!(config.matches_path(Path::new("src/test.py")));
-    assert!(config.matches_path(Path::new("src/app.py")));
+    assert!(!config.matches_path(Path::new("src/app.py")));
   }
 }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -385,13 +385,14 @@ rule:
     let src = r#"
 files:
   - ./src/**/*.py
-ignore:
+ignores:
   - ./src/excluded/*.py
 rule:
   all:
 "#;
     let config = make_rule(src);
     assert!(config.files.iter().count() == 1);
+    assert!(config.ignores.iter().count() == 1);
     assert!(config.matches_path(Path::new("./src/test.py")));
     assert!(config.matches_path(Path::new("./src/some_folder/test.py")));
     assert!(!config.matches_path(Path::new("./src/excluded/app.py")));

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -379,4 +379,21 @@ rule:
     assert!(config.matches_path(Path::new("./src/test.py")));
     assert!(!config.matches_path(Path::new("./src/app.py")));
   }
+
+  #[test]
+  fn test_files_with_ignores_rule() {
+    let src = r#"
+files:
+  - ./src/**/*.py
+ignore:
+  - ./src/excluded/*.py
+rule:
+  all:
+"#;
+    let config = make_rule(src);
+    assert!(config.files.iter().count() == 1);
+    assert!(config.matches_path(Path::new("./src/test.py")));
+    assert!(config.matches_path(Path::new("./src/some_folder/test.py")));
+    assert!(!config.matches_path(Path::new("./src/excluded/app.py")));
+  }
 }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -341,4 +341,34 @@ fix: ($B, lifecycle.update(['$A']))",
     let ret = apply_rewrite(&root, config.get_matcher(), &config.get_fixer().unwrap());
     assert_eq!(ret, "let a = () => (c++, lifecycle.update(['c']))");
   }
+
+  #[test]
+  fn test_ignore_rule() {
+    let src = r#"
+ignores:
+  - manage.py
+  - "**/test*"
+rule:
+  all:
+"#;
+    let config = make_rule(src);
+    assert!(config.ignores.iter().count() == 1);
+    assert!(!config.matches_path(Path::new("manage.py")));
+    assert!(!config.matches_path(Path::new("src/test.py")));
+  }
+
+  #[test]
+  fn test_files_rule() {
+    let src = r#"
+files:
+  - manage.py
+  - "**/test*"
+rule:
+  all:
+"#;
+    let config = make_rule(src);
+    assert!(config.files.iter().count() == 1);
+    assert!(config.matches_path(Path::new("manage.py")));
+    assert!(config.matches_path(Path::new("src/test.py")));
+  }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,6 +19,7 @@ ast-grep-core = { version="0.1.7", path = "../core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"
 regex = {version = "1.6.0", optional = true }
+globset = "0.4.9"
 
 [dev-dependencies]
 tree-sitter-typescript="0.20.1"

--- a/crates/config/src/rule_collection.rs
+++ b/crates/config/src/rule_collection.rs
@@ -45,13 +45,19 @@ impl<L: Language + Eq> RuleCollection<L> {
 
   // TODO: get rules without allocation
   pub fn get_rules_for_lang(&self, lang: &L) -> Vec<&RuleConfig<L>> {
-    // TODO: add contingent
+    let mut all_rules = vec![];
     for rule in &self.tenured {
       if &rule.lang == lang {
-        return rule.rules.iter().collect();
+        all_rules = rule.rules.iter().collect();
       }
     }
-    vec![]
+    for rule in &self.contingent {
+      if &rule.language == lang {
+        all_rules.push(rule);
+      }
+    }
+
+    all_rules
   }
 
   pub fn get_rule(&self, id: &str) -> Option<&RuleConfig<L>> {


### PR DESCRIPTION
Starting this PR because I want to only apply rules to certain files in my codebase.

"Contingent rules" seem to be the rules which are only applied to certain files. [4548c6f](https://github.com/ast-grep/ast-grep/pull/82/commits/4548c6f37a5ee51e62f4714513fbddefdcdaccd2) adds loading for these rules, adds a `matches_path` function to `RuleConfig` which can be used to see if a rule should be run on a given path, and adds a test for testing both of these.

Note: Globset was used because this was the same library that `ignore` uses. The `Glob` object can be used to build [overrides](https://docs.rs/ignore/latest/ignore/overrides/struct.Glob.html) for ignore's WalkBuilder. When we separate the rules into TenuredRules and ContingentRules, we will be able to efficiently build walk builders for each ContingentRule. 

Instead of building walkbuilders, this PR checks each path before reading the file in the normal and interactive walk builder. If it matches the rule, it will read the file and continue with normal operation. 

