### PR TITLE
chore: fix asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           # [possible values: all, unix, windows, none]
           zip: all
           target: ${{ matrix.target }}
-          archive: app-$target
+          archive: sg-$target
           # uncomment this for debug
           # ref: refs/tags/debug_release
         env:


### PR DESCRIPTION
Fix a bug of 3a6e55317a7904285b4f0df16c7f1f603a608543 .

1. Released asset names are wrong. https://github.com/ast-grep/ast-grep/releases/tag/0.22.2
1. Release workflow fails. https://github.com/ast-grep/ast-grep/actions/runs/9050071514/job/24865070006

Asset names should be not `app-*` but `sg-*`.

https://github.com/ast-grep/ast-grep/releases/tag/0.22.2

<img width="392" alt="image" src="https://github.com/ast-grep/ast-grep/assets/13323303/2a5b5d8f-089e-43af-bf56-e23106cb4bad">

https://github.com/ast-grep/ast-grep/releases/tag/0.22.0

<img width="422" alt="image" src="https://github.com/ast-grep/ast-grep/assets/13323303/e03ecaea-2823-4842-b813-a86774caca73">

This change would fix the failure.

https://github.com/ast-grep/ast-grep/actions/runs/9050071514/job/24865070006

```
Run files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu)
unzip:  cannot find or open artifacts/sg-aarch64-apple-darwin.zip, artifacts/sg-aarch64-apple-darwin.zip.zip or artifacts/sg-aarch64-apple-darwin.zip.ZIP.
Error: Process completed with exit code 9.
```

https://github.com/ast-grep/ast-grep/blob/99989f9d1bc15dcdce3e003a620b12fe780253c1/.github/workflows/release.yml#L86-L102