### PR TITLE
refactor: use termcolor for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "serde_yaml",
  "similar",
  "tempdir",
+ "termcolor",
  "tokio",
 ]
 
@@ -1593,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,6 +30,7 @@ ast-grep-dynamic = { version = "0.5.2", path = "../dynamic" }
 ast-grep-language = { version = "0.5.2", path = "../language" }
 
 ansi_term = "0.12"
+termcolor = "1.2"
 atty = "0.2.14"
 crossterm = "0.26.0"
 inquire = "0.6.2"


### PR DESCRIPTION
A part fix of #156 , only applied for errors' style.

For this case, I also tested at my local machine and it should work correctly. If we need more confidence, we can also discuss how to improve tests in this thread (https://github.com/ast-grep/ast-grep/issues/156#issuecomment-1551768759), add the related test cases, and then get this merged. 

It is also worth mentioning that there are so many `unwrap()` call, any suggestion?