### PR TITLE
feat(language): Add support for Haskell via `tree-sitter-haskell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-go",
+ "tree-sitter-haskell",
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript-sg",
@@ -1954,6 +1955,16 @@ name = "tree-sitter-go"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb318be5ccf75f44e054acf6898a5c95d59b53443eed578e16be0cd7ec037f"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25a7e6c73cc1cbe0c0b7dbd5406e7b3485b370bd61c5d8d852ae0781f9bf9a"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -24,6 +24,7 @@ tree-sitter-css = { version = "0.21.0", optional = true }
 tree-sitter-dart= { version = "0.0.4", optional = true }
 tree-sitter-elixir = { version = "0.2.0", optional = true }
 tree-sitter-go = { version = "0.21.0", optional = true }
+tree-sitter-haskell = { version = "0.21.0", optional = true }
 tree-sitter-html = { version = "0.20.3", optional = true }
 tree-sitter-java = { version = "0.21.0", optional = true }
 # https://github.com/tree-sitter/tree-sitter-javascript/issues/316
@@ -50,6 +51,7 @@ builtin-parser = [
   "tree-sitter-dart",
   "tree-sitter-elixir",
   "tree-sitter-go",
+  "tree-sitter-haskell",
   "tree-sitter-html",
   "tree-sitter-java",
   "tree-sitter-javascript",

--- a/crates/language/src/haskell.rs
+++ b/crates/language/src/haskell.rs
@@ -27,11 +27,42 @@ fn test_haskell_str() {
 
 fn test_replace(src: &str, pattern: &str, replacer: &str) -> Result<String, TSParseError> {
   use crate::test::test_replace_lang;
-  test_replace_lang(src, pattern, replacer, Html)
+  test_replace_lang(src, pattern, replacer, Haskell)
 }
 
 #[test]
 fn test_haskell_replace() -> Result<(), TSParseError> {
-  // TODO: Test replacing
+  let ret = test_replace(
+    r#"
+fibonacci :: [Int]
+fibonacci =
+  1 : 1 : zipWith (+) fibonacci (tail fibonacci)
+"#,
+    r#"$F = $$$BODY"#,
+    r#"$F = undefined"#,
+  )?;
+  assert_eq!(
+    ret,
+    r#"
+fibonacci :: [Int]
+fibonacci = undefined
+"#
+  );
+
+  let ret = test_replace(
+    r#"
+flip :: (a -> b -> c) -> b -> a -> c
+flip f x y = f y x
+"#,
+    r#"$F :: $A -> $B"#,
+    r#"$F :: ($B) -> $A"#,
+  )?;
+  assert_eq!(
+    ret,
+    r#"
+flip :: (b -> a -> c) -> (a -> b -> c)
+flip f x y = f y x
+"#
+  );
   Ok(())
 }

--- a/crates/language/src/haskell.rs
+++ b/crates/language/src/haskell.rs
@@ -15,10 +15,14 @@ fn test_non_match(query: &str, source: &str) {
 
 #[test]
 fn test_haskell_str() {
-  // TODO: Basic patterns do not work yet
-  // test_match("return $A", "return 3");
-  // test_match(r#""$A""#, r#""abc""#);
-  test_match("return", "return");
+  test_match("return $A", "return 3");
+  test_match(r#""abc""#, r#""abc""#);
+  test_match("$A $B", "f x");
+  test_match("$A ($B $C)", "f (x y)");
+  test_match("let $A = $B in $A + $A", "let x = 3 in x + x");
+  test_non_match("$A $B", "f");
+  test_non_match("$A + $A", "3 + 4");
+  test_non_match("$A ($B $C)", "f x y");
 }
 
 fn test_replace(src: &str, pattern: &str, replacer: &str) -> Result<String, TSParseError> {

--- a/crates/language/src/haskell.rs
+++ b/crates/language/src/haskell.rs
@@ -1,0 +1,33 @@
+#![cfg(test)]
+use ast_grep_core::source::TSParseError;
+
+use super::*;
+
+fn test_match(query: &str, source: &str) {
+  use crate::test::test_match_lang;
+  test_match_lang(query, source, Haskell);
+}
+
+fn test_non_match(query: &str, source: &str) {
+  use crate::test::test_non_match_lang;
+  test_non_match_lang(query, source, Haskell);
+}
+
+#[test]
+fn test_haskell_str() {
+  // TODO: Basic patterns do not work yet
+  // test_match("return $A", "return 3");
+  // test_match(r#""$A""#, r#""abc""#);
+  test_match("return", "return");
+}
+
+fn test_replace(src: &str, pattern: &str, replacer: &str) -> Result<String, TSParseError> {
+  use crate::test::test_replace_lang;
+  test_replace_lang(src, pattern, replacer, Html)
+}
+
+#[test]
+fn test_haskell_replace() -> Result<(), TSParseError> {
+  // TODO: Test replacing
+  Ok(())
+}

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -13,6 +13,7 @@ mod csharp;
 mod css;
 mod elixir;
 mod go;
+mod haskell;
 mod html;
 mod json;
 mod kotlin;

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -110,6 +110,10 @@ impl_lang_expando!(Elixir, language_elixir, 'µ');
 // we can use any Unicode code point categorized as "Letter"
 // https://go.dev/ref/spec#letter
 impl_lang_expando!(Go, language_go, 'µ');
+// GHC supports Unicode syntax per
+// https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/unicode_syntax.html
+// and the tree-sitter-haskell grammar parses it too.
+impl_lang_expando!(Haskell, language_haskell, 'µ');
 // tree-sitter-html uses locale dependent iswalnum for tagName
 // https://github.com/tree-sitter/tree-sitter-html/blob/b5d9758e22b4d3d25704b72526670759a9e4d195/src/scanner.c#L194
 impl_lang_expando!(Html, language_html, 'z');
@@ -135,7 +139,6 @@ impl_lang!(Java, language_java);
 impl_lang!(JavaScript, language_javascript);
 impl_lang!(Json, language_json);
 impl_lang!(Lua, language_lua);
-impl_lang!(Haskell, language_haskell);
 impl_lang!(Php, language_php);
 impl_lang!(Scala, language_scala);
 impl_lang!(Tsx, language_tsx);

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -178,8 +178,8 @@ impl SupportLang {
   pub const fn all_langs() -> &'static [SupportLang] {
     use SupportLang::*;
     &[
-      Bash, C, Cpp, CSharp, Css, Dart, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua, Php,
-      Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript,
+      Bash, C, Cpp, CSharp, Css, Dart, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin,
+      Lua, Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript,
     ]
   }
 

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -134,6 +134,7 @@ impl_lang!(Java, language_java);
 impl_lang!(JavaScript, language_javascript);
 impl_lang!(Json, language_json);
 impl_lang!(Lua, language_lua);
+impl_lang!(Haskell, language_haskell);
 impl_lang!(Php, language_php);
 impl_lang!(Scala, language_scala);
 impl_lang!(Tsx, language_tsx);
@@ -152,6 +153,7 @@ pub enum SupportLang {
   Dart,
   Go,
   Elixir,
+  Haskell,
   Html,
   Java,
   JavaScript,
@@ -172,7 +174,7 @@ impl SupportLang {
   pub const fn all_langs() -> &'static [SupportLang] {
     use SupportLang::*;
     &[
-      Bash, C, Cpp, CSharp, Css, Dart, Elixir, Go, Html, Java, JavaScript, Json, Kotlin, Lua, Php,
+      Bash, C, Cpp, CSharp, Css, Dart, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua, Php,
       Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript,
     ]
   }
@@ -225,6 +227,7 @@ const fn alias(lang: &SupportLang) -> &[&str] {
     Dart => &["dart"],
     Elixir => &["ex", "elixir"],
     Go => &["go", "golang"],
+    Haskell => &["hs", "haskell"],
     Html => &["html"],
     Java => &["java"],
     JavaScript => &["javascript", "js", "jsx"],
@@ -269,6 +272,7 @@ macro_rules! execute_lang_method {
       S::Dart => Dart.$method($($pname,)*),
       S::Elixir => Elixir.$method($($pname,)*),
       S::Go => Go.$method($($pname,)*),
+      S::Haskell => Haskell.$method($($pname,)*),
       S::Html => Html.$method($($pname,)*),
       S::Java => Java.$method($($pname,)*),
       S::JavaScript => JavaScript.$method($($pname,)*),
@@ -324,6 +328,7 @@ fn extensions(lang: &SupportLang) -> &[&str] {
     Dart => &["dart"],
     Elixir => &["ex", "exs"],
     Go => &["go"],
+    Haskell => &["hs"],
     Html => &["html", "htm", "xhtml"],
     Java => &["java"],
     JavaScript => &["cjs", "js", "mjs", "jsx"],

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -32,6 +32,9 @@ mod parser_implementation {
   pub fn language_go() -> TSLanguage {
     tree_sitter_go::language().into()
   }
+  pub fn language_haskell() -> TSLanguage {
+    tree_sitter_haskell::language().into()
+  }
   pub fn language_html() -> TSLanguage {
     tree_sitter_html::language().into()
   }
@@ -104,6 +107,7 @@ mod parser_implementation {
     language_dart,
     language_elixir,
     language_go,
+    language_haskell,
     language_html,
     language_java,
     language_javascript,


### PR DESCRIPTION
### Fixes #1127 

This adds support for Haskell by integrating [`tree-sitter-haskell`](https://github.com/tree-sitter/tree-sitter-haskell). While it compiles, even rudimentary patterns such as `return $A` or `$A $B` do not work yet (probably an upstream issue?), therefore I will mark this PR as a draft for now.