### PR TITLE
chore: support Python 3.8 by using `typing-extensions`

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -2,7 +2,7 @@ name: PyO3
 
 env:
   PACKAGE_NAME: ast_grep_pyo3 # note: maturin package name only accepts underscore
-  PYTHON_VERSION: "3.11" # to build abi3 wheels
+  PYTHON_VERSION: "3.8" # to build abi3 wheels
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   PACKAGE_NAME: ast_grep_cli # note: maturin package name only accepts underscore
-  PYTHON_VERSION: "3.11" # to build abi3 wheels
+  PYTHON_VERSION: "3.8" # to build abi3 wheels
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always

--- a/crates/pyo3/ast_grep_pyo3/__init__.py
+++ b/crates/pyo3/ast_grep_pyo3/__init__.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict,  Literal, Dict
+from __future__ import annotations
+
+from typing import List, TypedDict,  Literal, Dict, Union
 from .ast_grep_pyo3 import SgNode, SgRoot, Pos, Range
 
 class Pattern(TypedDict):
@@ -31,7 +33,7 @@ class Rule(RuleWithoutNot, TypedDict("Not", {"not": "Rule"}, total=False)):
     pass
 
 # Relational Rule Related
-StopBy = Literal["neighbor"] | Literal["end"] | Rule
+StopBy = Union[Literal["neighbor"], Literal["end"], Rule]
 
 class Relation(Rule, total=False):
     stopBy: StopBy

--- a/crates/pyo3/ast_grep_pyo3/ast_grep_pyo3.pyi
+++ b/crates/pyo3/ast_grep_pyo3/ast_grep_pyo3.pyi
@@ -1,4 +1,7 @@
-from typing import List, Optional, Unpack, overload
+from typing import List, Optional, overload
+
+from typing_extensions import Unpack
+
 from . import Rule, Config
 
 class Pos:

--- a/crates/pyo3/pyproject.toml
+++ b/crates/pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ast-grep-pyo3"
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 version = "0.12.5"
 description = "Structural Search and Rewrite code at large scale using precise AST pattern."
 authors = [{ name = "Herrington Darkholme", email = "2883231+HerringtonDarkholme@users.noreply.github.com" }]
@@ -28,6 +28,7 @@ classifiers = [
   "Topic :: Software Development",
   "Topic :: Text Processing"
 ]
+dependencies = ["typing-extensions"]
 
 [project.urls]
 Repository = "https://github.com/ast-grep/ast-grep"


### PR DESCRIPTION
- import `Unpack` from `typing_extensions` to support Python 3.8. (3.8 is the lowest aliving version[^1].)
- Use [PEP 563](https://peps.python.org/pep-0563/) in `.py` file to support `|` in type annotations. We don't need to explicitly use PEP 563 in `.pyi` because it is always enabled in stubs[^2].

This PR might be helpful for https://twitter.com/hd_nvim/status/1721013482286629077

[^1]: [Status of Python versions](https://devguide.python.org/versions/)
[^2]: [Type Stubs - Syntax](https://typing.readthedocs.io/en/latest/source/stubs.html#syntax)