### PR TITLE
feat: remove var matcher

### DIFF
--- a/crates/config/src/constraints.rs
+++ b/crates/config/src/constraints.rs
@@ -75,11 +75,16 @@ impl<L: Language> Matcher<L> for RuleWithConstraint<L> {
     node: Node<'tree, L>,
     env: &mut MetaVarEnv<'tree, L>,
   ) -> Option<Node<'tree, L>> {
-    self.rule.match_node_with_env(node, env)
+    let ret = self.rule.match_node_with_env(node, env);
+    if ret.is_some() && env.match_constraints(&self.matchers) {
+      ret
+    } else {
+      None
+    }
   }
 
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    MetaVarEnv::from_matchers(self.matchers.clone())
+    MetaVarEnv::new()
   }
 
   fn potential_kinds(&self) -> Option<BitSet> {

--- a/crates/config/src/constraints.rs
+++ b/crates/config/src/constraints.rs
@@ -83,10 +83,6 @@ impl<L: Language> Matcher<L> for RuleWithConstraint<L> {
     }
   }
 
-  fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    MetaVarEnv::new()
-  }
-
   fn potential_kinds(&self) -> Option<BitSet> {
     self.rule.potential_kinds()
   }

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -45,7 +45,7 @@ pub trait Matcher<L: Language> {
   fn match_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
     let mut env = self.get_meta_var_env();
     let node = self.match_node_with_env(node, &mut env)?;
-    env.match_constraints().then_some(NodeMatch::new(node, env))
+    Some(NodeMatch::new(node, env))
   }
 
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -4,7 +4,7 @@ mod pattern;
 #[cfg(feature = "regex")]
 mod text;
 
-use crate::meta_var::{MetaVarEnv, MetaVarMatchers};
+use crate::meta_var::MetaVarEnv;
 use crate::traversal::Pre;
 use crate::Language;
 use crate::Node;
@@ -48,12 +48,8 @@ pub trait Matcher<L: Language> {
     env.match_constraints().then_some(NodeMatch::new(node, env))
   }
 
-  fn get_meta_var_matchers(&self) -> MetaVarMatchers<L> {
-    MetaVarMatchers::new()
-  }
-
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    MetaVarEnv::from_matchers(self.get_meta_var_matchers())
+    MetaVarEnv::new()
   }
 
   fn find_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
@@ -122,10 +118,6 @@ where
     (**self).match_node(node)
   }
 
-  fn get_meta_var_matchers(&self) -> MetaVarMatchers<L> {
-    (**self).get_meta_var_matchers()
-  }
-
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
     (**self).get_meta_var_env()
   }
@@ -155,10 +147,6 @@ impl<L: Language> Matcher<L> for Box<dyn Matcher<L>> {
 
   fn match_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
     (**self).match_node(node)
-  }
-
-  fn get_meta_var_matchers(&self) -> MetaVarMatchers<L> {
-    (**self).get_meta_var_matchers()
   }
 
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -43,13 +43,10 @@ pub trait Matcher<L: Language> {
   }
 
   fn match_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
-    let mut env = self.get_meta_var_env();
+    // in future we might need to customize initial MetaVarEnv
+    let mut env = MetaVarEnv::new();
     let node = self.match_node_with_env(node, &mut env)?;
     Some(NodeMatch::new(node, env))
-  }
-
-  fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    MetaVarEnv::new()
   }
 
   fn find_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
@@ -118,10 +115,6 @@ where
     (**self).match_node(node)
   }
 
-  fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    (**self).get_meta_var_env()
-  }
-
   fn find_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
     (**self).find_node(node)
   }
@@ -147,10 +140,6 @@ impl<L: Language> Matcher<L> for Box<dyn Matcher<L>> {
 
   fn match_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {
     (**self).match_node(node)
-  }
-
-  fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    (**self).get_meta_var_env()
   }
 
   fn find_node<'tree>(&self, node: Node<'tree, L>) -> Option<NodeMatch<'tree, L>> {

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -10,19 +10,13 @@ pub type MetaVariableID = String;
 /// const a = 123 matched with const a = $A will produce env: $A => 123
 #[derive(Clone)]
 pub struct MetaVarEnv<'tree, L: Language> {
-  var_matchers: MetaVarMatchers<L>,
   single_matched: HashMap<MetaVariableID, Node<'tree, L>>,
   multi_matched: HashMap<MetaVariableID, Vec<Node<'tree, L>>>,
 }
 
 impl<'tree, L: Language> MetaVarEnv<'tree, L> {
   pub fn new() -> Self {
-    Self::from_matchers(MetaVarMatchers::new())
-  }
-
-  pub fn from_matchers(var_matchers: MetaVarMatchers<L>) -> Self {
     Self {
-      var_matchers,
       single_matched: HashMap::new(),
       multi_matched: HashMap::new(),
     }
@@ -73,9 +67,9 @@ impl<'tree, L: Language> MetaVarEnv<'tree, L> {
     self.multi_matched.get(label)
   }
 
-  pub fn match_constraints(&self) -> bool {
+  pub fn match_constraints(&self, var_matchers: &MetaVarMatchers<L>) -> bool {
     for (var_id, candidate) in &self.single_matched {
-      if let Some(m) = self.var_matchers.0.get(var_id) {
+      if let Some(m) = var_matchers.0.get(var_id) {
         if !m.matches(candidate.clone()) {
           return false;
         }
@@ -257,11 +251,11 @@ mod test {
       "A".to_string(),
       MetaVarMatcher::Pattern(Pattern::new(pattern, Tsx)),
     );
-    let mut env = MetaVarEnv::from_matchers(matchers);
+    let mut env = MetaVarEnv::new();
     let root = Tsx.ast_grep(node);
     let node = root.root().child(0).unwrap().child(0).unwrap();
     env.insert("A".to_string(), node);
-    env.match_constraints()
+    env.match_constraints(&matchers)
   }
 
   #[test]

--- a/crates/core/src/ops.rs
+++ b/crates/core/src/ops.rs
@@ -209,12 +209,16 @@ where
     node: Node<'tree, L>,
     env: &mut MetaVarEnv<'tree, L>,
   ) -> Option<Node<'tree, L>> {
-    self.inner.match_node_with_env(node, env)
+    let ret = self.inner.match_node_with_env(node, env);
+    if ret.is_some() && env.match_constraints(&self.meta_vars) {
+      ret
+    } else {
+      None
+    }
   }
 
   fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    // TODO: avoid clone
-    MetaVarEnv::from_matchers(self.meta_vars.clone())
+    MetaVarEnv::new()
   }
 
   fn potential_kinds(&self) -> Option<BitSet> {

--- a/crates/core/src/ops.rs
+++ b/crates/core/src/ops.rs
@@ -217,10 +217,6 @@ where
     }
   }
 
-  fn get_meta_var_env<'tree>(&self) -> MetaVarEnv<'tree, L> {
-    MetaVarEnv::new()
-  }
-
   fn potential_kinds(&self) -> Option<BitSet> {
     self.inner.potential_kinds()
   }


### PR DESCRIPTION
Perf

before
```
sg scan -c ./sgconfig.yml ../TypeScript/src  17.63s user 0.46s system 167% cpu 10.823 total
```

after
```
sg scan -c ./sgconfig.yml ../TypeScript/src  9.95s user 0.38s system 432% cpu 2.387 total
```