### PR TITLE
doc: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ brew install ast-grep
 
 # install via scoop, thank @brian6932
 scoop install main/ast-grep
+
+# install via MacPorts
+sudo port install ast-grep
 ```
 Or you can build ast-grep from source. You need install rustup, clone the repository and then
 ```bash


### PR DESCRIPTION
Add a line in the installation section touching on how to install `ast-grep` via [MacPorts](https://macports.org)

Ports page for `ast-grep`: https://ports.macports.org/port/ast-grep/