### PR TITLE
feat: add inline-rules command line options

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -194,9 +194,10 @@ mod test_cli {
     ok("scan -r test.yml --format github");
     ok("scan --format github");
     ok("scan --interactive");
+    ok("scan -r test.yml -c test.yml --json dir"); // allow registering custom lang
     error("scan -i --json dir"); // conflict
     error("scan --report-style rich --json dir"); // conflict
-    error("scan -r test.yml -c test.yml --json dir"); // conflict
+    error("scan -r test.yml --inline-rules '{}'"); // conflict
     error("scan --format gitlab");
     error("scan --format github -i");
     error("scan --format local");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -30,8 +30,15 @@ pub struct ScanArg {
   /// Scan the codebase with the single rule located at the path RULE_FILE.
   ///
   /// This flags conflicts with --config. It is useful to run single rule without project setup.
-  #[clap(short, long, conflicts_with = "config", value_name = "RULE_FILE")]
+  #[clap(short, long, value_name = "RULE_FILE")]
   rule: Option<PathBuf>,
+
+  /// Scan the codebase with a rule defined by the provided RULE_TEXT.
+  ///
+  /// Use this argument if you want to test a rule without creating a YAML file on disk.
+  /// --inline-rules is incompatible with --rule.
+  #[clap(long, conflicts_with = "rule", value_name = "RULE_TEXT")]
+  inline_rules: Option<String>,
 
   /// Scan the codebase with rules with ids matching REGEX.
   ///
@@ -98,6 +105,8 @@ impl<P: Printer> ScanWithConfig<P> {
     let configs = if let Some(path) = &arg.rule {
       let rules = read_rule_file(path, None)?;
       RuleCollection::try_new(rules).context(EC::GlobPattern)?
+    } else if let Some(text) = &arg.inline_rules {
+      todo!("{text}")
     } else {
       find_rules(arg.config.take(), arg.filter.as_ref())?
     };
@@ -175,6 +184,8 @@ impl<P: Printer> ScanWithRule<P> {
   fn try_new(arg: ScanArg, printer: P) -> Result<Self> {
     let rule = if let Some(path) = &arg.rule {
       read_rule_file(path, None)?.pop().unwrap()
+    } else if let Some(text) = &arg.inline_rules {
+      todo!("{text}")
     } else {
       return Err(anyhow::anyhow!(EC::RuleNotSpecified));
     };
@@ -303,6 +314,7 @@ rule:
       config: Some(dir.path().join("sgconfig.yml")),
       filter: None,
       rule: None,
+      inline_rules: None,
       report_style: ReportStyle::Rich,
       input: InputArgs {
         no_ignore: vec![],

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -353,9 +353,10 @@ rule:
     assert!(run_with_config(arg).is_ok());
   }
 
+  // baseline test for coverage
   #[test]
   fn test_scan_with_inline_rules_error() {
-    let inline_rules = "nonesnese".to_string();
+    let inline_rules = "nonsense".to_string();
     let arg = ScanArg {
       inline_rules: Some(inline_rules),
       ..default_scan_arg()

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -79,7 +79,7 @@ fn test_sg_scan_inline_rules() -> Result<()> {
     .args(["scan", "--stdin", "--inline-rules", inline_rules, "--json"])
     .write_stdin("console.log(123)")
     .assert()
-    .stdout(contains("console.log(123)"))
+    .stdout(contains("\"text\": \"console.log(123)\""))
     .stdout(predicate::function(|n| from_slice::<Value>(n).is_ok()));
   Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now specify custom rules for code scanning directly through command-line arguments.

- **Tests**
  - Enhanced testing suite with a new test case for the scan command with custom language registration.
  - Updated existing tests to cover scenarios with conflicting command-line options.

- **Refactor**
  - Improved command-line argument handling for a more robust scanning process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->