### PR TITLE
Fix typo: Mutliple => Multiple

### DIFF
--- a/crates/core/src/match_tree.rs
+++ b/crates/core/src/match_tree.rs
@@ -26,7 +26,7 @@ fn match_leaf_meta_var<'tree, D: Doc>(
       }
     }
     // Ellipsis will be matched in parent level
-    MV::Mutliple => {
+    MV::Multiple => {
       debug_assert!(false, "Ellipsis should be matched in parent level");
       Some(candidate)
     }
@@ -44,7 +44,7 @@ fn try_get_ellipsis_mode(node: &Pattern<impl Language>) -> Result<Option<String>
     return Err(());
   };
   match meta_var {
-    MetaVariable::Mutliple => Ok(None),
+    MetaVariable::Multiple => Ok(None),
     MetaVariable::MultiCapture(n) => Ok(Some(n.into())),
     _ => Err(()),
   }

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -196,7 +196,7 @@ pub enum MetaVariable {
   /// $_ for non-captured meta var
   Dropped(bool),
   /// $$$ for non-captured multi var
-  Mutliple,
+  Multiple,
   /// $$$A for captured ellipsis
   MultiCapture(MetaVariableID),
 }
@@ -205,14 +205,14 @@ pub(crate) fn extract_meta_var(src: &str, meta_char: char) -> Option<MetaVariabl
   use MetaVariable::*;
   let ellipsis: String = std::iter::repeat(meta_char).take(3).collect();
   if src == ellipsis {
-    return Some(Mutliple);
+    return Some(Multiple);
   }
   if let Some(trimmed) = src.strip_prefix(&ellipsis) {
     if !trimmed.chars().all(is_valid_meta_var_char) {
       return None;
     }
     if trimmed.starts_with('_') {
-      return Some(Mutliple);
+      return Some(Multiple);
     } else {
       return Some(MultiCapture(trimmed.to_owned()));
     }
@@ -282,7 +282,7 @@ mod test {
   #[test]
   fn test_match_var() {
     use MetaVariable::*;
-    assert_eq!(extract_var("$$$"), Some(Mutliple));
+    assert_eq!(extract_var("$$$"), Some(Multiple));
     assert_eq!(extract_var("$ABC"), Some(Capture("ABC".into(), true)));
     assert_eq!(extract_var("$$ABC"), Some(Capture("ABC".into(), false)));
     assert_eq!(extract_var("$MATCH1"), Some(Capture("MATCH1".into(), true)));
@@ -315,7 +315,7 @@ mod test {
   fn test_non_ascii_meta_var() {
     let extract = |s| extract_meta_var(s, 'µ');
     use MetaVariable::*;
-    assert_eq!(extract("µµµ"), Some(Mutliple));
+    assert_eq!(extract("µµµ"), Some(Multiple));
     assert_eq!(extract("µABC"), Some(Capture("ABC".into(), true)));
     assert_eq!(extract("µµABC"), Some(Capture("ABC".into(), false)));
     assert_eq!(extract("µµµABC"), Some(MultiCapture("ABC".into())));


### PR DESCRIPTION
What it says on the tin. This might be a semver break, but since we're in 0.x territory, it doesn't matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the enum variant name from `Mutliple` to `Multiple` for improved consistency in handling meta variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->