### PR TITLE
[refactor] move language out of SerializableRuleCore

### DIFF
--- a/crates/config/src/rule/deserialize_env.rs
+++ b/crates/config/src/rule/deserialize_env.rs
@@ -1,9 +1,7 @@
 use super::referent_rule::{GlobalRules, ReferentRuleError, RuleRegistration};
 use crate::maybe::Maybe;
 use crate::rule::{self, Rule, RuleSerializeError, SerializableRule};
-use crate::rule_config::{
-  into_map, RuleConfigError, SerializableRuleCore, SerializableRuleCoreWithId,
-};
+use crate::rule_config::{into_map, RuleConfigError, SerializableRuleCoreWithId};
 
 use ast_grep_core::language::Language;
 
@@ -33,12 +31,12 @@ impl DependentRule for SerializableRule {
   }
 }
 
-impl<L: Language> DependentRule for SerializableRuleCore<L> {
+impl<L: Language> DependentRule for SerializableRuleCoreWithId<L> {
   fn visit_dependent_rules<'a>(
     &'a self,
     sorter: &mut TopologicalSort<'a, Self>,
   ) -> OrderResult<()> {
-    visit_dependent_rule_ids(&self.rule, sorter)
+    visit_dependent_rule_ids(&self.core.rule, sorter)
   }
 }
 
@@ -152,7 +150,7 @@ impl<L: Language> DeserializeEnv<L> {
     for id in order {
       let rule = utils.get(id).expect("must exist");
       let env = DeserializeEnv::new(rule.language.clone()).with_globals(&registration);
-      let matcher = rule.get_matcher(env)?;
+      let matcher = rule.core.get_matcher(env)?;
       registration
         .insert(id, matcher)
         .map_err(RuleSerializeError::MatchesReference)?;

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -35,23 +35,27 @@ pub enum Severity {
 #[derive(Serialize, Deserialize, Clone, JsonSchema)]
 pub struct SerializableRuleCoreWithId<L: Language> {
   #[serde(flatten)]
-  pub core: SerializableRuleCore<L>,
+  pub core: SerializableRuleCore,
   /// Unique, descriptive identifier, e.g., no-unused-variable
   pub id: String,
+  /// Specify the language to parse and the file extension to include in matching.
+  pub language: L,
 }
 
 pub fn into_map<L: Language>(
   rules: Vec<SerializableRuleCoreWithId<L>>,
-) -> HashMap<String, SerializableRuleCore<L>> {
-  rules.into_iter().map(|r| (r.id, r.core)).collect()
+) -> HashMap<String, SerializableRuleCoreWithId<L>> {
+  rules.into_iter().map(|r| (r.id.clone(), r)).collect()
 }
 
 #[derive(Serialize, Deserialize, Clone, JsonSchema)]
 pub struct SerializableRuleConfig<L: Language> {
   #[serde(flatten)]
-  pub core: SerializableRuleCore<L>,
+  pub core: SerializableRuleCore,
   /// Unique, descriptive identifier, e.g., no-unused-variable
   pub id: String,
+  /// Specify the language to parse and the file extension to include in matching.
+  pub language: L,
   /// Rewrite rules for `applyRewriters` transformation
   pub rewriters: Option<Vec<SerializableRuleCoreWithId<L>>>,
   /// Main message highlighting why this rule fired. It should be single line and concise,
@@ -86,7 +90,7 @@ impl<L: Language> SerializableRuleConfig<L> {
 }
 
 impl<L: Language> Deref for SerializableRuleConfig<L> {
-  type Target = SerializableRuleCore<L>;
+  type Target = SerializableRuleCore;
   fn deref(&self) -> &Self::Target {
     &self.core
   }
@@ -163,7 +167,6 @@ mod test {
 
   fn ts_rule_config(rule: SerializableRule) -> SerializableRuleConfig<TypeScript> {
     let core = SerializableRuleCore {
-      language: TypeScript::Tsx,
       rule,
       constraints: None,
       transform: None,
@@ -173,6 +176,7 @@ mod test {
     SerializableRuleConfig {
       core,
       id: "".into(),
+      language: TypeScript::Tsx,
       rewriters: None,
       message: "".into(),
       note: None,

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -31,7 +31,6 @@ impl NapiConfig {
   pub fn parse_with(self, language: FrontEndLanguage) -> NapiResult<RuleCore<FrontEndLanguage>> {
     let lang = self.language.unwrap_or(language);
     let rule = SerializableRuleCore {
-      language: lang,
       rule: serde_json::from_value(self.rule)?,
       constraints: self.constraints.map(serde_json::from_value).transpose()?,
       transform: self.transform.map(serde_json::from_value).transpose()?,

--- a/crates/pyo3/src/py_node.rs
+++ b/crates/pyo3/src/py_node.rs
@@ -269,9 +269,9 @@ impl SgNode {
   ) -> PyResult<RuleCore<SupportLang>> {
     let lang = self.inner.lang();
     let config = if let Some(config) = config {
-      config_from_dict(lang, config)?
+      config_from_dict(config)?
     } else if let Some(rule) = kwargs {
-      config_from_rule(lang, rule)?
+      config_from_rule(rule)?
     } else {
       return Err(PyErr::new::<PyValueError, _>("rule must not be empty"));
     };
@@ -281,23 +281,13 @@ impl SgNode {
   }
 }
 
-fn config_from_dict(
-  lang: &SupportLang,
-  dict: &PyDict,
-) -> PyResult<SerializableRuleCore<SupportLang>> {
-  dict
-    .set_item("language", lang.to_string())
-    .expect("set language should never fail");
+fn config_from_dict(dict: &PyDict) -> PyResult<SerializableRuleCore> {
   Ok(depythonize(dict)?)
 }
 
-fn config_from_rule(
-  lang: &SupportLang,
-  dict: &PyDict,
-) -> PyResult<SerializableRuleCore<SupportLang>> {
+fn config_from_rule(dict: &PyDict) -> PyResult<SerializableRuleCore> {
   let rule = depythonize(dict)?;
   Ok(SerializableRuleCore {
-    language: *lang,
     rule,
     constraints: None,
     utils: None,
@@ -312,7 +302,7 @@ fn get_matcher_from_rule(
 ) -> PyResult<RuleCore<SupportLang>> {
   let rule = dict.ok_or_else(|| PyErr::new::<PyValueError, _>("rule must not be empty"))?;
   let env = DeserializeEnv::new(*lang);
-  let config = config_from_rule(lang, rule)?;
+  let config = config_from_rule(rule)?;
   let matcher = config.get_matcher(env).context("cannot get matcher")?;
   Ok(matcher)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rule serialization and deserialization logic with language-specific handling.
	- Introduced `SerializableRuleCoreWithId` to include language context in rule configurations.

- **Refactor**
	- Decoupled language types from rule core serialization.
	- Improved environment handling in rule matching methods.

- **Bug Fixes**
	- Fixed potential issues in language parameter handling for rule matching.

- **Documentation**
	- Added comments to clarify changes in language parameter usage.

- **Tests**
	- Removed nested replacement support in test functions for better clarity and focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->