### PR TITLE
feat: add debugging tree in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "similar",
  "tempfile",
  "tokio",
+ "tree-sitter-facade-sg",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ ast-grep-config.workspace = true
 ast-grep-dynamic.workspace = true
 ast-grep-language.workspace = true
 ast-grep-lsp.workspace = true
+tree-sitter.workspace = true
 
 ansi_term = "0.12.1"
 anyhow.workspace = true

--- a/crates/cli/src/debug.rs
+++ b/crates/cli/src/debug.rs
@@ -15,9 +15,8 @@ impl DebugFormat {
   pub fn debug_query(&self, pattern: &str, lang: SgLang) {
     match self {
       DebugFormat::Pattern => {
-        if let Ok(pattern) = Pattern::try_new(pattern, lang) {
-          println!("Debug Pattern:\n{:?}", pattern);
-        }
+        let pattern = Pattern::try_new(pattern, lang).expect("pattern must be validated in run");
+        println!("Debug Pattern:\n{:?}", pattern);
       }
       DebugFormat::Sexp => {
         let root = lang.ast_grep(pattern);

--- a/crates/cli/src/debug.rs
+++ b/crates/cli/src/debug.rs
@@ -1,0 +1,146 @@
+use crate::lang::SgLang;
+use ast_grep_core::Pattern;
+use ast_grep_language::Language;
+use clap::ValueEnum;
+use tree_sitter as ts;
+
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum DebugFormat {
+  Pattern,
+  Ast,
+  Cst,
+  Sexp,
+}
+impl DebugFormat {
+  pub fn debug_query(&self, pattern: &str, lang: SgLang) {
+    match self {
+      DebugFormat::Pattern => {
+        if let Ok(pattern) = Pattern::try_new(pattern, lang) {
+          println!("Debug Pattern:\n{:?}", pattern);
+        }
+      }
+      DebugFormat::Sexp => {
+        let root = lang.ast_grep(pattern);
+        println!("Debug Sexp:\n{}", root.root().to_sexp());
+      }
+      DebugFormat::Ast => {
+        let root = lang.ast_grep(pattern);
+        let dumped = dump_node(root.root().get_ts_node());
+        println!("Debug AST:\n{}", dumped.ast());
+      }
+      DebugFormat::Cst => {
+        let root = lang.ast_grep(pattern);
+        let dumped = dump_node(root.root().get_ts_node());
+        println!("Debug CST:\n{}", dumped.cst());
+      }
+    }
+  }
+}
+
+pub struct DumpNode {
+  field: Option<String>,
+  kind: String,
+  start: Pos,
+  end: Pos,
+  is_named: bool,
+  children: Vec<DumpNode>,
+}
+
+// TODO: add colorized output
+use std::fmt::{Result as FmtResult, Write};
+impl DumpNode {
+  pub fn ast(&self) -> String {
+    let mut result = String::new();
+    self
+      .helper(&mut result, true, 0)
+      .expect("should write string");
+    result
+  }
+
+  pub fn cst(&self) -> String {
+    let mut result = String::new();
+    self
+      .helper(&mut result, false, 0)
+      .expect("should write string");
+    result
+  }
+
+  fn helper(&self, result: &mut String, named_only: bool, depth: usize) -> FmtResult {
+    let indent = "  ".repeat(depth);
+    if named_only && !self.is_named {
+      return Ok(());
+    }
+    write!(result, "{indent}")?;
+    if let Some(field) = &self.field {
+      write!(result, "{field}: ")?;
+    }
+    write!(result, "{}", self.kind)?;
+    writeln!(result, " ({:?})-({:?})", self.start, self.end)?;
+    for child in &self.children {
+      child.helper(result, named_only, depth + 1)?;
+    }
+    Ok(())
+  }
+}
+
+pub struct Pos {
+  row: u32,
+  column: u32,
+}
+
+impl std::fmt::Debug for Pos {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{},{}", self.row, self.column)
+  }
+}
+
+impl From<ts::Point> for Pos {
+  #[inline]
+  fn from(pt: ts::Point) -> Self {
+    Pos {
+      row: pt.row(),
+      column: pt.column(),
+    }
+  }
+}
+
+fn dump_node(node: ts::Node) -> DumpNode {
+  let mut cursor = node.walk();
+  let mut nodes = vec![];
+  dump_one_node(&mut cursor, &mut nodes);
+  nodes.pop().expect("should have at least one node")
+}
+
+fn dump_one_node(cursor: &mut ts::TreeCursor, target: &mut Vec<DumpNode>) {
+  let node = cursor.node();
+  let kind = if node.is_missing() {
+    format!("MISSING {}", node.kind())
+  } else {
+    node.kind().to_string()
+  };
+  let start = node.start_position().into();
+  let end = node.end_position().into();
+  let field = cursor.field_name().map(|c| c.to_string());
+  let mut children = vec![];
+  if cursor.goto_first_child() {
+    dump_nodes(cursor, &mut children);
+    cursor.goto_parent();
+  }
+  target.push(DumpNode {
+    field,
+    kind,
+    start,
+    end,
+    children,
+    is_named: node.is_named(),
+  })
+}
+
+fn dump_nodes(cursor: &mut ts::TreeCursor, target: &mut Vec<DumpNode>) {
+  loop {
+    dump_one_node(cursor, target);
+    if !cursor.goto_next_sibling() {
+      break;
+    }
+  }
+}

--- a/crates/cli/src/debug.rs
+++ b/crates/cli/src/debug.rs
@@ -1,4 +1,6 @@
 use crate::lang::SgLang;
+use crate::print::ColorArg;
+use ansi_term::Style;
 use ast_grep_core::Pattern;
 use ast_grep_language::Language;
 use clap::ValueEnum;
@@ -12,7 +14,8 @@ pub enum DebugFormat {
   Sexp,
 }
 impl DebugFormat {
-  pub fn debug_query(&self, pattern: &str, lang: SgLang) {
+  pub fn debug_query(&self, pattern: &str, lang: SgLang, color: ColorArg) {
+    let colored = color.should_use_color();
     match self {
       DebugFormat::Pattern => {
         let pattern = Pattern::try_new(pattern, lang).expect("pattern must be validated in run");
@@ -25,12 +28,12 @@ impl DebugFormat {
       DebugFormat::Ast => {
         let root = lang.ast_grep(pattern);
         let dumped = dump_node(root.root().get_ts_node());
-        println!("Debug AST:\n{}", dumped.ast());
+        println!("Debug AST:\n{}", dumped.ast(colored));
       }
       DebugFormat::Cst => {
         let root = lang.ast_grep(pattern);
         let dumped = dump_node(root.root().get_ts_node());
-        println!("Debug CST:\n{}", dumped.cst());
+        println!("Debug CST:\n{}", dumped.cst(colored));
       }
     }
   }
@@ -45,38 +48,66 @@ pub struct DumpNode {
   children: Vec<DumpNode>,
 }
 
+struct DumpFmt {
+  kind_style: Style,
+  field_style: Style,
+  named_only: bool,
+}
+
+impl DumpFmt {
+  fn named(colored: bool) -> Self {
+    let style = Style::new();
+    Self {
+      kind_style: if colored { style.bold() } else { style },
+      field_style: if colored { style.italic() } else { style },
+      named_only: true,
+    }
+  }
+  fn all(colored: bool) -> Self {
+    let style = Style::new();
+    Self {
+      kind_style: if colored { style.bold() } else { style },
+      field_style: if colored { style.italic() } else { style },
+      named_only: false,
+    }
+  }
+}
+
 // TODO: add colorized output
 use std::fmt::{Result as FmtResult, Write};
 impl DumpNode {
-  pub fn ast(&self) -> String {
+  pub fn ast(&self, colored: bool) -> String {
     let mut result = String::new();
+    let fmt = DumpFmt::named(colored);
     self
-      .helper(&mut result, true, 0)
+      .helper(&mut result, &fmt, 0)
       .expect("should write string");
     result
   }
 
-  pub fn cst(&self) -> String {
+  pub fn cst(&self, colored: bool) -> String {
     let mut result = String::new();
+    let fmt = DumpFmt::all(colored);
     self
-      .helper(&mut result, false, 0)
+      .helper(&mut result, &fmt, 0)
       .expect("should write string");
     result
   }
 
-  fn helper(&self, result: &mut String, named_only: bool, depth: usize) -> FmtResult {
+  fn helper(&self, result: &mut String, fmt: &DumpFmt, depth: usize) -> FmtResult {
     let indent = "  ".repeat(depth);
-    if named_only && !self.is_named {
+    if fmt.named_only && !self.is_named {
       return Ok(());
     }
     write!(result, "{indent}")?;
     if let Some(field) = &self.field {
-      write!(result, "{field}: ")?;
+      let field = fmt.field_style.paint(field);
+      write!(result, "{}: ", field)?;
     }
-    write!(result, "{}", self.kind)?;
+    write!(result, "{}", fmt.kind_style.paint(&self.kind))?;
     writeln!(result, " ({:?})-({:?})", self.start, self.end)?;
     for child in &self.children {
-      child.helper(result, named_only, depth + 1)?;
+      child.helper(result, fmt, depth + 1)?;
     }
     Ok(())
   }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -166,6 +166,9 @@ mod test_cli {
     ok("run -p test --interactive dir");
     ok("run -p test -r Test dir");
     ok("run -p test -l rs --debug-query");
+    ok("run -p test -l rs --debug-query not");
+    ok("run -p test -l rs --debug-query=ast");
+    ok("run -p test -l rs --debug-query=cst");
     ok("run -p test -l rs --color always");
     ok("run -p test -l rs --heading always");
     ok("run -p test dir1 dir2 dir3"); // multiple paths
@@ -174,6 +177,8 @@ mod test_cli {
     ok("run -p test --json compact"); // argument after --json should not be parsed as JsonStyle
     ok("run -p test --json=pretty dir");
     ok("run -p test --json dir"); // arg after --json should not be parsed as JsonStyle
+    ok("run -p test --strictness ast");
+    ok("run -p test --strictness relaxed");
     error("run test");
     error("run --debug-query test"); // missing lang
     error("run -r Test dir");
@@ -181,6 +186,8 @@ mod test_cli {
     error("run -p test -l rs -c always"); // no color shortcut
     error("run -p test -U");
     error("run -p test --update-all");
+    error("run -p test --strictness not");
+    error("run -p test -l rs --debug-query=not");
   }
 
   #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,5 +1,6 @@
 mod completions;
 mod config;
+mod debug;
 mod error;
 mod lang;
 mod lsp;

--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -628,7 +628,7 @@ impl From<ColorChoice> for PrintStyles {
 }
 
 // copied from termcolor
-mod choose_color {
+pub(crate) mod choose_color {
   use super::ColorChoice;
   use std::env;
   /// Returns true if we should attempt to write colored output.

--- a/crates/cli/src/print/mod.rs
+++ b/crates/cli/src/print/mod.rs
@@ -105,6 +105,13 @@ pub enum ColorArg {
   Never,
 }
 
+impl ColorArg {
+  pub fn should_use_color(self) -> bool {
+    use colored_print::choose_color::should_use_color;
+    should_use_color(&self.into())
+  }
+}
+
 impl From<ColorArg> for ColorChoice {
   fn from(arg: ColorArg) -> ColorChoice {
     use ColorArg::*;

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -8,6 +8,7 @@ use clap::{builder::PossibleValue, Parser, ValueEnum};
 use ignore::WalkParallel;
 
 use crate::config::register_custom_language;
+use crate::debug::DebugFormat;
 use crate::error::ErrorContext as EC;
 use crate::lang::SgLang;
 use crate::print::{ColoredPrinter, Diff, Heading, InteractivePrinter, JSONPrinter, Printer};
@@ -60,13 +61,6 @@ impl ValueEnum for Strictness {
       }
     })
   }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum DebugFormat {
-  Pattern,
-  Ast,
-  Cst,
 }
 
 #[derive(Parser)]
@@ -265,8 +259,8 @@ impl<P: Printer> Worker for RunWithSpecificLang<P> {
     printer.before_print()?;
     let arg = &self.arg;
     let lang = arg.lang.expect("must present");
-    if arg.debug_query.is_some() {
-      println!("Pattern TreeSitter {:?}", self.pattern);
+    if let Some(format) = arg.debug_query {
+      format.debug_query(&self.arg.pattern, lang);
     }
     let rewrite = if let Some(s) = &arg.rewrite {
       Some(Fixer::from_str(s, &lang).context(EC::ParsePattern)?)

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -260,7 +260,7 @@ impl<P: Printer> Worker for RunWithSpecificLang<P> {
     let arg = &self.arg;
     let lang = arg.lang.expect("must present");
     if let Some(format) = arg.debug_query {
-      format.debug_query(&self.arg.pattern, lang);
+      format.debug_query(&self.arg.pattern, lang, self.arg.output.color);
     }
     let rewrite = if let Some(s) = &arg.rewrite {
       Some(Fixer::from_str(s, &lang).context(EC::ParsePattern)?)


### PR DESCRIPTION
fix #1218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced debugging functionality to inspect queries in various formats (patterns, AST, CST, and Sexp) for a specified language.
  - Added a new CLI module for debugging queries and related test cases.
  - Introduced a method to determine color usage in CLI output.

- **Improvements**
  - Changed the visibility of the `choose_color` module to improve access control.
  - Enhanced flexibility in the `RunArg` struct by modifying the `debug_query` field from a boolean to an `Option<DebugFormat>`.
  - Updated the `M::Relaxed` value descriptor for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->