### PR TITLE
fix: out of bounds panic

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -20,7 +20,7 @@ type Pattern<L> = SgPattern<StrDoc<L>>;
 // NOTE: have to register custom lang before clap read arg
 // RunArg has a field of SgLang
 pub fn register_custom_language_if_is_run(args: &[String]) -> Result<()> {
-  if !args.is_empty() && (args[1].starts_with('-') || args[1] == "run") {
+  if args.len() > 1 && (args[1].starts_with('-') || args[1] == "run") {
     register_custom_language(None)?;
   }
   Ok(())


### PR DESCRIPTION
Avoid panic when run `sg` without providing any cli args.