### PR TITLE
feat: add strictness to YAML

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ mod match_tree;
 mod node;
 
 pub use language::Language;
+pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
 pub use node::Node;
 pub use source::{Doc, StrDoc};

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -209,6 +209,11 @@ impl<L: Language> Pattern<L> {
     Self::try_new(src, lang).unwrap()
   }
 
+  pub fn with_strictness(mut self, strictness: MatchStrictness) -> Self {
+    self.strictness = strictness;
+    self
+  }
+
   pub fn contextual(context: &str, selector: &str, lang: L) -> Result<Self, PatternError> {
     let processed = lang.pre_process_pattern(context);
     let root = Root::<StrDoc<L>>::try_new(&processed, lang.clone())?;


### PR DESCRIPTION
fix #1239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `MatchStrictness` functionality, allowing users to define the strictness level for pattern matching.
  - Added an option to set match strictness in pattern matching, providing more control over how patterns are applied.

- **Enhancements**
  - Extended `PatternStyle` to include an optional strictness field, improving flexibility in defining match patterns.

- **API Changes**
  - Updated public exports to include `MatchStrictness`, ensuring users have access to the new strictness features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->