### PR TITLE
refactor: remove IndentSensitive trait

### DIFF
--- a/crates/config/src/fixer.rs
+++ b/crates/config/src/fixer.rs
@@ -2,7 +2,7 @@ use crate::maybe::Maybe;
 use crate::rule::{Relation, Rule, RuleSerializeError, StopBy};
 use crate::transform::Transformation;
 use crate::DeserializeEnv;
-use ast_grep_core::replacer::{IndentSensitive, Replacer, TemplateFix, TemplateFixError};
+use ast_grep_core::replacer::{Content, Replacer, TemplateFix, TemplateFixError};
 use ast_grep_core::{Doc, Language, Matcher, NodeMatch};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -60,7 +60,7 @@ impl<L: Language> Expansion<L> {
   }
 }
 
-pub struct Fixer<C: IndentSensitive, L: Language> {
+pub struct Fixer<C: Content, L: Language> {
   template: TemplateFix<C>,
   expand_start: Option<Expansion<L>>,
   expand_end: Option<Expansion<L>>,
@@ -68,7 +68,7 @@ pub struct Fixer<C: IndentSensitive, L: Language> {
 
 impl<C, L> Fixer<C, L>
 where
-  C: IndentSensitive,
+  C: Content,
   L: Language,
 {
   fn do_parse(
@@ -127,7 +127,7 @@ impl<D, L, C> Replacer<D> for Fixer<C, L>
 where
   D: Doc<Source = C, Lang = L>,
   L: Language,
-  C: IndentSensitive,
+  C: Content,
 {
   fn generate_replacement(&self, nm: &ast_grep_core::NodeMatch<D>) -> Vec<C::Underlying> {
     // simple forwarding to template

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -6,7 +6,7 @@ pub use crate::rule_core::{
   SerializableRuleCore, SerializeConstraintsError,
 };
 use ast_grep_core::language::Language;
-use ast_grep_core::replacer::{IndentSensitive, Replacer};
+use ast_grep_core::replacer::{Content, Replacer};
 use ast_grep_core::{NodeMatch, StrDoc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -131,7 +131,7 @@ impl<L: Language> RuleConfig<L> {
   pub fn get_message(&self, node: &NodeMatch<StrDoc<L>>) -> String {
     self.inner.get_message(node)
   }
-  pub fn get_fixer<C: IndentSensitive>(&self) -> Result<Option<Fixer<C, L>>, RuleConfigError> {
+  pub fn get_fixer<C: Content>(&self) -> Result<Option<Fixer<C, L>>, RuleConfigError> {
     if let Some(fix) = &self.fix {
       let env = self.matcher.get_env(self.language.clone());
       let parsed = Fixer::parse(fix, &env, &self.transform)?;

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -9,7 +9,7 @@ use crate::GlobalRules;
 use ast_grep_core::language::Language;
 use ast_grep_core::matcher::{KindMatcher, KindMatcherError, RegexMatcher, RegexMatcherError};
 use ast_grep_core::meta_var::{MetaVarEnv, MetaVarMatcher, MetaVarMatchers};
-use ast_grep_core::replacer::IndentSensitive;
+use ast_grep_core::replacer::Content;
 use ast_grep_core::{Doc, Matcher, Node, Pattern, PatternError, StrDoc};
 use serde::{Deserialize, Serialize};
 use serde_yaml::Error as YamlError;
@@ -120,7 +120,7 @@ impl<L: Language> SerializableRuleCore<L> {
     })
   }
 
-  fn get_fixer<C: IndentSensitive>(&self, env: &DeserializeEnv<L>) -> RResult<Option<Fixer<C, L>>> {
+  fn get_fixer<C: Content>(&self, env: &DeserializeEnv<L>) -> RResult<Option<Fixer<C, L>>> {
     if let Some(fix) = &self.fix {
       let parsed = Fixer::parse(fix, env, &self.transform)?;
       Ok(Some(parsed))

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,6 +1,6 @@
 use crate::matcher::{Matcher, NodeMatch};
 use crate::meta_var::{is_valid_meta_var_char, MetaVariableID};
-use crate::source::{Content, Edit as E};
+use crate::source::Edit as E;
 use crate::{Doc, Node, Root};
 use std::ops::Range;
 
@@ -11,7 +11,7 @@ mod indent;
 mod structural;
 mod template;
 
-pub use indent::IndentSensitive;
+pub use crate::source::Content;
 pub use template::{TemplateFix, TemplateFixError};
 
 /// Replace meta variable in the replacer string
@@ -27,10 +27,7 @@ pub trait Replacer<D: Doc> {
   }
 }
 
-impl<D: Doc> Replacer<D> for str
-where
-  D::Source: indent::IndentSensitive,
-{
+impl<D: Doc> Replacer<D> for str {
   fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source> {
     template::gen_replacement(self, nm)
   }


### PR DESCRIPTION
fix #868
BREAKING CHANGE: IndentSensitive is not used anymore. Just change it to Source. Source is reexported in replacer mod so you can mechanically change IndentSensitive to Source.