### PR TITLE
feat(lsp): execute command "ast-grep.applyAllFixes"

### DIFF
--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -19,14 +19,14 @@ rust-version.workspace = true
 [dependencies]
 ast-grep-core.workspace = true
 ast-grep-config.workspace = true
-
-dashmap = "5.5.3"
 serde.workspace = true
+
+serde_json = "1.0.115"
+dashmap = "5.5.3"
 tower-lsp = "0.20.0"
 
 [dev-dependencies]
 ast-grep-language.workspace = true
-serde_json = "1.0.115"
 tokio = { version = "1", features = [
   "rt-multi-thread",
   "io-std",

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -436,10 +436,6 @@ impl<L: LSPLang> Backend<L> {
     let mut response = CodeActionResponse::new();
 
     let code_action = params.context.only.as_ref()?.first()?.clone();
-    self
-      .client
-      .log_message(MessageType::LOG, "")
-      .await;
 
     // we only handle these code_actions
     // 1. QuickFix
@@ -450,6 +446,14 @@ impl<L: LSPLang> Backend<L> {
     {
       return Some(response);
     }
+
+    self
+      .client
+      .log_message(
+        MessageType::LOG,
+        format!("Running CodeAction {}", code_action.as_str()),
+      )
+      .await;
 
     let changes = self.compute_all_fixes(text_doc, error_id_to_ranges, path);
 
@@ -501,6 +505,13 @@ impl<L: LSPLang> Backend<L> {
 
     match command.as_ref() {
       APPLY_ALL_FIXES => {
+        self
+          .client
+          .log_message(
+            MessageType::LOG,
+            format!("Running ExecuteCommand {}", command),
+          )
+          .await;
         let uri = Url::parse(arguments.first()?["uri"].as_str()?).ok()?;
         let path = uri.to_file_path().ok()?;
         let version = arguments.first()?["version"].as_number()?.as_i64()? as i32;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -72,7 +72,7 @@ const FALLBACK_CODE_ACTION_PROVIDER: Option<CodeActionProviderCapability> =
 
 const SOURCE_FIX_ALL_AST_GREP: CodeActionKind = CodeActionKind::new("source.fixAll.ast-grep");
 
-const APPLY_ALL_FIXES: &str = "ast-grep.applyAllFixes";
+pub const APPLY_ALL_FIXES: &str = "ast-grep.applyAllFixes";
 
 fn code_action_provider(
   client_capability: &ClientCapabilities,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -318,7 +318,12 @@ impl<L: LSPLang> Backend<L> {
     let mut diagnostics = vec![];
     let path = uri.to_file_path().ok()?;
 
-    let rules = self.rules.as_ref().ok()?.for_path(&path);
+    let rules = match &self.rules {
+      Ok(rules) => rules.for_path(&path),
+      Err(_) => {
+        return Some(diagnostics);
+      }
+    };
 
     let scan = CombinedScan::new(rules);
     let hit_set = scan.all_kinds();

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -1,0 +1,156 @@
+use ast_grep_config::{from_yaml_string, GlobalRules, RuleCollection, RuleConfig};
+use ast_grep_language::SupportLang;
+use ast_grep_lsp::*;
+use serde_json::Value;
+use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
+
+pub fn req(msg: &str) -> String {
+  format!("Content-Length: {}\r\n\r\n{}", msg.len(), msg)
+}
+
+// A function that takes a byte slice as input and returns the content length as an option
+pub fn resp(input: &[u8]) -> Option<&str> {
+  let input_str = std::str::from_utf8(input).ok()?;
+  let mut splits = input_str.split("\r\n\r\n");
+  let header = splits.next()?;
+  let body = splits.next()?;
+  let length_str = header.trim_start_matches("Content-Length: ");
+  let length = length_str.parse::<usize>().ok()?;
+  Some(&body[..length])
+}
+
+pub fn create_lsp() -> (DuplexStream, DuplexStream) {
+  let globals = GlobalRules::default();
+  let config: RuleConfig<SupportLang> = from_yaml_string(
+    r"
+id: no-console-rule
+message: No console.log
+severity: warning
+language: TypeScript
+rule:
+  pattern: console.log($$$A)
+note: no console.log
+fix: |
+  alert($$$A)
+",
+    &globals,
+  )
+  .unwrap()
+  .pop()
+  .unwrap();
+  let rc: RuleCollection<SupportLang> = RuleCollection::try_new(vec![config]).unwrap();
+  let rc_result: std::result::Result<_, String> = Ok(rc);
+  let (service, socket) = LspService::build(|client| Backend::new(client, rc_result)).finish();
+  let (req_client, req_server) = duplex(1024);
+  let (resp_server, resp_client) = duplex(1024);
+
+  // start server as concurrent task
+  tokio::spawn(Server::new(req_server, resp_server, socket).serve(service));
+
+  (req_client, resp_client)
+}
+
+pub async fn initialize_lsp(
+  req_client: &mut DuplexStream,
+  resp_client: &mut DuplexStream,
+) -> Vec<u8> {
+  let initialize = r#"{
+      "jsonrpc":"2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "capabilities": {
+          "textDocumentSync": 1
+        }
+      }
+    }"#;
+  let mut buf = vec![0; 1024];
+
+  req_client
+    .write_all(req(initialize).as_bytes())
+    .await
+    .unwrap();
+  let _ = resp_client.read(&mut buf).await.unwrap();
+
+  buf
+}
+
+pub async fn request_code_action_to_lsp(
+  req_client: &mut DuplexStream,
+  resp_client: &mut DuplexStream,
+) -> Vec<u8> {
+  let code_action_request = r#"{
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "textDocument/codeAction",
+      "params": {
+        "range": {
+          "end": {
+            "character": 10,
+            "line": 1
+          },
+          "start": {
+            "character": 10,
+            "line": 1
+          }
+        },
+        "textDocument": {
+          "uri": "file:///Users/codes/ast-grep-vscode/test.tsx"
+        },
+        "context": {
+          "diagnostics": [
+            {
+              "range": {
+                "start": {
+                  "line": 0,
+                  "character": 0
+                },
+                "end": {
+                  "line": 0,
+                  "character": 16
+                }
+              },
+              "code": "no-console-rule",
+              "source": "ast-grep",
+              "message": "No console.log"
+            }
+          ],
+          "only": ["source.fixAll"]
+        }
+      }
+      }"#;
+
+  let mut buf = vec![0; 1024];
+  req_client
+    .write_all(req(code_action_request).as_bytes())
+    .await
+    .unwrap();
+  let _ = resp_client.read(&mut buf).await.unwrap();
+
+  buf
+}
+
+#[test]
+fn test_basic() {
+  tokio::runtime::Runtime::new().unwrap().block_on(async {
+    let (mut req_client, mut resp_client) = create_lsp();
+
+    let buf = initialize_lsp(&mut req_client, &mut resp_client).await;
+    assert!(resp(&buf).unwrap().starts_with('{'));
+  });
+}
+
+#[test]
+fn test_code_action() {
+  tokio::runtime::Runtime::new().unwrap().block_on(async {
+    let (mut req_client, mut resp_client) = create_lsp();
+
+    let buf = initialize_lsp(&mut req_client, &mut resp_client).await;
+    assert!(resp(&buf).unwrap().starts_with('{'));
+
+    let buf = request_code_action_to_lsp(&mut req_client, &mut resp_client).await;
+    let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
+    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
+    assert_eq!(json_val["method"], "window/logMessage");
+  });
+}

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -130,6 +130,37 @@ pub async fn request_code_action_to_lsp(
   buf
 }
 
+pub async fn request_execute_command_to_lsp(
+  req_client: &mut DuplexStream,
+  resp_client: &mut DuplexStream,
+) -> Vec<u8> {
+  let execute_command_request: &str = r#"
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "workspace/executeCommand",
+    "params": {
+      "command": "ast-grep.applyAllFixes",
+      "arguments": [
+        {
+          "text": "class AstGrepTest {\n  test() {\n    console.log('Hello, world!')\n  }\n}\n\nclass AnotherCase {\n  get test2() {\n    return 123\n  }\n}\n\nconst NoProblemHere = {\n  test() {\n    if (Math.random() > 3) {\n      throw new Error('This is not an error')\n    }\n  },\n}\n",
+          "uri": "file:///Users/appe/Documents/codes/ast-grep-vscode/fixture/test.ts",
+          "version": 1
+        }
+      ]
+    }
+  }
+  "#;
+  let mut buf = vec![0; 1024];
+  req_client
+    .write_all(req(execute_command_request).as_bytes())
+    .await
+    .unwrap();
+  let _ = resp_client.read(&mut buf).await.unwrap();
+
+  buf
+}
+
 #[test]
 fn test_basic() {
   tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -149,6 +180,21 @@ fn test_code_action() {
     assert!(resp(&buf).unwrap().starts_with('{'));
 
     let buf = request_code_action_to_lsp(&mut req_client, &mut resp_client).await;
+    let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
+    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
+    assert_eq!(json_val["method"], "window/logMessage");
+  });
+}
+
+#[test]
+fn test_execute_apply_all_fixes() {
+  tokio::runtime::Runtime::new().unwrap().block_on(async {
+    let (mut req_client, mut resp_client) = create_lsp();
+
+    let buf = initialize_lsp(&mut req_client, &mut resp_client).await;
+    assert!(resp(&buf).unwrap().starts_with('{'));
+
+    let buf = request_execute_command_to_lsp(&mut req_client, &mut resp_client).await;
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
     // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
     assert_eq!(json_val["method"], "window/logMessage");

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -169,7 +169,6 @@ fn test_basic() {
 
     let buf = initialize_lsp(&mut req_client, &mut resp_client).await;
 
-    dbg!(&buf);
     assert!(resp(&buf).unwrap().starts_with('{'));
   });
 }
@@ -183,10 +182,8 @@ fn test_code_action() {
     assert!(resp(&buf).unwrap().starts_with('{'));
 
     let buf = request_code_action_to_lsp(&mut req_client, &mut resp_client).await;
+    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"Running CodeAction source.fixAll","type":3}}
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
-    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
-    dbg!(String::from_utf8(buf).unwrap());
-
     assert_eq!(json_val["method"], "window/logMessage");
     assert_eq!(
       json_val["params"]["message"],
@@ -206,7 +203,6 @@ fn test_execute_apply_all_fixes() {
     let buf = request_execute_command_to_lsp(&mut req_client, &mut resp_client).await;
     // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"Running ExecuteCommand ast-grep.applyAllFixes","type":3}}
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
-    dbg!(String::from_utf8(buf).unwrap());
     assert_eq!(json_val["method"], "window/logMessage");
     assert_eq!(
       json_val["params"]["message"],

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -145,7 +145,8 @@ pub async fn request_execute_command_to_lsp(
         {
           "text": "class AstGrepTest {\n  test() {\n    console.log('Hello, world!')\n  }\n}\n\nclass AnotherCase {\n  get test2() {\n    return 123\n  }\n}\n\nconst NoProblemHere = {\n  test() {\n    if (Math.random() > 3) {\n      throw new Error('This is not an error')\n    }\n  },\n}\n",
           "uri": "file:///Users/appe/Documents/codes/ast-grep-vscode/fixture/test.ts",
-          "version": 1
+          "version": 1,
+          "languageId": "typescript"
         }
       ]
     }
@@ -167,6 +168,8 @@ fn test_basic() {
     let (mut req_client, mut resp_client) = create_lsp();
 
     let buf = initialize_lsp(&mut req_client, &mut resp_client).await;
+
+    dbg!(&buf);
     assert!(resp(&buf).unwrap().starts_with('{'));
   });
 }
@@ -182,7 +185,13 @@ fn test_code_action() {
     let buf = request_code_action_to_lsp(&mut req_client, &mut resp_client).await;
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
     // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
+    dbg!(String::from_utf8(buf).unwrap());
+
     assert_eq!(json_val["method"], "window/logMessage");
+    assert_eq!(
+      json_val["params"]["message"],
+      "Running CodeAction source.fixAll"
+    );
   });
 }
 
@@ -195,8 +204,13 @@ fn test_execute_apply_all_fixes() {
     assert!(resp(&buf).unwrap().starts_with('{'));
 
     let buf = request_execute_command_to_lsp(&mut req_client, &mut resp_client).await;
+    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"Running ExecuteCommand ast-grep.applyAllFixes","type":3}}
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
-    // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"run code action!","type":3}}
+    dbg!(String::from_utf8(buf).unwrap());
     assert_eq!(json_val["method"], "window/logMessage");
+    assert_eq!(
+      json_val["params"]["message"],
+      "Running ExecuteCommand ast-grep.applyAllFixes"
+    );
   });
 }

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -144,7 +144,7 @@ pub async fn request_execute_command_to_lsp(
       "arguments": [
         {
           "text": "class AstGrepTest {\n  test() {\n    console.log('Hello, world!')\n  }\n}\n\nclass AnotherCase {\n  get test2() {\n    return 123\n  }\n}\n\nconst NoProblemHere = {\n  test() {\n    if (Math.random() > 3) {\n      throw new Error('This is not an error')\n    }\n  },\n}\n",
-          "uri": "file:///Users/appe/Documents/codes/ast-grep-vscode/fixture/test.ts",
+          "uri": "file:///Users/codes/ast-grep-vscode/fixture/test.ts",
           "version": 1,
           "languageId": "typescript"
         }
@@ -183,6 +183,7 @@ fn test_code_action() {
 
     let buf = request_code_action_to_lsp(&mut req_client, &mut resp_client).await;
     // {"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"Running CodeAction source.fixAll","type":3}}
+    dbg!(String::from_utf8(buf.clone()));
     let json_val: Value = serde_json::from_str(resp(&buf).unwrap()).unwrap();
     assert_eq!(json_val["method"], "window/logMessage");
     assert_eq!(


### PR DESCRIPTION
https://github.com/ast-grep/ast-grep-vscode/pull/261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new custom command for applying all fixes in the Language Server Protocol (LSP) service.
	- Introduced testing capabilities for LSP functionality including initialization, code actions requests, and command execution.

- **Improvements**
	- Enhanced diagnostic handling to support conditional returns.
	- Optimized fix application process by refining the parameter requirements.

- **Dependencies**
	- Added `serde_json` to improve JSON handling capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->