### PR TITLE
refactor: unify run_worker and run_std_in

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -12,8 +12,7 @@ use crate::error::ErrorContext as EC;
 use crate::lang::SgLang;
 use crate::print::{ColoredPrinter, Diff, Heading, InteractivePrinter, JSONPrinter, Printer};
 use crate::utils::{filter_file_pattern, InputArgs, MatchUnit, OutputArgs};
-use crate::utils::{run_std_in, StdInWorker};
-use crate::utils::{run_worker, Items, PathWorker, Worker};
+use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 
 // NOTE: have to register custom lang before clap read arg
 // RunArg has a field of SgLang
@@ -133,11 +132,11 @@ pub fn run_with_pattern(arg: RunArg) -> Result<()> {
 
 fn run_pattern_with_printer(arg: RunArg, printer: impl Printer + Sync) -> Result<()> {
   if arg.input.stdin {
-    run_std_in(RunWithSpecificLang::new(arg, printer)?)
+    RunWithSpecificLang::new(arg, printer)?.run_std_in()
   } else if arg.lang.is_some() {
-    run_worker(RunWithSpecificLang::new(arg, printer)?)
+    RunWithSpecificLang::new(arg, printer)?.run_path()
   } else {
-    run_worker(RunWithInferredLang { arg, printer })
+    RunWithInferredLang { arg, printer }.run_path()
   }
 }
 

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -13,7 +13,7 @@ use crate::lang::SgLang;
 use crate::print::{ColoredPrinter, Diff, Heading, InteractivePrinter, JSONPrinter, Printer};
 use crate::utils::{filter_file_pattern, InputArgs, MatchUnit, OutputArgs};
 use crate::utils::{run_std_in, StdInWorker};
-use crate::utils::{run_worker, Items, Worker};
+use crate::utils::{run_worker, Items, PathWorker};
 
 // NOTE: have to register custom lang before clap read arg
 // RunArg has a field of SgLang
@@ -146,7 +146,7 @@ struct RunWithInferredLang<Printer> {
   printer: Printer,
 }
 
-impl<P: Printer + Sync> Worker for RunWithInferredLang<P> {
+impl<P: Printer + Sync> PathWorker for RunWithInferredLang<P> {
   type Item = (MatchUnit<Pattern<SgLang>>, SgLang);
   fn build_walk(&self) -> WalkParallel {
     self.arg.input.walk()
@@ -201,7 +201,7 @@ impl<Printer> RunWithSpecificLang<Printer> {
   }
 }
 
-impl<P: Printer + Sync> Worker for RunWithSpecificLang<P> {
+impl<P: Printer + Sync> PathWorker for RunWithSpecificLang<P> {
   type Item = MatchUnit<Pattern<SgLang>>;
   fn build_walk(&self) -> WalkParallel {
     let lang = self.arg.lang.expect("must present");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -16,8 +16,7 @@ use crate::print::{
   ReportStyle, SimpleFile,
 };
 use crate::utils::{filter_file_interactive, InputArgs, OutputArgs};
-use crate::utils::{run_std_in, StdInWorker, Worker};
-use crate::utils::{run_worker, Items, PathWorker};
+use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 
 type AstGrep = ast_grep_core::AstGrep<StrDoc<SgLang>>;
 
@@ -88,10 +87,10 @@ pub fn run_with_config(arg: ScanArg) -> Result<()> {
 fn run_scan<P: Printer + Sync>(arg: ScanArg, printer: P) -> Result<()> {
   if arg.input.stdin {
     let worker = ScanWithRule::try_new(arg, printer)?;
-    run_std_in(worker)
+    worker.run_std_in()
   } else {
     let worker = ScanWithConfig::try_new(arg, printer)?;
-    run_worker(worker)
+    worker.run_path()
   }
 }
 

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -17,7 +17,7 @@ use crate::print::{
 };
 use crate::utils::{filter_file_interactive, InputArgs, OutputArgs};
 use crate::utils::{run_std_in, StdInWorker};
-use crate::utils::{run_worker, Items, Worker};
+use crate::utils::{run_worker, Items, PathWorker};
 
 type AstGrep = ast_grep_core::AstGrep<StrDoc<SgLang>>;
 
@@ -120,7 +120,7 @@ impl<P: Printer> ScanWithConfig<P> {
   }
 }
 
-impl<P: Printer + Sync> Worker for ScanWithConfig<P> {
+impl<P: Printer + Sync> PathWorker for ScanWithConfig<P> {
   type Item = (PathBuf, AstGrep, BitSet);
   fn build_walk(&self) -> WalkParallel {
     self.arg.input.walk()
@@ -197,7 +197,7 @@ impl<P: Printer> ScanWithRule<P> {
   }
 }
 
-impl<P: Printer + Sync> Worker for ScanWithRule<P> {
+impl<P: Printer + Sync> PathWorker for ScanWithRule<P> {
   type Item = (PathBuf, AstGrep);
   fn build_walk(&self) -> WalkParallel {
     unreachable!()

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -79,7 +79,7 @@ pub fn prompt(prompt_text: &str, letters: &str, default: Option<char>) -> Result
 /// ast-grep discovers files in parallel by `build_walk`.
 /// Then every file is parsed and filtered in `produce_item`.
 /// Finally, `produce_item` will send `Item` to the consumer thread.
-pub trait Worker: Sync {
+pub trait PathWorker: Sync {
   /// The item to send between producer/consumer threads.
   /// It is usually parsed tree-sitter Root with optional data.
   type Item: Send;
@@ -92,7 +92,7 @@ pub trait Worker: Sync {
   fn consume_items(&self, items: Items<Self::Item>) -> Result<()>;
 }
 
-pub trait StdInWorker: Worker {
+pub trait StdInWorker: PathWorker {
   fn parse_stdin(&self, src: String) -> Option<Self::Item>;
 }
 
@@ -139,7 +139,7 @@ pub fn run_std_in<MW: StdInWorker>(worker: MW) -> Result<()> {
   }
 }
 
-pub fn run_worker<MW: Worker>(worker: MW) -> Result<()> {
+pub fn run_worker<MW: PathWorker>(worker: MW) -> Result<()> {
   let producer = |path: PathBuf| worker.produce_item(&path);
   let (tx, rx) = mpsc::channel();
   let walker = worker.build_walk();


### PR DESCRIPTION
# Summary 

Refactor to unify the handling of file path discovery and standard input processing by abstracting workers into two sub-traits: 
* PathWorker 
* StdInWorker

each with new run methods; modified run_worker function to accept a PathWorker trait reference.
