### PR TITLE
Revert "feat: add error reporting for injection"

### DIFF
--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -32,7 +32,6 @@ pub enum ErrorContext {
   InvalidGlobalUtils,
   GlobPattern,
   UnrecognizableLanguage(String),
-  LangInjection,
   // Run
   ParsePattern,
   LanguageNotSpecified,
@@ -72,7 +71,7 @@ impl ErrorContext {
       ReadConfiguration | ReadRule(_) | WalkRuleDir(_) | WriteFile(_) => 5,
       StdInIsNotInteractive => 6,
       ParseTest(_) | ParseRule(_) | ParseConfiguration | GlobPattern | ParsePattern
-      | InvalidGlobalUtils | LangInjection => 8,
+      | InvalidGlobalUtils => 8,
       CannotInferShell => 10,
       ProjectAlreadyExist | FileAlreadyExist(_) => 17,
       InsufficientCLIArgument(_) => 22,
@@ -146,11 +145,6 @@ impl ErrorMessage {
       GlobPattern => Self::new(
         "Cannot parse glob pattern in config",
         "The pattern in files/ignore is not a valid glob. Please refer to doc and fix the error.",
-        CONFIG_GUIDE,
-      ),
-      LangInjection => Self::new(
-        "Cannot parse languageInjections in config",
-        "The rule in languageInjections is not valid. Please refer to doc and fix the error.",
         CONFIG_GUIDE,
       ),
       InvalidGlobalUtils => Self::new(

--- a/crates/cli/src/lang.rs
+++ b/crates/cli/src/lang.rs
@@ -54,7 +54,10 @@ impl SgLang {
   }
 
   pub fn register_injections(injections: Vec<SerializableInjection>) -> Result<()> {
-    unsafe { injection::register_injetables(injections) }
+    unsafe {
+      injection::register_injetables(injections);
+    }
+    Ok(())
   }
 
   pub fn all_langs() -> Vec<Self> {


### PR DESCRIPTION
This reverts commit fd31d976cd4fc5967f7d624e67c58c81296439e2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified error management by removing the `LangInjection` context from error handling.
	- Enhanced compliance with error handling conventions in the injection registration process.
  
- **Bug Fixes**
	- Resolved compilation issues by ensuring the `register_injections` function returns a value.

- **Refactor**
	- Revised error handling approach in the `Injection` module, shifting to a more lenient execution path without explicit error propagation. 

- **Chores**
	- Removed outdated test cases related to error handling in the injection registration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->