### PR TITLE
added `-A` alias to `run --accept-all`

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -51,7 +51,7 @@ pub struct RunArg {
   paths: Vec<PathBuf>,
 
   /// Apply all rewrite without confirmation if true.
-  #[clap(long)]
+  #[clap(short = 'A', long)]
   accept_all: bool,
 
   /// Output matches in structured JSON text useful for tools like jq.


### PR DESCRIPTION
Added shorthand for `--accept-all`: `sg run -A -p 'ast_query' --rewrite 'rewrite_query' -l rs`

fix #386 