### PR TITLE
    fix: use get_range instead as_slice to handle byte_offset and underlying arry size

### DIFF
--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -100,12 +100,18 @@ fn match_multi_nodes_end_non_recursive<'g, 'c, D: Doc + 'c>(
       goal_children.next();
       // goal has all matched
       if goal_children.peek().is_none() {
-        return Some(end);
+        // TODO: handle named and unnamed ellipsis
+        // we need to consume all cand_children to match ellipsis
+        let updated_end = cand_children.last().map(|n| n.range().end).unwrap_or(end);
+        return Some(updated_end);
       }
       while !goal_children.peek().unwrap().is_named() {
         goal_children.next();
         if goal_children.peek().is_none() {
-          return Some(end);
+          // TODO: handle named and unnamed ellipsis
+          // we need to consume all cand_children to match ellipsis
+          let updated_end = cand_children.last().map(|n| n.range().end).unwrap_or(end);
+          return Some(updated_end);
         }
       }
       // if next node is a Ellipsis, consume one candidate node

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -180,7 +180,7 @@ impl<'r, D: Doc> Node<'r, D> {
 impl<'r, L: Language> Node<'r, StrDoc<L>> {
   #[doc(hidden)]
   pub fn display_context(&self, context_lines: usize) -> DisplayContext<'r> {
-    let bytes = self.root.doc.get_source().as_slice();
+    let bytes = self.root.doc.get_source().as_bytes();
     let start = self.inner.start_byte() as usize;
     let end = self.inner.end_byte() as usize;
     let (mut leading, mut trailing) = (start, end);

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -162,11 +162,17 @@ fn get_meta_var_replacement<D: Doc>(
       if nodes.is_empty() {
         vec![]
       } else {
-        // TODO: this is wrong. start_byte is not always index range of slice.
+        // NOTE: start_byte is not always index range of source's slice.
         // e.g. start_byte is still byte_offset in utf_16 (napi). start_byte
+        // so we need to call source's get_range method
         let start = nodes[0].inner.start_byte() as usize;
         let end = nodes[nodes.len() - 1].inner.end_byte() as usize;
-        nodes[0].root.doc.get_source().as_slice()[start..end].to_vec()
+        nodes[0]
+          .root
+          .doc
+          .get_source()
+          .get_range(start..end)
+          .to_vec()
       }
     }
   };

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -1,5 +1,6 @@
 use crate::language::Language;
 use std::borrow::Cow;
+use std::ops::Range;
 use thiserror::Error;
 use tree_sitter::{
   InputEdit, Language as TsLang, LanguageError, Node, Parser, ParserError, Point, Tree,
@@ -112,7 +113,7 @@ pub trait Content: Sized {
     parser: &mut Parser,
     tree: Option<&Tree>,
   ) -> Result<Option<Tree>, ParserError>;
-  fn as_slice(&self) -> &[Self::Underlying];
+  fn get_range(&self, range: Range<usize>) -> &[Self::Underlying];
   fn transform_str(s: &str) -> Vec<Self::Underlying>;
   fn accept_edit(&mut self, edit: &Edit<Self>) -> InputEdit;
   fn get_text<'a>(&'a self, node: &Node) -> Cow<'a, str>;
@@ -127,8 +128,8 @@ impl Content for String {
   ) -> Result<Option<Tree>, ParserError> {
     parser.parse(self.as_bytes(), tree)
   }
-  fn as_slice(&self) -> &[Self::Underlying] {
-    self.as_bytes()
+  fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
+    &self.as_bytes()[range]
   }
   fn transform_str(s: &str) -> Vec<Self::Underlying> {
     s.bytes().collect()

--- a/crates/napi/__test__/index.spec.ts
+++ b/crates/napi/__test__/index.spec.ts
@@ -18,6 +18,20 @@ test('find from native code', t => {
   })
 })
 
+test('find multiple nodes', t => {
+  const sg = parse('a(1, 2, 3)')
+  const match = sg.root().find('a($$$B)')
+  t.deepEqual(match!.range(), {
+    start: { line: 0, column: 0, index: 0 },
+    end: { line: 0, column: 10, index: 10 },
+  })
+  const matchedVar = match!.getMultipleMatches('B')
+  let start = matchedVar[0].range().start;
+  let end = matchedVar[matchedVar.length - 1].range().end;
+  t.deepEqual(start, { line: 0, column: 2, index: 2 })
+  t.deepEqual(end, { line: 0, column: 9, index: 9 })
+})
+
 test('find unicode', t => {
   const str = `console.log("Hello, 世界")
   print("ザ・ワールド")`

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -160,4 +160,19 @@ mod test {
     let node = grep.root().find("console");
     assert!(node.is_some());
   }
+
+  #[test]
+  fn test_js_doc_multiple_node_replace() {
+    let doc = JsDoc::new(
+      "console.log(1 + 2 + 3)".into(),
+      FrontEndLanguage::JavaScript,
+    );
+    let mut grep = AstGrep::doc(doc);
+    let edit = grep
+      .root()
+      .replace("console.log($$$MULTI)", "log($$$MULTI)")
+      .expect("should exist");
+    grep.edit(edit).expect("should work");
+    assert_eq!(grep.root().text(), "log(1 + 2 + 3)");
+  }
 }


### PR DESCRIPTION
   We used to expose underlying binary array of the Source. However, in JavaScript.
    The start_pos is in byte offset.  But underlying binary array can be in u16.
    This pull request changes the interface of source by replacing as_slice with get_range.
    So source can handle this discrepancy gracefully.
    fix #400

Also added test cases.