### PR TITLE
Include license file in the primary crate

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,6 +6,7 @@ categories = ["command-line-utilities", "development-tools", "parsing"]
 default-run = "sg"
 # use relative path because maturin does not recognize
 readme = "../../README.md"
+license-file = "../../LICENSE"
 
 version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
This should put the `LICENSE` file itself in the [crate upload](https://crates.io/crates/ast-grep). Downstream distributors who need to include the license along with the software can then build from the crate tarball.