### PR TITLE
feat: add before/after context

### DIFF
--- a/crates/cli/src/print/colored_print/test.rs
+++ b/crates/cli/src/print/colored_print/test.rs
@@ -165,7 +165,7 @@ fn test_overlap_print_impl(heading: Heading) {
     // empty
     Some(2)
   ";
-  let printer = make_test_printer().heading(heading).context(1);
+  let printer = make_test_printer().heading(heading).context((1, 1));
   let lang = SgLang::from(SupportLang::Tsx);
   let grep = lang.ast_grep(src);
   let matches = grep.root().find_all("Some($A)");

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -98,10 +98,10 @@ pub struct RunArg {
   stdin: bool,
 
   // context related options
-  // #[clap(short = 'A', long, default_value = "0")]
-  // after: u16,
-  // #[clap(short = 'B', long, default_value = "0")]
-  // before: u16,
+  #[clap(short = 'A', long, default_value = "0", conflicts_with = "context")]
+  after: u16,
+  #[clap(short = 'B', long, default_value = "0", conflicts_with = "context")]
+  before: u16,
   #[clap(short = 'C', long, default_value = "0")]
   context: u16,
 }
@@ -112,7 +112,11 @@ pub fn run_with_pattern(arg: RunArg) -> Result<()> {
   if arg.json {
     return run_pattern_with_printer(arg, JSONPrinter::stdout());
   }
-  let context = arg.context;
+  let context = if arg.context != 0 {
+    (arg.context, arg.context)
+  } else {
+    (arg.before, arg.after)
+  };
   let printer = ColoredPrinter::stdout(arg.color)
     .heading(arg.heading)
     .context(context);
@@ -292,8 +296,8 @@ mod test {
       debug_query: false,
       update_all: false,
       paths: vec![PathBuf::from(".")],
-      // before: 0,
-      // after: 0,
+      before: 0,
+      after: 0,
       context: 0,
     }
   }


### PR DESCRIPTION
fix #464 

I'm pretty happy the `DisplayContext` and `MatchMerger` can gracefully be extended to support contextual printing.

`sg -p 'Some($A)' -B 1 -A 2`

![image](https://github.com/ast-grep/ast-grep/assets/2883231/4f9a8dc9-1a45-4ebb-b127-0ec04b629bfb)
