### PR TITLE
LSP default message for diagnostics

### DIFF
--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -67,18 +67,8 @@ pub struct SerializableRuleConfig<L: Language> {
 }
 
 impl<L: Language> SerializableRuleConfig<L> {
-  fn get_default_message(&self) -> &str {
-    &self.id
-  }
-
   fn get_message(&self, node_match: &NodeMatch<StrDoc<L>>) -> String {
-    // Note: The LSP client in vscode won't show any diagnostics at all if it receives one with an empty message
-    let msg = if self.message.is_empty() {
-      self.get_default_message()
-    } else {
-      &self.message
-    };
-    let bytes = msg.generate_replacement(node_match);
+    let bytes = self.message.generate_replacement(node_match);
     String::from_utf8(bytes).expect("replacement must be valid utf-8")
   }
 

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -67,8 +67,18 @@ pub struct SerializableRuleConfig<L: Language> {
 }
 
 impl<L: Language> SerializableRuleConfig<L> {
+  fn get_default_message(&self) -> &str {
+    &self.id
+  }
+
   fn get_message(&self, node_match: &NodeMatch<StrDoc<L>>) -> String {
-    let bytes = self.message.generate_replacement(node_match);
+    // Note: The LSP client in vscode won't show any diagnostics at all if it receives one with an empty message
+    let msg = if self.message.is_empty() {
+      self.get_default_message()
+    } else {
+      &self.message
+    };
+    let bytes = msg.generate_replacement(node_match);
     String::from_utf8(bytes).expect("replacement must be valid utf-8")
   }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -187,6 +187,14 @@ fn convert_node_to_range<D: Doc>(node_match: &Node<D>) -> Range {
   }
 }
 
+fn get_non_empty_message<L: Language>(rule: &RuleConfig<L>) -> String {
+  // Note: The LSP client in vscode won't show any diagnostics at all if it receives one with an empty message
+  if rule.message.is_empty() {
+    rule.id.to_string()
+  } else {
+    rule.message.to_string()
+  }
+}
 fn convert_match_to_diagnostic<L: Language>(
   node_match: NodeMatch<StrDoc<L>>,
   rule: &RuleConfig<L>,
@@ -203,7 +211,7 @@ fn convert_match_to_diagnostic<L: Language>(
       Severity::Hint => DiagnosticSeverity::HINT,
       Severity::Off => unreachable!("turned-off rule should not have match"),
     }),
-    message: rule.get_message(&node_match),
+    message: get_non_empty_message(rule),
     source: Some(String::from("ast-grep")),
     tags: None,
     related_information: collect_labels(&node_match, uri),


### PR DESCRIPTION
Fix for https://github.com/ast-grep/ast-grep/issues/969
If a published diagnostic's message property would be the empty string, replace it with a default string.
The default string is the rule's id property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved message handling in configurations by introducing a fallback to default messages when no custom message is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->