### PR TITLE
fix: expose get_fixer method for non str doc

### DIFF
--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -10,7 +10,7 @@ pub use crate::constraints::{
 };
 use ast_grep_core::language::Language;
 use ast_grep_core::meta_var::MetaVarMatchers;
-use ast_grep_core::replacer::Replacer;
+use ast_grep_core::replacer::{IndentSensitive, Replacer};
 use ast_grep_core::replacer::{TemplateFix, TemplateFixError};
 use ast_grep_core::{NodeMatch, StrDoc};
 use schemars::JsonSchema;
@@ -129,7 +129,7 @@ pub struct SerializableRuleConfig<L: Language> {
 type RResult<T> = std::result::Result<T, RuleConfigError>;
 
 impl<L: Language> SerializableRuleConfig<L> {
-  fn get_fixer(&self) -> RResult<Option<TemplateFix<String>>> {
+  pub fn get_fixer<C: IndentSensitive>(&self) -> RResult<Option<TemplateFix<C>>> {
     if let Some(Fixer::Str(fix)) = &self.fix {
       if let Some(trans) = &self.transform {
         let keys: Vec<_> = trans.keys().cloned().collect();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the configuration capabilities for rule definitions to support new formatting options.

- **Documentation**
	- Updated public API documentation to reflect changes in configuration interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->