### PR TITLE
Implement string conversions

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -8,6 +8,7 @@ mod rule;
 mod rule_collection;
 mod rule_config;
 mod transform;
+mod string_conversion;
 
 use serde::Deserialize;
 use serde_yaml::{with::singleton_map_recursive::deserialize, Deserializer, Error as YamlError};

--- a/crates/config/src/string_conversion.rs
+++ b/crates/config/src/string_conversion.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum StringConversion {
+  LowerCase,
+  UpperCase,
+  Capitalize,
+}
+
+pub fn apply_string_conversion(string: String, transform: &StringConversion) -> String {
+  match transform {
+    StringConversion::LowerCase => string.to_lowercase(),
+    StringConversion::UpperCase => string.to_uppercase(),
+    StringConversion::Capitalize => {
+      let mut chars = string.chars();
+      if let Some(c) = chars.next() {
+        c.to_uppercase().chain(chars).collect()
+      } else {
+        string
+      }
+    },
+  }
+}

--- a/crates/config/src/transform.rs
+++ b/crates/config/src/transform.rs
@@ -29,13 +29,6 @@ pub struct Substring {
   end_char: Option<i32>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Replace {
-  source: String,
-  replace: String,
-  by: String,
-}
 impl Substring {
   fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;
@@ -66,6 +59,13 @@ fn resolve_char(opt: &Option<i32>, dft: i32, len: i32) -> usize {
   }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Replace {
+  source: String,
+  replace: String,
+  by: String,
+}
 impl Replace {
   fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;


### PR DESCRIPTION
This implements the three string transformations described in #436:

> **Transform**
> Similar to https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html#intrinsic-string-manipulation-types
>
> ```yaml
> NEW_VAR: 
>   transform: [uppercase, lowercase, capitalize]
>   source: $VAR
> ```

(with the keyword `convert` as discussed in the comments/review)

Here's my actual use-case (slightly anonymized):

```yaml
id: foo
language: python
rule:
  pattern: ObjectStatus.$A
  regex: ObjectStatus.(.*)_statuses
transform:
  B:
    replace:
      source: $A
      replace: '(.*)_statuses'
      by: '${1}_STATUSES'
  CHANGED:
    convert:
      source: $B
      convert: uppercase
fix:
  $CHANGED
```

This turns `ObjectStatus.foo_statuses` to `FOO_OBJECT_STATUSES` everywhere.