### PR TITLE
flake.nix: init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ docs/_build/
 
 # Pyenv
 .python-version
+
+# Nix
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712084331,
+        "narHash": "sha256-15d0TYHpFRDIst6rsNcBn1/F0F5jU2s2xwwKasIRLQ4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ac9983e7765f6b5e452429912d156ff1fa7bd4db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "ast-grep: a fast and polyglot tool for code searching, linting, rewriting at large scale";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.systems.url = "github:nix-systems/default";
+
+  outputs = { self, systems, nixpkgs }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+      });
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, installShellFiles
+}:
+
+let
+  cargoToml = lib.importTOML ./Cargo.toml;
+in
+
+rustPlatform.buildRustPackage rec {
+  pname = "ast-grep";
+  version = cargoToml.workspace.package.version;
+
+  src = ./.;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkFlags = [
+     # BUG: Broke by 0.12.1 update (https://github.com/NixOS/nixpkgs/pull/257385)
+     # Please check if this is fixed in future updates of the package
+     "--skip=verify::test_case::tests::test_unmatching_id"
+  ];
+
+  # error: linker `aarch64-linux-gnu-gcc` not found
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd sg \
+      --bash <($out/bin/sg completions bash) \
+      --fish <($out/bin/sg completions fish) \
+      --zsh <($out/bin/sg completions zsh)
+  '';
+
+  meta = with lib; {
+    mainProgram = "sg";
+    description = "A fast and polyglot tool for code searching, linting, rewriting at large scale";
+    homepage = "https://ast-grep.github.io/";
+    changelog = "https://github.com/ast-grep/ast-grep/blob/main/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ montchr lord-valen cafkafk ];
+  };
+}


### PR DESCRIPTION
This is based almost entirely off [the version in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/as/ast-grep/package.nix).

Enables:

* `nix run github:ast-grep/ast-grep`
* `nix develop` in the repository to get cargo/rust etc even if you don't have those in the environment.
* Use of this flake in other flakes to get the most recent version of the code, even if it hasn't been packaged in nixpkgs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced package management capabilities and support for building the `ast-grep` Rust package using Nix.

- **Chores**
	- Updated `.gitignore` to exclude specific temporary files related to Nix operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->