### PR TITLE
feat(language): add initial support for C++

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "ignore",
  "serde",
  "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-css",
  "tree-sitter-dart",
  "tree-sitter-go",
@@ -1783,6 +1784,16 @@ name = "tree-sitter-c"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca211f4827d4b4dc79f388bf67b6fa3bc8a8cfa642161ef24f99f371ba34c7b"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a869e3c5cef4e5db4e9ab16a8dc84d73010e60ada14cdc60d2f6d8aed17779d"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -17,6 +17,7 @@ ignore.workspace = true
 serde.workspace = true
 
 tree-sitter-c = { version = "0.20.2", optional = true }
+tree-sitter-cpp = { version = "0.20.0", optional = true }
 tree-sitter-c-sharp = { version = "0.20.0", package = "ast-grep-tree-sitter-c-sharp", optional = true }
 tree-sitter-css = { version = "0.19.0", optional = true }
 tree-sitter-dart= { version = "0.0.3", optional = true }
@@ -35,6 +36,7 @@ tree-sitter-typescript= { version = "0.20.2", optional = true }
 [features]
 builtin-parser = [
   "tree-sitter-c",
+  "tree-sitter-cpp",
   "tree-sitter-c-sharp",
   "tree-sitter-css",
   "tree-sitter-dart",

--- a/crates/language/src/cpp.rs
+++ b/crates/language/src/cpp.rs
@@ -1,0 +1,63 @@
+use crate::parsers::language_cpp;
+use ast_grep_core::language::{Language, TSLanguage};
+use std::borrow::Cow;
+
+#[derive(Clone, Copy)]
+pub struct Cpp;
+impl Language for Cpp {
+  fn get_ts_language(&self) -> TSLanguage {
+    language_cpp()
+  }
+  // https://en.cppreference.com/w/cpp/language/identifiers
+  // Due to some issues in the tree-sitter parser, it is not possible to use
+  // unicode literals in identifiers for C/C++ parsers
+  fn expando_char(&self) -> char {
+    '_'
+  }
+  fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+    // use stack buffer to reduce allocation
+    let mut buf = [0; 4];
+    let expando = self.expando_char().encode_utf8(&mut buf);
+    // TODO: use more precise replacement
+    let replaced = query.replace(self.meta_var_char(), expando);
+    Cow::Owned(replaced)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use ast_grep_core::source::TSParseError;
+
+  use super::*;
+
+  fn test_match(query: &str, source: &str) {
+    use crate::test::test_match_lang;
+    test_match_lang(query, source, Cpp);
+  }
+
+  #[test]
+  fn test_cpp_pattern() {
+    test_match("$A->b()", "expr->b()");
+    test_match("expr->$B()", "expr->b()");
+    test_match("ns::ns2::$F()", "ns::ns2::func()");
+    test_match("template <typename $T>", "template <typename T>");
+    test_match("if constexpr ($C) {}", "if constexpr (13+5==18) {}");
+    test_match("template <typename T> typename std::enable_if<$C, T>::type;", "template <typename T> typename std::enable_if<std::is_signed<T>::value, T>::type;");
+  }
+
+  fn test_replace(src: &str, pattern: &str, replacer: &str) -> Result<String, TSParseError> {
+    use crate::test::test_replace_lang;
+    test_replace_lang(src, pattern, replacer, Cpp)
+  }
+
+  #[test]
+  fn test_cpp_replace() -> Result<(), TSParseError> {
+    let ret = test_replace(
+      "expr->b()",
+      "$A->b()",
+      "func($A)->b()",
+    )?;
+    assert_eq!(ret, "func(expr)->b()");
+    Ok(())
+  }
+}

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -1,3 +1,4 @@
+mod cpp;
 mod csharp;
 mod css;
 mod go;
@@ -9,6 +10,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::path::Path;
 
+pub use cpp::Cpp;
 pub use csharp::CSharp;
 pub use css::Css;
 pub use go::Go;
@@ -50,6 +52,7 @@ use std::str::FromStr;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum SupportLang {
   C,
+  Cpp,
   CSharp,
   Css,
   Dart,
@@ -71,7 +74,7 @@ impl SupportLang {
   pub fn all_langs() -> Vec<SupportLang> {
     use SupportLang::*;
     vec![
-      C, CSharp, Css, Dart, Go, Html, Java, JavaScript, Kotlin, Lua, Python, Rust, Swift, Thrift,
+      C, Cpp, CSharp, Css, Dart, Go, Html, Java, JavaScript, Kotlin, Lua, Python, Rust, Swift, Thrift,
       Tsx, TypeScript,
     ]
   }
@@ -109,6 +112,7 @@ impl FromStr for SupportLang {
     use SupportLang::*;
     match s {
       "c" => Ok(C),
+      "cc" | "c++" | "cpp" | "cxx" => Ok(Cpp),
       "cs" | "csharp" => Ok(CSharp),
       "css" | "scss" => Ok(Css),
       "dart" => Ok(Dart),
@@ -134,6 +138,7 @@ macro_rules! execute_lang_method {
     use SupportLang as S;
     match $me {
       S::C => C.$method($($pname,)*),
+      S::Cpp => Cpp.$method($($pname,)*),
       S::CSharp => CSharp.$method($($pname,)*),
       S::Css => Css.$method($($pname,)*),
       S::Dart => Dart.$method($($pname,)*),
@@ -183,6 +188,7 @@ fn from_extension(path: &Path) -> Option<SupportLang> {
   use SupportLang::*;
   match path.extension()?.to_str()? {
     "c" | "h" => Some(C),
+    "cc" | "hpp" | "cpp" | "c++" | "hh" | "cxx" | "cu" | "ino" => Some(Cpp),
     "cs" => Some(CSharp),
     "css" | "scss" => Some(Css),
     "dart" => Some(Dart),
@@ -221,6 +227,7 @@ fn file_types(lang: &SupportLang) -> Types {
   builder.add_defaults();
   let builder = match lang {
     L::C => builder.select("c"),
+    L::Cpp => builder.select("cpp"),
     L::CSharp => builder.select("csharp"),
     L::Css => builder.select("css"),
     L::Dart => builder.select("dart"),

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -10,6 +10,9 @@ mod parser_implmentation {
   pub fn language_c() -> TSLanguage {
     tree_sitter_c::language().into()
   }
+  pub fn language_cpp() -> TSLanguage {
+    tree_sitter_cpp::language().into()
+  }
   pub fn language_c_sharp() -> TSLanguage {
     tree_sitter_c_sharp::language().into()
   }


### PR DESCRIPTION
This pull request adds initial support for C++.

Due to the limitations in the tree-sitter C++ parser, you need a fairly comprehensive search pattern in order for the search to work.

For instance, given the following C++ snippet:

```cpp
a->b().c(p1);
```

The search pattern `$b().c($p)` won't work (because `$b` matches a function call, but the `b()` in the snippet is identified as a `field_expression`), but the pattern `$a->$b().$c($p)` will correctly match the snippet.

Should fix #417.