### PR TITLE
refactor: add comments for ansi link

### DIFF
--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -4,6 +4,8 @@ use anyhow::{Error, Result};
 use std::fmt;
 use std::path::PathBuf;
 
+use crate::utils::ansi_link;
+
 const DOC_SITE_HOST: &str = "https://ast-grep.github.io";
 const PATTERN_GUIDE: Option<&str> = Some("/guide/pattern-syntax.html");
 const CONFIG_GUIDE: Option<&str> = Some("/guide/rule-config.html");
@@ -229,11 +231,7 @@ impl<'a> fmt::Display for ErrorFormat<'a> {
     writeln!(f, "{help} {description}")?;
     if let Some(url) = link {
       let reference = Style::new().bold().dimmed().paint("See also:");
-      let link = format!(
-        "\u{1b}]8;;{DOC_SITE_HOST}{url}\u{1b}\\{}{}\u{1b}]8;;\u{1b}\\",
-        Color::Cyan.italic().paint(DOC_SITE_HOST),
-        Color::Cyan.italic().paint(url)
-      );
+      let link = ansi_link(format!("{DOC_SITE_HOST}{url}"));
       writeln!(f, "{reference} {link}")?;
     }
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -169,6 +169,17 @@ fn file_too_large(file_content: &String) -> bool {
   file_content.len() > MAX_FILE_SIZE && file_content.lines().count() > MAX_LINE_COUNT
 }
 
+// use raw ansi escape code to render links in terminal. references:
+// https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+// https://github.com/zkat/miette/blob/c25676cb1f4266c2607836e6359f15b9cbd8637e/src/handlers/graphical.rs#L186
+pub fn ansi_link(url: String) -> String {
+  format!(
+    "\u{1b}]8;;{}\u{1b}\\{}\u{1b}]8;;\u{1b}\\",
+    url,
+    ansi_term::Color::Cyan.italic().paint(&url)
+  )
+}
+
 /// A single atomic unit where matches happen.
 /// It contains the file path, sg instance and matcher.
 /// An analogy to compilation unit in C programming language.


### PR DESCRIPTION
Preparation of #156

This style seems not supported by `termcolor` (considering Windows support), so I guess it's better to replace it before the refactor.

Style change: dotted underline -> underline