### PR TITLE
feature: revamp pattern implementation

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ast_grep_core::replacer::TemplateFix;
-use ast_grep_core::{Matcher, Pattern as SgPattern, StrDoc};
+use ast_grep_core::{Matcher, Pattern};
 use ast_grep_language::Language;
 use clap::Parser;
 use ignore::WalkParallel;
@@ -14,8 +14,6 @@ use crate::print::{ColoredPrinter, Diff, Heading, InteractivePrinter, JSONPrinte
 use crate::utils::{filter_file_pattern, InputArgs, MatchUnit, OutputArgs};
 use crate::utils::{run_std_in, StdInWorker};
 use crate::utils::{run_worker, Items, Worker};
-
-type Pattern<L> = SgPattern<StrDoc<L>>;
 
 // NOTE: have to register custom lang before clap read arg
 // RunArg has a field of SgLang

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -195,8 +195,8 @@ pub fn filter_file_interactive<M: Matcher<SgLang>>(
 pub fn filter_file_pattern(
   path: &Path,
   lang: SgLang,
-  matcher: Pattern<StrDoc<SgLang>>,
-) -> Option<MatchUnit<Pattern<StrDoc<SgLang>>>> {
+  matcher: Pattern<SgLang>,
+) -> Option<MatchUnit<Pattern<SgLang>>> {
   let file_content = read_file(path)?;
   let fixed = matcher.fixed_string();
   if !fixed.is_empty() && !file_content.contains(&*fixed) {

--- a/crates/config/src/rule/mod.rs
+++ b/crates/config/src/rule/mod.rs
@@ -12,15 +12,13 @@ use ast_grep_core::language::Language;
 use ast_grep_core::matcher::{KindMatcher, KindMatcherError, RegexMatcher, RegexMatcherError};
 use ast_grep_core::meta_var::MetaVarEnv;
 use ast_grep_core::ops as o;
-use ast_grep_core::{Doc, Matcher, Node, Pattern as PatternCore, PatternError, StrDoc};
+use ast_grep_core::{Doc, Matcher, Node, Pattern, PatternError};
 
 use bit_set::BitSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use thiserror::Error;
-
-type Pattern<L> = PatternCore<StrDoc<L>>;
 
 /// A rule object to find matching AST nodes. We have three categories of rules in ast-grep.
 ///

--- a/crates/config/src/transform/mod.rs
+++ b/crates/config/src/transform/mod.rs
@@ -119,14 +119,14 @@ pub enum Transformation {
 impl Transformation {
   fn insert<D: Doc>(&self, key: &str, ctx: &mut Ctx<D>) {
     // avoid cyclic
-    ctx.env.insert_transformation(key.to_string(), vec![]);
+    ctx.env.insert_transformation(key, vec![]);
     let opt = self.compute(ctx);
     let bytes = if let Some(s) = opt {
       <D::Source as Content>::decode_str(&s).to_vec()
     } else {
       vec![]
     };
-    ctx.env.insert_transformation(key.to_string(), bytes);
+    ctx.env.insert_transformation(key, bytes);
   }
   fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
     use Transformation as T;

--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -90,7 +90,7 @@ pub fn match_end_non_recursive<D: Doc>(
   }
 }
 
-fn match_multi_nodes_end_non_recursive<'g, 'c, D: Doc + 'c>(
+fn match_multi_nodes_end_non_recursive<'c, D: Doc + 'c>(
   goals: &[Pattern<D::Lang>],
   candidates: impl Iterator<Item = Node<'c, D>>,
 ) -> Option<usize> {
@@ -193,7 +193,7 @@ pub fn match_node_non_recursive<'tree, D: Doc>(
   }
 }
 
-fn match_nodes_non_recursive<'goal, 'tree, D: Doc + 'tree>(
+fn match_nodes_non_recursive<'tree, D: Doc + 'tree>(
   goals: &[Pattern<D::Lang>],
   candidates: impl Iterator<Item = Node<'tree, D>>,
   env: &mut Cow<MetaVarEnv<'tree, D>>,

--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -14,7 +14,7 @@ fn match_leaf_meta_var<'tree, D: Doc>(
       if *named && !candidate.is_named() {
         None
       } else {
-        env.to_mut().insert(name.clone(), candidate.clone())?;
+        env.to_mut().insert(name, candidate.clone())?;
         Some(candidate)
       }
     }
@@ -31,7 +31,7 @@ fn match_leaf_meta_var<'tree, D: Doc>(
       Some(candidate)
     }
     MV::NamedEllipsis(name) => {
-      env.to_mut().insert(name.clone(), candidate.clone())?;
+      env.to_mut().insert(name, candidate.clone())?;
       Some(candidate)
     }
   }
@@ -61,7 +61,7 @@ fn update_ellipsis_env<'t, D: Doc>(
     matched.extend(cand_children);
     let skipped = matched.len().saturating_sub(skipped_anonymous);
     drop(matched.drain(skipped..));
-    env.to_mut().insert_multi(name.to_string(), matched)?;
+    env.to_mut().insert_multi(name, matched)?;
   }
   Some(())
 }

--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -42,7 +42,8 @@ fn match_leaf_meta_var<'tree, D: Doc>(
 fn is_node_eligible_for_meta_var(goal: &Node<impl Doc>, is_leaf: bool) -> bool {
   // allow Error as meta_var
   // see https://github.com/ast-grep/ast-grep/issues/526
-  is_leaf || goal.is_error()
+  extract_var_from_node(goal).is_some()
+  // is_leaf || goal.is_error()
 }
 
 fn try_get_ellipsis_mode(node: &Node<impl Doc>) -> Result<Option<String>, ()> {

--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -48,7 +48,7 @@ fn is_node_eligible_for_meta_var(goal: &Node<impl Doc>, is_leaf: bool) -> bool {
 /// Returns Ok if ellipsis pattern is found. If the ellipsis is named, returns it name.
 /// If the ellipsis is unnamed, returns None. If it is not ellipsis node, returns Err.
 fn try_get_pattern_ellipsis_mode(node: &Pattern<impl Doc>) -> Result<Option<String>, ()> {
-  let Pattern::MetaVar(mv) = node else {
+  let Pattern::MetaVar(mv, _) = node else {
     return Err(());
   };
   match mv {
@@ -87,7 +87,7 @@ pub fn match_end_non_recursive<D: Doc>(
 ) -> Option<usize> {
   use Pattern as P;
   match goal {
-    P::MetaVar(_) => Some(candidate.range().end),
+    P::MetaVar(_, _) => Some(candidate.range().end),
     P::NonTerminal { kind_id, children } if *kind_id == candidate.kind_id() => {
       let cand_children = candidate.children();
       match_multi_nodes_end_non_recursive(children, cand_children)
@@ -215,7 +215,7 @@ pub fn match_node_non_recursive<'tree, D: Doc>(
         None
       }
     }
-    P::MetaVar(mv) => match_leaf_meta_var(mv, candidate, env),
+    P::MetaVar(mv, _) => match_leaf_meta_var(mv, candidate, env),
     P::NonTerminal { kind_id, children } if *kind_id == candidate.kind_id() => {
       let cand_children = candidate.children();
       match_nodes_non_recursive(children, cand_children, env).map(|_| candidate)

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -113,7 +113,7 @@ impl<D: Doc> Pattern<D> {
   // for skipping trivial nodes in goal after ellipsis
   pub fn is_trivial(&self) -> bool {
     match self {
-      Pattern::Leaf { is_named, .. } => *is_named,
+      Pattern::Leaf { is_named, .. } => !*is_named,
       _ => false,
     }
   }

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -406,7 +406,7 @@ mod test {
   }
 
   #[test]
-  fn test_error() {
+  fn test_error_kind() {
     let ret = Pattern::contextual("a", "property_identifier", Tsx);
     assert!(ret.is_err());
     let ret = Pattern::str("123+", Tsx);
@@ -420,5 +420,28 @@ mod test {
     let cand = pattern_node("let b = 123");
     // should it match?
     assert!(pattern.find_node(cand.root()).is_some());
+  }
+
+  #[test]
+  fn test_pattern_fixed_string() {
+    let pattern = Pattern::new("class A { $F }", Tsx);
+    assert_eq!(pattern.fixed_string(), "class");
+    let pattern =
+      Pattern::<StrDoc<_>>::contextual("class A { $F }", "property_identifier", Tsx).expect("test");
+    assert!(pattern.fixed_string().is_empty());
+  }
+
+  #[test]
+  fn test_pattern_error() {
+    let pattern = Pattern::try_new("", Tsx);
+    assert!(matches!(pattern, Err(PatternError::NoContent(_))));
+    let pattern = Pattern::try_new("12  3344", Tsx);
+    assert!(matches!(pattern, Err(PatternError::MultipleNode(_))));
+  }
+
+  #[test]
+  fn test_debug_pattern() {
+    let pattern = Pattern::str("var $A = 1", Tsx);
+    assert_eq!(format!("{pattern:?}"), "[var, [Named(\"A\", true), =, 1]]");
   }
 }

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -112,11 +112,6 @@ impl<L: Language> Pattern<StrDoc<L>> {
       Pattern::MetaVar(_, None) => return false,
     };
     KindMatcher::<L>::from_id(kind).is_error_matcher()
-    // let node = match &self.style {
-    //   PatternStyle::Single => self.single_matcher(),
-    //   PatternStyle::Selector(kind) => self.kind_matcher(kind),
-    // };
-    // node.matches(KindMatcher::error_matcher())
   }
 }
 impl<D: Doc> Pattern<D> {
@@ -176,17 +171,6 @@ impl<L: Language> Pattern<StrDoc<L>> {
       inner = inner.child(0).unwrap();
     }
     Node { inner, root }
-  }
-
-  fn kind_matcher<D: Doc>(&self, kind_matcher: &KindMatcher<D::Lang>) -> Node<D> {
-    todo!("pattern")
-    // debug_assert!(matches!(self.style, PatternStyle::Selector(_)));
-    // self
-    //   .root
-    //   .root()
-    //   .find(kind_matcher)
-    //   .map(Node::from)
-    //   .expect("contextual match should succeed")
   }
 }
 

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -1,29 +1,48 @@
 use crate::language::Language;
 use crate::match_tree::{extract_var_from_node, match_end_non_recursive, match_node_non_recursive};
 use crate::matcher::{KindMatcher, KindMatcherError, Matcher};
+use crate::meta_var::{MetaVarEnv, MetaVariable};
 use crate::source::TSParseError;
-use crate::{meta_var::MetaVarEnv, Node, Root};
-use crate::{Doc, StrDoc};
+use crate::{Doc, Node, Root, StrDoc};
 
 use bit_set::BitSet;
 use std::borrow::Cow;
+use std::marker::PhantomData;
 use thiserror::Error;
 
-/// Pattern style specify how we find the ast node to match, assuming pattern text's root is `Program`
-/// the effective AST node to match is either
 #[derive(Clone)]
-enum PatternStyle<L: Language> {
-  /// single non-program ast node, notwithstanding MISSING node.
-  Single,
-  /// sub AST node specified by user in contextual pattern
-  /// e.g. in js`class { $F }` we set selector to public_field_definition
-  Selector(KindMatcher<L>),
+pub enum Pattern<D: Doc> {
+  MetaVar(MetaVariable),
+  Leaf {
+    text: String,
+    is_named: bool,
+    kind_id: u16,
+    lang: PhantomData<D>,
+  },
+  NonTerminal {
+    kind_id: u16,
+    children: Vec<Pattern<D>>,
+  },
 }
 
-#[derive(Clone)]
-pub struct Pattern<D: Doc> {
-  pub(crate) root: Root<D>,
-  style: PatternStyle<D::Lang>,
+impl<'r, D: Doc> From<Node<'r, D>> for Pattern<D> {
+  fn from(node: Node<'r, D>) -> Self {
+    if let Some(meta_var) = extract_var_from_node(&node) {
+      Self::MetaVar(meta_var)
+    } else if node.is_leaf() {
+      Self::Leaf {
+        text: node.text().to_string(),
+        is_named: node.is_named(),
+        kind_id: node.kind_id(),
+        lang: PhantomData,
+      }
+    } else {
+      Self::NonTerminal {
+        kind_id: node.kind_id(),
+        children: node.children().map(Self::from).collect(),
+      }
+    }
+  }
 }
 
 #[derive(Debug, Error)]
@@ -59,32 +78,38 @@ impl<L: Language> Pattern<StrDoc<L>> {
   }
 
   pub fn fixed_string(&self) -> Cow<str> {
-    let node = match &self.style {
-      PatternStyle::Single => self.single_matcher(),
-      PatternStyle::Selector(kind) => self.kind_matcher(kind),
-    };
-    let mut fixed = Cow::Borrowed("");
-    for n in node.dfs() {
-      if n.is_leaf() && extract_var_from_node(&n).is_none() && n.text().len() > fixed.len() {
-        fixed = n.text();
+    match self {
+      Self::Leaf { text, .. } => Cow::Borrowed(text),
+      Self::MetaVar(_) => Cow::Borrowed(""),
+      Self::NonTerminal { children, .. } => {
+        children
+          .iter()
+          .map(|n| n.fixed_string())
+          .fold(Cow::Borrowed(""), |longest, curr| {
+            if longest.len() >= curr.len() {
+              longest
+            } else {
+              curr
+            }
+          })
       }
     }
-    fixed
   }
 
   pub fn has_error(&self) -> bool {
-    let node = match &self.style {
-      PatternStyle::Single => self.single_matcher(),
-      PatternStyle::Selector(kind) => self.kind_matcher(kind),
-    };
-    node.matches(KindMatcher::error_matcher())
+    todo!("pattern")
+    // let node = match &self.style {
+    //   PatternStyle::Single => self.single_matcher(),
+    //   PatternStyle::Selector(kind) => self.kind_matcher(kind),
+    // };
+    // node.matches(KindMatcher::error_matcher())
   }
 }
 
-impl<D: Doc> Pattern<D> {
-  pub fn try_new(src: &str, lang: D::Lang) -> Result<Self, PatternError> {
+impl<L: Language> Pattern<StrDoc<L>> {
+  pub fn try_new(src: &str, lang: L) -> Result<Self, PatternError> {
     let processed = lang.pre_process_pattern(src);
-    let root = Root::try_new(&processed, lang)?;
+    let root = Root::<StrDoc<L>>::try_new(&processed, lang)?;
     let goal = root.root();
     if goal.inner.child_count() == 0 {
       return Err(PatternError::NoContent(src.into()));
@@ -92,111 +117,88 @@ impl<D: Doc> Pattern<D> {
     if !is_single_node(&goal.inner) {
       return Err(PatternError::MultipleNode(src.into()));
     }
-    Ok(Self {
-      root,
-      style: PatternStyle::Single,
-    })
+    let node = Self::single_matcher(&root);
+    Ok(Self::from(node))
   }
 
-  pub fn new(src: &str, lang: D::Lang) -> Self {
+  pub fn new(src: &str, lang: L) -> Self {
     Self::try_new(src, lang).unwrap()
   }
 
-  pub fn contextual(context: &str, selector: &str, lang: D::Lang) -> Result<Self, PatternError> {
+  pub fn contextual(context: &str, selector: &str, lang: L) -> Result<Self, PatternError> {
     let processed = lang.pre_process_pattern(context);
-    let root = Root::try_new(&processed, lang.clone())?;
+    let root = Root::<StrDoc<L>>::try_new(&processed, lang.clone())?;
     let goal = root.root();
     let kind_matcher = KindMatcher::try_new(selector, lang)?;
-    if goal.find(&kind_matcher).is_none() {
+    let Some(node) = goal.find(&kind_matcher) else {
       return Err(PatternError::NoSelectorInContext {
         context: context.into(),
         selector: selector.into(),
       });
-    }
-    Ok(Self {
-      root,
-      style: PatternStyle::Selector(kind_matcher),
-    })
+    };
+    Ok(Self::from(node.get_node().clone()))
   }
-  pub fn doc(doc: D) -> Self {
-    Self {
-      root: Root::doc(doc),
-      style: PatternStyle::Single,
-    }
+  pub fn doc(doc: StrDoc<L>) -> Self {
+    let root = Root::doc(doc);
+    Self::from(root.root())
   }
-  fn single_matcher(&self) -> Node<D> {
-    debug_assert!(matches!(self.style, PatternStyle::Single));
-    let root = self.root.root();
-    let mut node = root.inner;
-    while is_single_node(&node) {
-      node = node.child(0).unwrap();
+  fn single_matcher<D: Doc>(root: &Root<D>) -> Node<D> {
+    // debug_assert!(matches!(self.style, PatternStyle::Single));
+    let node = root.root();
+    let mut inner = node.inner;
+    while is_single_node(&inner) {
+      inner = inner.child(0).unwrap();
     }
-    Node {
-      inner: node,
-      root: &self.root,
-    }
+    Node { inner, root }
   }
 
-  fn kind_matcher(&self, kind_matcher: &KindMatcher<D::Lang>) -> Node<D> {
-    debug_assert!(matches!(self.style, PatternStyle::Selector(_)));
-    self
-      .root
-      .root()
-      .find(kind_matcher)
-      .map(Node::from)
-      .expect("contextual match should succeed")
+  fn kind_matcher<D: Doc>(&self, kind_matcher: &KindMatcher<D::Lang>) -> Node<D> {
+    todo!("pattern")
+    // debug_assert!(matches!(self.style, PatternStyle::Selector(_)));
+    // self
+    //   .root
+    //   .root()
+    //   .find(kind_matcher)
+    //   .map(Node::from)
+    //   .expect("contextual match should succeed")
   }
 }
 
-impl<P: Doc> Matcher<P::Lang> for Pattern<P> {
-  fn match_node_with_env<'tree, D: Doc<Lang = P::Lang>>(
+impl<L: Language, P: Doc<Lang = L>> Matcher<L> for Pattern<P> {
+  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    match &self.style {
-      PatternStyle::Single => {
-        let matcher = self.single_matcher();
-        match_node_non_recursive(&matcher, node, env)
-      }
-      PatternStyle::Selector(kind) => {
-        let matcher = self.kind_matcher(kind);
-        match_node_non_recursive(&matcher, node, env)
-      }
-    }
+    todo!("pattern")
+    // match_node_non_recursive(&self, node, env)
   }
 
   fn potential_kinds(&self) -> Option<bit_set::BitSet> {
-    let kind = match &self.style {
-      PatternStyle::Selector(kind) => return kind.potential_kinds(),
-      PatternStyle::Single => {
-        let matcher = self.single_matcher();
-        if matcher.is_leaf() && extract_var_from_node(&matcher).is_some() {
-          return None;
-        }
-        matcher.kind_id()
-      }
+    let kind = match self {
+      Self::Leaf { kind_id, .. } => *kind_id,
+      Self::MetaVar(_) => return None,
+      Self::NonTerminal { kind_id, .. } => *kind_id,
     };
     let mut kinds = BitSet::new();
     kinds.insert(kind.into());
     Some(kinds)
   }
 
-  fn get_match_len<D: Doc<Lang = P::Lang>>(&self, node: Node<D>) -> Option<usize> {
-    let start = node.range().start;
-    let end = match &self.style {
-      PatternStyle::Single => match_end_non_recursive(&self.single_matcher(), node)?,
-      PatternStyle::Selector(kind) => match_end_non_recursive(&self.kind_matcher(kind), node)?,
-    };
-    Some(end - start)
+  fn get_match_len<D: Doc<Lang = L>>(&self, node: Node<D>) -> Option<usize> {
+    todo!("pattern")
+    // let start = node.range().start;
+    // let end = match_end_non_recursive(self, node)?;
+    // Some(end - start)
   }
 }
 
 impl<D: Doc> std::fmt::Debug for Pattern<D> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match &self.style {
-      PatternStyle::Single => write!(f, "{}", self.single_matcher().to_sexp()),
-      PatternStyle::Selector(kind) => write!(f, "{}", self.kind_matcher(kind).to_sexp()),
+    match self {
+      Self::MetaVar(m) => write!(f, "{:?}", m),
+      Self::Leaf { text, .. } => write!(f, "{}", text),
+      Self::NonTerminal { children, .. } => write!(f, "{:?}", children),
     }
   }
 }
@@ -217,8 +219,8 @@ mod test {
     let cand = cand.root();
     assert!(
       pattern.find_node(cand.clone()).is_some(),
-      "goal: {}, candidate: {}",
-      pattern.root.root().to_sexp(),
+      "goal: {:?}, candidate: {}",
+      pattern,
       cand.to_sexp(),
     );
   }
@@ -228,8 +230,8 @@ mod test {
     let cand = cand.root();
     assert!(
       pattern.find_node(cand.clone()).is_none(),
-      "goal: {}, candidate: {}",
-      pattern.root.root().to_sexp(),
+      "goal: {:?}, candidate: {}",
+      pattern,
       cand.to_sexp(),
     );
   }
@@ -276,7 +278,7 @@ mod test {
 
   #[test]
   fn test_contextual_pattern() {
-    let pattern: Pattern<StrDoc<_>> =
+    let pattern =
       Pattern::contextual("class A { $F = $I }", "public_field_definition", Tsx).expect("test");
     let cand = pattern_node("class B { b = 123 }");
     assert!(pattern.find_node(cand.root()).is_some());
@@ -286,7 +288,7 @@ mod test {
 
   #[test]
   fn test_contextual_match_with_env() {
-    let pattern: Pattern<StrDoc<_>> =
+    let pattern =
       Pattern::contextual("class A { $F = $I }", "public_field_definition", Tsx).expect("test");
     let cand = pattern_node("class B { b = 123 }");
     let nm = pattern.find_node(cand.root()).expect("test");
@@ -298,7 +300,7 @@ mod test {
 
   #[test]
   fn test_contextual_unmatch_with_env() {
-    let pattern: Pattern<StrDoc<_>> =
+    let pattern =
       Pattern::contextual("class A { $F = $I }", "public_field_definition", Tsx).expect("test");
     let cand = pattern_node("let b = 123");
     let nm = pattern.find_node(cand.root());
@@ -339,7 +341,7 @@ mod test {
 
   #[test]
   fn test_contextual_potential_kinds() {
-    let pattern: Pattern<StrDoc<_>> =
+    let pattern =
       Pattern::contextual("class A { $F = $I }", "public_field_definition", Tsx).expect("test");
     let kind = get_kind("public_field_definition");
     let kinds = pattern.potential_kinds().expect("should have kinds");
@@ -349,8 +351,7 @@ mod test {
 
   #[test]
   fn test_contextual_wildcard() {
-    let pattern =
-      Pattern::<StrDoc<_>>::contextual("class A { $F }", "property_identifier", Tsx).expect("test");
+    let pattern = Pattern::contextual("class A { $F }", "property_identifier", Tsx).expect("test");
     let kind = get_kind("property_identifier");
     let kinds = pattern.potential_kinds().expect("should have kinds");
     assert_eq!(kinds.len(), 1);
@@ -391,7 +392,7 @@ mod test {
 
   #[test]
   fn test_error() {
-    let ret = Pattern::<StrDoc<_>>::contextual("a", "property_identifier", Tsx);
+    let ret = Pattern::contextual("a", "property_identifier", Tsx);
     assert!(ret.is_err());
     let ret = Pattern::str("123+", Tsx);
     assert!(ret.has_error());

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -105,6 +105,15 @@ impl<L: Language> Pattern<StrDoc<L>> {
     // node.matches(KindMatcher::error_matcher())
   }
 }
+impl<D: Doc> Pattern<D> {
+  // for skipping trivial nodes in goal after ellipsis
+  pub fn is_trivial(&self) -> bool {
+    match self {
+      Pattern::Leaf { is_named, .. } => *is_named,
+      _ => false,
+    }
+  }
+}
 
 impl<L: Language> Pattern<StrDoc<L>> {
   pub fn try_new(src: &str, lang: L) -> Result<Self, PatternError> {
@@ -170,8 +179,7 @@ impl<L: Language, P: Doc<Lang = L>> Matcher<L> for Pattern<P> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    todo!("pattern")
-    // match_node_non_recursive(&self, node, env)
+    match_node_non_recursive(self, node, env)
   }
 
   fn potential_kinds(&self) -> Option<bit_set::BitSet> {

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -101,7 +101,12 @@ impl<L: Language> Pattern<StrDoc<L>> {
   }
 
   pub fn has_error(&self) -> bool {
-    todo!("pattern")
+    let kind = match self {
+      Pattern::Leaf { kind_id, .. } => *kind_id,
+      Pattern::MetaVar(_) => return false,
+      Pattern::NonTerminal { kind_id, .. } => *kind_id,
+    };
+    KindMatcher::<L>::from_id(kind).is_error_matcher()
     // let node = match &self.style {
     //   PatternStyle::Single => self.single_matcher(),
     //   PatternStyle::Selector(kind) => self.kind_matcher(kind),

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -26,31 +26,26 @@ impl<'tree, D: Doc> MetaVarEnv<'tree, D> {
     }
   }
 
-  // TODO: change id to use borrow
-  pub fn insert(&mut self, id: MetaVariableID, ret: Node<'tree, D>) -> Option<&mut Self> {
-    if self.match_variable(&id, &ret) {
-      self.single_matched.insert(id, ret);
+  pub fn insert(&mut self, id: &str, ret: Node<'tree, D>) -> Option<&mut Self> {
+    if self.match_variable(id, &ret) {
+      self.single_matched.insert(id.to_string(), ret);
       Some(self)
     } else {
       None
     }
   }
 
-  pub fn insert_multi(
-    &mut self,
-    id: MetaVariableID,
-    ret: Vec<Node<'tree, D>>,
-  ) -> Option<&mut Self> {
-    if self.match_multi_var(&id, &ret) {
-      self.multi_matched.insert(id, ret);
+  pub fn insert_multi(&mut self, id: &str, ret: Vec<Node<'tree, D>>) -> Option<&mut Self> {
+    if self.match_multi_var(id, &ret) {
+      self.multi_matched.insert(id.to_string(), ret);
       Some(self)
     } else {
       None
     }
   }
 
-  pub fn insert_transformation(&mut self, name: MetaVariableID, src: Underlying<D>) {
-    self.transformed_var.insert(name, src);
+  pub fn insert_transformation(&mut self, name: &str, src: Underlying<D>) {
+    self.transformed_var.insert(name.to_string(), src);
   }
 
   pub fn get_match(&self, var: &str) -> Option<&'_ Node<'tree, D>> {
@@ -116,13 +111,13 @@ impl<'tree, D: Doc> MetaVarEnv<'tree, D> {
     true
   }
 
-  fn match_variable(&self, id: &MetaVariableID, candidate: &Node<D>) -> bool {
+  fn match_variable(&self, id: &str, candidate: &Node<D>) -> bool {
     if let Some(m) = self.single_matched.get(id) {
       return does_node_match_exactly(m, candidate);
     }
     true
   }
-  fn match_multi_var(&self, id: &MetaVariableID, cands: &[Node<D>]) -> bool {
+  fn match_multi_var(&self, id: &str, cands: &[Node<D>]) -> bool {
     let Some(nodes) = self.multi_matched.get(id) else {
       return true;
     };
@@ -338,7 +333,7 @@ mod test {
     let mut env = MetaVarEnv::new();
     let root = Tsx.ast_grep(node);
     let node = root.root().child(0).unwrap().child(0).unwrap();
-    env.insert("A".to_string(), node);
+    env.insert("A", node);
     env.match_constraints(&matchers)
   }
 

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -26,6 +26,7 @@ impl<'tree, D: Doc> MetaVarEnv<'tree, D> {
     }
   }
 
+  // TODO: change id to use borrow
   pub fn insert(&mut self, id: MetaVariableID, ret: Node<'tree, D>) -> Option<&mut Self> {
     if self.match_variable(&id, &ret) {
       self.single_matched.insert(id, ret);

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -222,7 +222,7 @@ pub enum MetaVarMatcher<D: Doc> {
   /// A regex to filter matched metavar based on its textual content.
   Regex(RegexMatcher<D::Lang>),
   /// A pattern to filter matched metavar based on its AST tree shape.
-  Pattern(Pattern<D>),
+  Pattern(Pattern<D::Lang>),
   /// A kind_id to filter matched metavar based on its ts-node kind
   Kind(KindMatcher<D::Lang>),
 }

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -189,7 +189,7 @@ impl<'tree, D: Doc> Default for MetaVarEnv<'tree, D> {
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MetaVariable {
   /// $A for captured meta var
   Named(MetaVariableID, bool),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -132,6 +132,8 @@ impl<'r, D: Doc> Node<'r, D> {
   pub fn is_leaf(&self) -> bool {
     self.inner.child_count() == 0
   }
+  /// if has no named children.
+  /// N.B. it is different from is_named && is_leaf
   pub fn is_named_leaf(&self) -> bool {
     self.inner.named_child_count() == 0
   }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -134,6 +134,7 @@ impl<'r, D: Doc> Node<'r, D> {
   }
   /// if has no named children.
   /// N.B. it is different from is_named && is_leaf
+  // see https://github.com/ast-grep/ast-grep/issues/276
   pub fn is_named_leaf(&self) -> bool {
     self.inner.named_child_count() == 0
   }

--- a/crates/core/src/ops.rs
+++ b/crates/core/src/ops.rs
@@ -388,7 +388,7 @@ impl<L: Language, M: Matcher<L>, N: Matcher<L>> Op<L, Or<L, M, N>> {
 mod test {
   use super::*;
   use crate::language::Tsx;
-  use crate::{Root, StrDoc};
+  use crate::Root;
 
   fn test_find(matcher: &impl Matcher<Tsx>, code: &str) {
     let node = Root::str(code, Tsx);
@@ -494,10 +494,10 @@ mod test {
   */
   use crate::Pattern;
   trait TsxMatcher {
-    fn t(self) -> Pattern<StrDoc<Tsx>>;
+    fn t(self) -> Pattern<Tsx>;
   }
   impl TsxMatcher for &str {
-    fn t(self) -> Pattern<StrDoc<Tsx>> {
+    fn t(self) -> Pattern<Tsx> {
       Pattern::new(self, Tsx)
     }
   }

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,7 +1,6 @@
 use crate::matcher::NodeMatch;
 use crate::meta_var::{is_valid_meta_var_char, MetaVariableID};
 use crate::source::{Content, Edit as E};
-use crate::Pattern;
 use crate::{Doc, Node, Root};
 
 type Edit<D> = E<<D as Doc>::Source>;
@@ -33,12 +32,6 @@ impl<D: Doc> Replacer<D> for Root<D> {
     structural::gen_replacement(self, nm)
   }
 }
-
-// impl<D: Doc> Replacer<D> for Pattern<D> {
-//   fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source> {
-//     structural::gen_replacement(&self.root, nm)
-//   }
-// }
 
 impl<D, T> Replacer<D> for &T
 where

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -34,12 +34,11 @@ impl<D: Doc> Replacer<D> for Root<D> {
   }
 }
 
-impl<D: Doc> Replacer<D> for Pattern<D> {
-  fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source> {
-    todo!("pattern")
-    // structural::gen_replacement(&self.root, nm)
-  }
-}
+// impl<D: Doc> Replacer<D> for Pattern<D> {
+//   fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source> {
+//     structural::gen_replacement(&self.root, nm)
+//   }
+// }
 
 impl<D, T> Replacer<D> for &T
 where

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -36,7 +36,8 @@ impl<D: Doc> Replacer<D> for Root<D> {
 
 impl<D: Doc> Replacer<D> for Pattern<D> {
   fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source> {
-    structural::gen_replacement(&self.root, nm)
+    todo!("pattern")
+    // structural::gen_replacement(&self.root, nm)
   }
 }
 

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -107,7 +107,7 @@ mod test {
       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
       .collect();
     for (var, root) in &roots {
-      env.insert(var.to_string(), root.root());
+      env.insert(var, root.root());
     }
     let dummy = Tsx.ast_grep("dummy");
     let node_match = NodeMatch::new(dummy.root(), env.clone());
@@ -170,7 +170,7 @@ mod test {
       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
       .collect();
     for (var, root) in &roots {
-      env.insert_multi(var.to_string(), root.root().children().collect());
+      env.insert_multi(var, root.root().children().collect());
     }
     let dummy = Tsx.ast_grep("dummy");
     let node_match = NodeMatch::new(dummy.root(), env.clone());

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -203,7 +203,7 @@ if (true) {
       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
       .collect();
     for (var, root) in &roots {
-      env.insert(var.to_string(), root.root());
+      env.insert(var, root.root());
     }
     let dummy = Tsx.ast_grep("dummy");
     let node_match = NodeMatch::new(dummy.root(), env.clone());
@@ -265,7 +265,7 @@ if (true) {
       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
       .collect();
     for (var, root) in &roots {
-      env.insert_multi(var.to_string(), root.root().children().collect());
+      env.insert_multi(var, root.root().children().collect());
     }
     let dummy = Tsx.ast_grep("dummy");
     let node_match = NodeMatch::new(dummy.root(), env.clone());
@@ -314,7 +314,7 @@ if (true) {
       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
       .collect();
     for (var, root) in &roots {
-      env.insert(var.to_string(), root.root());
+      env.insert(var, root.root());
     }
     let dummy = Tsx.ast_grep("dummy");
     let node_match = NodeMatch::new(dummy.root(), env.clone());

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -382,7 +382,9 @@ mod test {
     lang: impl Language,
   ) -> Result<String, TSParseError> {
     let mut source = lang.ast_grep(src);
-    let replacer = Pattern::new(replacer, lang);
+    // TODO: we should have still have pattern as replacer
+    let replacer = lang.pre_process_pattern(replacer);
+    let replacer = lang.ast_grep(replacer).inner;
     assert!(source.replace(pattern, replacer)?);
     Ok(source.generate())
   }

--- a/crates/language/src/rust.rs
+++ b/crates/language/src/rust.rs
@@ -1,16 +1,10 @@
 #![cfg(test)]
 use super::*;
-use ast_grep_core::{source::TSParseError, Matcher, Pattern};
+use crate::test::{test_match_lang, test_replace_lang};
+use ast_grep_core::source::TSParseError;
 
 fn test_match(s1: &str, s2: &str) {
-  let pattern = Pattern::str(s1, Rust);
-  let cand = Rust.ast_grep(s2);
-  assert!(
-    pattern.find_node(cand.root()).is_some(),
-    "goal: {:?}, candidate: {}",
-    pattern,
-    cand.root().to_sexp(),
-  );
+  test_match_lang(s1, s2, Rust)
 }
 
 #[test]
@@ -60,10 +54,7 @@ fn test_rust_spread_syntax() {
 }
 
 fn test_replace(src: &str, pattern: &str, replacer: &str) -> Result<String, TSParseError> {
-  let mut source = Rust.ast_grep(src);
-  let replacer = Pattern::new(replacer, Rust);
-  assert!(source.replace(pattern, replacer)?);
-  Ok(source.generate())
+  test_replace_lang(src, pattern, replacer, Rust)
 }
 
 #[test]

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -161,7 +161,7 @@ impl SgNode {
     let lang = *reference.inner.lang();
     let node_match = match matcher {
       Either3::A(pattern) => {
-        let pattern = Pattern::<JsDoc>::new(&pattern, lang);
+        let pattern = Pattern::new(&pattern, lang);
         reference.inner.find(pattern)
       }
       Either3::B(kind) => {
@@ -201,7 +201,7 @@ impl SgNode {
     let lang = *reference.inner.lang();
     let all_matches: Vec<_> = match matcher {
       Either3::A(pattern) => {
-        let pattern = Pattern::<JsDoc>::new(&pattern, lang);
+        let pattern = Pattern::new(&pattern, lang);
         reference.inner.find_all(pattern).collect()
       }
       Either3::B(kind) => {


### PR DESCRIPTION
# Summary

This pull request revamps `Pattern` implementation. Pattern was backed by tree-sitter Root and now it is backed by a custom data-structure.

# Reason behind the change

* reduce pattern Root traversal during search
* better cloning
* less dependent on tree-sitter
* more intuitive meta variable
* more flexible pattern code normalization


# Benchmark Result

## Criterion based microbench
<img width="897" alt="image" src="https://github.com/ast-grep/ast-grep/assets/2883231/1d2d2147-6b75-4b8e-8866-cc26ced215a0">

## Hyperfine based real-world-test
<img width="927" alt="image" src="https://github.com/ast-grep/ast-grep/assets/2883231/08121cb5-93d9-4258-8b8c-fe597df4b58f">
