### PR TITLE
feat: add rewriters in RuleConfig

### DIFF
--- a/crates/config/src/rule/referent_rule.rs
+++ b/crates/config/src/rule/referent_rule.rs
@@ -97,6 +97,16 @@ impl<L: Language> RuleRegistration<L> {
     }
     Ok(())
   }
+
+  pub fn insert_rewrite(&self, id: &str, rewrite: RuleCore<L>) -> Result<(), ReferentRuleError> {
+    let mut map = self.rewrites.write();
+    if map.contains_key(id) {
+      return Err(ReferentRuleError::DuplicateRule(id.into()));
+    }
+    map.insert(id.to_string(), rewrite);
+    // TODO: add cyclic rewrite check?
+    Ok(())
+  }
 }
 impl<L: Language> Default for RuleRegistration<L> {
   fn default() -> Self {

--- a/crates/config/src/rule/referent_rule.rs
+++ b/crates/config/src/rule/referent_rule.rs
@@ -56,6 +56,7 @@ impl<R> Default for Registration<R> {
 pub struct RuleRegistration<L: Language> {
   local: Registration<Rule<L>>,
   global: Registration<RuleCore<L>>,
+  rewrites: Registration<RuleCore<L>>,
 }
 
 // these are shit code
@@ -72,6 +73,7 @@ impl<L: Language> RuleRegistration<L> {
     Self {
       local: Default::default(),
       global: global.clone(),
+      rewrites: Default::default(),
     }
   }
 
@@ -101,6 +103,7 @@ impl<L: Language> Default for RuleRegistration<L> {
     Self {
       local: Default::default(),
       global: Default::default(),
+      rewrites: Default::default(),
     }
   }
 }
@@ -114,7 +117,11 @@ impl<L: Language> RegistrationRef<L> {
   pub fn unref(&self) -> RuleRegistration<L> {
     let local = Registration(self.local.upgrade().unwrap());
     let global = Registration(self.global.upgrade().unwrap());
-    RuleRegistration { local, global }
+    RuleRegistration {
+      local,
+      global,
+      rewrites: Default::default(),
+    }
   }
 }
 

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -50,6 +50,8 @@ pub struct SerializableRuleConfig<L: Language> {
   pub core: SerializableRuleCore<L>,
   /// Unique, descriptive identifier, e.g., no-unused-variable
   pub id: String,
+  /// Rewrite rules for `applyRewriters` transformation
+  pub rewriters: Option<Vec<SerializableRuleCoreWithId<L>>>,
   /// Main message highlighting why this rule fired. It should be single line and concise,
   /// but specific enough to be understood without additional context.
   #[serde(default)]
@@ -144,6 +146,7 @@ mod test {
     SerializableRuleConfig {
       core,
       id: "".into(),
+      rewriters: None,
       message: "".into(),
       note: None,
       severity: Severity::Hint,


### PR DESCRIPTION
- [x] add rewriters in ruleconfig
- [x] add rewrites in deserialize_env and referent rule
- [x] add rewrites in config

fix #855 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced rewrite rules capability for the transformation process.
  - Renamed `rewriter` field to `rewriters` in `SerializableRuleConfig` struct.
  - Added new field `rewriters` of type `Option<Vec<SerializableRuleCoreWithId<L>>>` in `SerializableRuleConfig` struct.
  - Modified `get_fixer` method's signature to accept `env` directly.
  - Adjusted `get_fixer` method's implementation to use the provided `env`.
  - Updated `get_fixer` method's usage to pass `env` instead of `globals`.
  - Renamed `_utils` field to `utils`.
  - Added new `get_env` method to obtain `DeserializeEnv` using `lang` and `utils`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->