### PR TITLE
feat(lsp):  run "source.fixAll.ast-grep" onsave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,11 +216,12 @@ version = "0.20.2"
 dependencies = [
  "ast-grep-config",
  "ast-grep-core",
+ "ast-grep-language",
  "dashmap",
  "serde",
+ "serde_json",
  "tokio",
  "tower-lsp",
- "tree-sitter-typescript",
 ]
 
 [[package]]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,7 +25,8 @@ serde.workspace = true
 tower-lsp = "0.20.0"
 
 [dev-dependencies]
-tree-sitter-typescript = "0.20.5"
+ast-grep-language.workspace = true
+serde_json = "1.0.115"
 tokio = { version = "1", features = [
   "rt-multi-thread",
   "io-std",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "ast-grep-lsp"
 description = "Search and Rewrite code at large scale using precise AST pattern"
-keywords = ["ast", "pattern", "codemod", "search", "rewrite"]
+keywords = [
+  "ast",
+  "pattern",
+  "codemod",
+  "search",
+  "rewrite",
+]
 
 version.workspace = true
 authors.workspace = true
@@ -20,4 +26,8 @@ tower-lsp = "0.20.0"
 
 [dev-dependencies]
 tree-sitter-typescript = "0.20.5"
-tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util"] }
+tokio = { version = "1", features = [
+  "rt-multi-thread",
+  "io-std",
+  "io-util",
+] }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -434,7 +434,9 @@ impl<L: LSPLang> Backend<L> {
       }
     }
 
-    let rules = if let Ok(rules) = &self.rules {
+    let Ok(rules) = &self.rules else {
+      return Some(response);
+    }
       rules
     } else {
       return Some(response);

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -379,6 +379,7 @@ impl<L: LSPLang> Backend<L> {
       };
       let matcher = &config.matcher;
 
+      let entry = changes.entry(text_document.uri.clone()).or_default();
       for matched_node in versioned.root.root().find_all(&matcher) {
         let range = convert_node_to_range(&matched_node);
         if !ranges.contains(&range) {
@@ -393,10 +394,8 @@ impl<L: LSPLang> Backend<L> {
           range,
           new_text: String::from_utf8(edit.inserted_text).unwrap(),
         };
-        changes
-          .entry(text_document.uri.clone())
-          .or_default()
-          .push(edit);
+
+        entry.push(edit);
       }
     }
     Some(changes)


### PR DESCRIPTION
https://github.com/ast-grep/ast-grep-vscode/issues/67
format with ast-grep when setting source.fixAll
```jsonc
// .vscode/settings.json
{
  "editor.codeActionsOnSave": {
    "source.fixAll.ast-grep": "explicit" // or "source.fixAll" it works too
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Improved code action generation logic for efficiency.
- **New Features**
    - Expanded code action options to include source-related actions.
- **Chores**
    - Modified `Cargo.toml` file for better dependency readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->