### PR TITLE
ci: fix the failure of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           length=${#files[@]}
           for (( i=0; i<${length}; i++ ));
           do
-            unzip "artifacts/sg-${files[$i]}.zip" -d "npm/platforms/${target_dir[$i]}/"
+            unzip "artifacts/app-${files[$i]}.zip" -d "npm/platforms/${target_dir[$i]}/"
           done
           # windows
           files=(x86_64-pc-windows-msvc i686-pc-windows-msvc aarch64-pc-windows-msvc)
@@ -98,7 +98,7 @@ jobs:
           length=${#files[@]}
           for (( i=0; i<${length}; i++ ));
           do
-            unzip "artifacts/sg-${files[$i]}.zip" -d "npm/platforms/${target_dir[$i]}/"
+            unzip "artifacts/app-${files[$i]}.zip" -d "npm/platforms/${target_dir[$i]}/"
           done
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
         env:


### PR DESCRIPTION
Release workflow failed. https://github.com/ast-grep/ast-grep/actions/runs/9050071514/job/24865070006

https://github.com/ast-grep/ast-grep/actions/runs/9050071514/job/24865070006

```
Run files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu)
unzip:  cannot find or open artifacts/sg-aarch64-apple-darwin.zip, artifacts/sg-aarch64-apple-darwin.zip.zip or artifacts/sg-aarch64-apple-darwin.zip.ZIP.
Error: Process completed with exit code 9.
```

This pull request fixes the failure.

Assets `sg-*` were renamed to `app-*` 3a6e55317a7904285b4f0df16c7f1f603a608543, so we need to fix the release workflow.

https://github.com/ast-grep/ast-grep/releases/tag/0.22.2