### PR TITLE
chore: add project json schema for intellisense

### DIFF
--- a/schemas/project.json
+++ b/schemas/project.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Project",
+  "definitions": {
+    "Project": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ruleDirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Rule directories",
+          "description": "A list of string instructing where to discover ast-grep's YAML rules."
+        },
+        "testConfigs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TestConfig"
+          },
+          "title": "Test configurations",
+          "description": "A list of object to configure ast-grep's test cases. Each object can have two fields."
+        },
+        "utilDirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Utility directories",
+          "description": "A list of string instructing where to discover ast-grep's global utility rules."
+        }
+      },
+      "required": ["ruleDirs"],
+      "title": "ast-grep project configuration"
+    },
+    "TestConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "testDir": {
+          "type": "string",
+          "description": "A string specifies where to discover test cases for ast-grep."
+        },
+        "snapshotDir": {
+          "type": "string",
+          "description": "A string path relative to testDir that specifies where to store test snapshots for ast-grep. You can think it like __snapshots___ in popular test framework like jest. If this option is not specified, ast-grep will store the snapshot under the __snapshots__ folder undert the testDir."
+        }
+      },
+      "required": ["testDir"],
+      "title": "Test configuration"
+    }
+  }
+}


### PR DESCRIPTION
For `sgconfig.yml`, related: https://github.com/ast-grep/ast-grep-vscode/issues/31

Not quite sure where it should be placed, temporarily at `schema/` folder