### PR TITLE
feat: use smarter matching algorithm

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -138,4 +138,13 @@ mod test {
     assert_eq!(source, "let a = 1; /*haha*/");
     Ok(())
   }
+
+  #[test]
+  fn test_replace_trivia_with_skipped() -> Result {
+    let mut ast_grep = Tsx.ast_grep("return foo(1, 2,) /*haha*/;");
+    ast_grep.replace("return foo($A, $B)", "return bar($A, $B)")?;
+    let source = ast_grep.generate();
+    assert_eq!(source, "return bar(1, 2) /*haha*/;"); // semicolon
+    Ok(())
+  }
 }

--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -248,12 +248,16 @@ fn match_nodes_non_recursive<'goal, 'tree, D: Doc + 'tree>(
         cand_children.peek()?;
       }
     }
-    let mut matched = false;
     // skip if cand children is trivial
-    while let Some(cand) = cand_children.peek() {
+    loop {
+      let Some(cand) = cand_children.peek() else {
+        // if cand runs out, remaining goal is not matched
+        return None;
+      };
+      let matched =
+        match_node_non_recursive(goal_children.peek().unwrap(), cand.clone(), env).is_some();
       // try match goal node with candidate node
-      if match_node_non_recursive(goal_children.peek().unwrap(), cand.clone(), env).is_some() {
-        matched = true;
+      if matched {
         break;
       } else if !cand.is_named() {
         // skip trivial node
@@ -263,9 +267,6 @@ fn match_nodes_non_recursive<'goal, 'tree, D: Doc + 'tree>(
         // unmatched significant node
         return None;
       }
-    }
-    if !matched {
-      return None;
     }
     goal_children.next();
     if goal_children.peek().is_none() {


### PR DESCRIPTION
See #374 .

We can skip non-matching trivial nodes in source to make the matching more AST-like.