### PR TITLE
fix: fix macos lack 3.10

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -102,12 +102,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.8
-            3.9
-            3.10
-            3.11
-            3.12
+          python-version: ${{ env.PYTHON_VERSION }}
+          # you have to list python version because macos-latest lack python
+          # https://github.com/actions/runner-images/issues/9770
+          # python-version: |
+          #   3.8
+          #   3.9
+          #   3.10
+          #   3.11
+          #   3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -103,14 +103,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          # you have to list python version because macos-latest lack python
-          # https://github.com/actions/runner-images/issues/9770
-          # python-version: |
-          #   3.8
-          #   3.9
-          #   3.10
-          #   3.11
-          #   3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:
@@ -121,7 +113,7 @@ jobs:
           args: --release --out dist --find-interpreter
           working-directory: crates/pyo3
       - name: Test sdist
-        if: matrix.target == 'x86_64'
+        if: matrix.target == 'aarch64'
         run: |
           pip install pytest
           pip install --no-index --find-links=dist ${{env.PACKAGE_NAME}} --force-reinstall

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -94,8 +94,7 @@ jobs:
           path: crates/pyo3/dist
 
   macos:
-    # use old macos due to https://github.com/actions/setup-python/issues/852
-    runs-on: macos-13
+    runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64, aarch64]
@@ -103,7 +102,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
fix #1305 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to use the latest macOS version.
  - Modified test conditions for the "Test sdist" step to run on `aarch64` target instead of `x86_64`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->