### PR TITLE
feat(test): add test case filter for sg test

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -242,7 +242,7 @@ pub fn read_test_files(
     } else {
       let test_case: TestCase =
         from_str(&yaml).with_context(|| EC::ParseTest(path.to_path_buf()))?;
-      path_map.insert(test_case.id.clone(), dir_path.join(SNAPSHOT_DIR));
+      path_map.insert(test_case.id.clone(), test_path.join(snapshot_dirname));
       test_cases.push(test_case);
     }
   }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -43,6 +43,7 @@ pub enum ErrorContext {
   WriteFile(PathBuf),
   // Test
   TestFail(String),
+  TestCaseGlobFilter,
   // New
   ProjectAlreadyExist,
   ProjectNotExist,
@@ -63,7 +64,8 @@ impl ErrorContext {
       NoTestDirConfigured | NoUtilDirConfigured => 4,
       ReadConfiguration | ReadRule(_) | WalkRuleDir(_) | WriteFile(_) => 5,
       StdInIsNotInteractive => 6,
-      ParseTest(_) | ParseRule(_) | ParseConfiguration | GlobPattern | ParsePattern => 8,
+      ParseTest(_) | ParseRule(_) | ParseConfiguration | GlobPattern | ParsePattern
+      | TestCaseGlobFilter => 8,
       ProjectAlreadyExist | FileAlreadyExist(_) => 17,
       InsufficientCLIArgument(_) => 22,
       OpenEditor | StartLanguageServer => 126,
@@ -180,6 +182,11 @@ impl ErrorMessage {
         message,
         "You can use ast-grep playground to debug your rules and test cases.",
         PLAYGROUND,
+      ),
+      TestCaseGlobFilter => Self::new(
+        "Cannot parse the test case glob pattern.",
+        "The pattern provided to filter test cases to run is not a valid glob. Please refer to the doc and fix the error.",
+        CLI_USAGE,
       ),
       ProjectAlreadyExist => Self::new(
         "ast-grep project already exists.",


### PR DESCRIPTION
When done, this should close #248 and I will be submitting a PR on https://github.com/ast-grep/ast-grep.github.io to update the docs. During dev/testing, I had some issues around snapshots, I fixed one of them and will just mention the other in case that’s unexpected behaviour. Ofc let me know if I broke anything.

## Changes

### Add the `-f,--filter` arg to the test command

Implemented by adding a glob filter on the test directory walker. The glob filter is not applied to the snapshots directory nested inside of it. This does mean the whole snapshots dir is always loaded regardless of the glob filter’s value, let me know if that’s an issue.

### Fix user-provided snapshot dir not being used when persisting snapshots

The snapshot dir (be it from CLI arg or test config) is taken into account when determining where to load snapshots from but was ignored when determining the directory to save snapshots to (always using `<test_dir>/__snapshots__`), so I fixed it.

## Tests

- Manually tested test case glob filters with snapshot testing enabled to check that the files inside the snapshots directory are still being picked up despite the filter
- Manually tested that the user-provided snapshot dir is the one used for both loading and saving of test snapshots

## Questions

- In this implementation we’re filtering test cases by file name and the test output is 1 result line per test case file (for example `FAIL my-rule-id .W`). In the output there’s no mention of the originating file’s name for each test case, so there’s no user feedback as to which files were matched exactly. Would we want to include the filename in there, and how if so? Example: `my-test-file.yml [rule my-rule-id]: FAIL .W`
- Should some unit tests be added and how? The code touched by the feature doesn’t seem unit tested + interacts with the file system, it looks like it would require some heavy lifting to set that up

## Other

Might be worth a separate issue but: when testing the feature, I tried having multiple test case files for one rule and ran into some problems which made me wonder about something: is there an expectation that users should only ever create a single test case file for each rule? Here are the issues I had:

- Only the last test case’s snapshots are persisted if multiple test cases reference the same rule. This is due to case id == rule id and building a map of case id ⇒ test snapshots before writing them to disk. Relevant code here:
https://github.com/ast-grep/ast-grep/blob/c826725db86494bce2e384406ec19dffb8efae3e/crates/cli/src/verify.rs#L247

- Similarly, since case id == rule id and a case id → snapshot dir mapping is used to determine where to save snapshots, having tests for one rule scattered across multiple test configs (with different test + snapshot dirs) would mean the effective snapshot dir for all test snapshots of one rule will be the one from the last inserted map entry. Relevant code here:
https://github.com/ast-grep/ast-grep/blob/c826725db86494bce2e384406ec19dffb8efae3e/crates/cli/src/config.rs#L219

I guess this all makes sense if a 1-1 mapping between rule and test case is expected, although it would be nice to make it clear to users if that's the case (update docs, add some config validation etc). Lmkwyt ✌🏼