### PR TITLE
refactor: simplify the extract_injection method

### DIFF
--- a/crates/cli/src/lang.rs
+++ b/crates/cli/src/lang.rs
@@ -172,14 +172,10 @@ impl Language for SgLang {
     }
   }
 
-  fn extract_injections<D: Doc>(
-    &self,
-    root: Node<D>,
-    conv: impl Fn(Self) -> D::Lang,
-  ) -> HashMap<String, Vec<TSRange>> {
+  fn extract_injections<D: Doc>(&self, root: Node<D>) -> HashMap<String, Vec<TSRange>> {
     match self {
-      Builtin(b) => b.extract_injections(root, |b| conv(Builtin(b))),
-      Custom(c) => c.extract_injections(root, |c| conv(Custom(c))),
+      Builtin(b) => b.extract_injections(root),
+      Custom(c) => c.extract_injections(root),
     }
   }
 }

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -65,11 +65,7 @@ pub trait Language: Clone {
   /// The first item is the embedded region language, e.g. javascript
   /// The second item is a list of regions in tree_sitter.
   /// also see https://tree-sitter.github.io/tree-sitter/using-parsers#multi-language-documents
-  fn extract_injections<D: Doc>(
-    &self,
-    _root: Node<D>,
-    _conv: impl Fn(Self) -> D::Lang,
-  ) -> HashMap<String, Vec<TSRange>> {
+  fn extract_injections<D: Doc>(&self, _root: Node<D>) -> HashMap<String, Vec<TSRange>> {
     HashMap::new()
   }
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -92,7 +92,7 @@ impl<D: Doc> Root<D> {
     get_lang: F,
   ) -> Option<Vec<Root<D>>> {
     let root = self.root();
-    let range = self.lang().extract_injections(root, |l| l);
+    let range = self.lang().extract_injections(root);
     if range.is_empty() {
       return None;
     }

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -20,12 +20,8 @@ impl ast_grep_core::language::Language for Html {
   fn injectable_languages(&self) -> Option<&'static [&'static str]> {
     Some(&["css", "js", "ts", "tsx", "scss", "less", "stylus", "coffee"])
   }
-  fn extract_injections<D: Doc>(
-    &self,
-    root: Node<D>,
-    conv: impl Fn(Self) -> D::Lang,
-  ) -> HashMap<String, Vec<TSRange>> {
-    let lang = conv(*self);
+  fn extract_injections<D: Doc>(&self, root: Node<D>) -> HashMap<String, Vec<TSRange>> {
+    let lang = root.lang();
     let mut map = HashMap::new();
     let matcher = KindMatcher::new("script_element", lang.clone());
     for script in root.find_all(matcher) {
@@ -38,7 +34,7 @@ impl ast_grep_core::language::Language for Html {
           .push(node_to_range(&content));
       };
     }
-    let matcher = KindMatcher::new("style_element", lang);
+    let matcher = KindMatcher::new("style_element", lang.clone());
     for style in root.find_all(matcher) {
       let injected = find_lang(&style).unwrap_or_else(|| "css".into());
       let content = style.children().find(|c| c.kind() == "raw_text");

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -316,13 +316,9 @@ impl Language for SupportLang {
   impl_lang_method!(extract_meta_var, (source: &str) => Option<MetaVariable>);
   impl_lang_method!(injectable_languages, () => Option<&'static [&'static str]>);
 
-  fn extract_injections<D: Doc>(
-    &self,
-    root: Node<D>,
-    conv: impl Fn(Self) -> D::Lang,
-  ) -> HashMap<String, Vec<TSRange>> {
+  fn extract_injections<D: Doc>(&self, root: Node<D>) -> HashMap<String, Vec<TSRange>> {
     match self {
-      SupportLang::Html => Html.extract_injections(root, |_| conv(SupportLang::Html)),
+      SupportLang::Html => Html.extract_injections(root),
       _ => HashMap::new(),
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `extract_injections` method across multiple modules, leading to a more straightforward and efficient implementation.
  - Removed unnecessary generic parameters and closure logic in the `extract_injections` method, enhancing code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->