### PR TITLE
perf: optimize relational rule's stopBy: neighbor

### DIFF
--- a/crates/config/src/relational_rule/mod.rs
+++ b/crates/config/src/relational_rule/mod.rs
@@ -41,7 +41,8 @@ impl<L: Language> Matcher<L> for Inside<L> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    let ancestors = node.ancestors();
+    let parent = || node.parent();
+    let ancestors = || node.ancestors();
     if let Some(field) = &self.field {
       let mut last_id = node.node_id();
       let finder = move |nd: Node<'tree, D>| {
@@ -54,10 +55,10 @@ impl<L: Language> Matcher<L> for Inside<L> {
           self.outer.match_node_with_env(nd, env)
         }
       };
-      self.stop_by.find(ancestors, finder)
+      self.stop_by.find(parent, ancestors, finder)
     } else {
       let finder = |n| self.outer.match_node_with_env(n, env);
-      self.stop_by.find(ancestors, finder)
+      self.stop_by.find(parent, ancestors, finder)
     }
   }
 }
@@ -150,9 +151,10 @@ impl<L: Language> Matcher<L> for Precedes<L> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    let next_all = node.next_all();
+    let next = || node.next();
+    let next_all = || node.next_all();
     let finder = |n| self.later.match_node_with_env(n, env);
-    self.stop_by.find(next_all, finder)
+    self.stop_by.find(next, next_all, finder)
   }
 }
 
@@ -177,9 +179,10 @@ impl<L: Language> Matcher<L> for Follows<L> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    let prev_all = node.prev_all();
+    let prev = || node.prev();
+    let prev_all = || node.prev_all();
     let finder = |n| self.former.match_node_with_env(n, env);
-    self.stop_by.find(prev_all, finder)
+    self.stop_by.find(prev, prev_all, finder)
   }
 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -323,6 +323,9 @@ impl<'r, D: Doc> Node<'r, D> {
     })
   }
 
+  /// Returns all ancestors nodes of `self`.
+  /// Note: each invocation of the returned iterator is O(n)
+  /// Using cursor is overkill here because adjust cursor is too expensive.
   pub fn ancestors(&self) -> impl Iterator<Item = Node<'r, D>> + '_ {
     let mut parent = self.inner.parent();
     std::iter::from_fn(move || {


### PR DESCRIPTION
## Idea

We can skip creating a tree-cursor if we just want to match one node around. Creating a tree-cursor is quite expensive.

## Implementation
`stop_by`'s `find` now gets three arguments: `once`, `multi` and `finder`. All of the three are closures. We create iterator and, thusly, cursor only when `stop_by` is `end`.

## Benchmark 

Before:

```sh
 hyperfine -i 'sg scan -c ../eslint/sgconfig.yml src > /dev/null'
Benchmark 1: sg scan -c ../eslint/sgconfig.yml src > /dev/null
  Time (mean ± σ):      3.310 s ±  0.055 s    [User: 9.473 s, System: 0.128 s]
  Range (min … max):    3.235 s …  3.405 s    10 runs

  Warning: Ignoring non-zero exit code.
```

After:
```shell
hyperfine -i 'sg scan -c ../eslint/sgconfig.yml src > /dev/null'
Benchmark 1: sg scan -c ../eslint/sgconfig.yml src > /dev/null
  Time (mean ± σ):      2.990 s ±  0.069 s    [User: 8.675 s, System: 0.129 s]
  Range (min … max):    2.880 s …  3.087 s    10 runs

  Warning: Ignoring non-zero exit code.
```

I cannot believe it saves yet another 9% wall time and 8% CPU time! 😍 

partially fix #358. 