### PR TITLE
feat: add more impl skeleton for nth child

### DIFF
--- a/crates/config/src/rule/mod.rs
+++ b/crates/config/src/rule/mod.rs
@@ -9,7 +9,7 @@ pub use relational_rule::Relation;
 pub use stop_by::StopBy;
 
 use crate::maybe::Maybe;
-use nth_child::NthChild;
+use nth_child::SerializableNthChild;
 use referent_rule::{ReferentRule, ReferentRuleError};
 use relational_rule::{Follows, Has, Inside, Precedes};
 
@@ -51,9 +51,10 @@ pub struct SerializableRule {
   #[serde(default, skip_serializing_if = "Maybe::is_absent")]
   pub regex: Maybe<String>,
   /// `nth_child` accepts number, string or object.
-  /// It specifies the position in nodes' sibling.
+  /// It specifies the position in nodes' sibling list.
   #[serde(default, skip_serializing_if = "Maybe::is_absent", rename = "nthChild")]
-  pub nth_child: Maybe<NthChild>,
+  pub nth_child: Maybe<SerializableNthChild>,
+
   // relational
   /// `inside` accepts a relational rule object.
   /// the target node must appear inside of another node matching the `inside` sub-rule.

--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -1,2 +1,69 @@
+use super::{Rule, SerializableRule};
+
+use ast_grep_core::language::Language;
+use ast_grep_core::meta_var::MetaVarEnv;
+use ast_grep_core::{Doc, Matcher, Node};
+
+use std::borrow::Cow;
+
+use bit_set::BitSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
 // TODO
-pub type NthChild = String;
+#[derive(Debug, Error)]
+pub enum NthChildError {}
+
+/// A string or number describing the indices of matching nodes in a list of siblings.
+#[derive(Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(untagged)]
+pub enum NthChildSimple {
+  /// A number indicating the precise element index
+  Numeric(usize),
+  /// Functional notation like CSS's An + B
+  Functional(String),
+}
+
+/// `nthChild` accepts either a number, a string or an object.
+#[derive(Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(untagged, rename_all = "camelCase")]
+pub enum SerializableNthChild {
+  Simple(NthChildSimple),
+  // TODO add comments
+  Complex {
+    position: NthChildSimple,
+    /// select the nth node that matches the rule, like CSS's of syntax
+    of_rule: Option<Box<SerializableRule>>,
+    /// matches from the end instead like CSS's nth-last-child
+    #[serde(default)]
+    reverse: bool,
+  },
+}
+
+/// Corresponds to the CSS syntax An+B
+/// See https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#functional_notation
+struct FunctionalPosition {
+  step_size: usize,
+  offset: usize,
+}
+
+struct NthChild<L: Language> {
+  position: FunctionalPosition,
+  of_rule: Option<Box<Rule<L>>>,
+  reverse: bool,
+}
+
+impl<L: Language> Matcher<L> for NthChild<L> {
+  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+    &self,
+    node: Node<'tree, D>,
+    env: &mut Cow<MetaVarEnv<'tree, D>>,
+  ) -> Option<Node<'tree, D>> {
+    todo!()
+  }
+
+  fn potential_kinds(&self) -> Option<BitSet> {
+    None
+  }
+}


### PR DESCRIPTION
part of #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling for node position specification with the introduction of `NthChildError`.
  - Enhanced flexibility in node indexing with the new `NthChildSimple` and `SerializableNthChild` enums.
  - Added support for CSS syntax handling via the new `FunctionalPosition` struct.

- **Refactor**
  - Renamed `NthChild` to `SerializableNthChild` to clarify its role in specifying node positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->