### PR TITLE
feat: Additional impls for language types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test-astgrep"
+version = "0.0.1"
+dependencies = [
+ "ast-grep-config",
+ "ast-grep-language",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 // tree-sitter-html uses locale dependent iswalnum for tagName
 // https://github.com/tree-sitter/tree-sitter-html/blob/b5d9758e22b4d3d25704b72526670759a9e4d195/src/scanner.c#L194
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Html;
 impl Language for Html {
   fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -276,7 +276,10 @@ struct FromStrVisitor<'a, T> {
 
 impl<'a, T> FromStrVisitor<'a, T> {
   pub fn new(expecting: &'a str) -> Self {
-    Self { expecting, _t: PhantomData }
+    Self {
+      expecting,
+      _t: PhantomData,
+    }
   }
 }
 
@@ -295,7 +298,7 @@ where
   where
     E: de::Error,
   {
-   v.parse().map_err(de::Error::custom)
+    v.parse().map_err(de::Error::custom)
   }
 }
 struct AliasVisitor<'a> {
@@ -306,18 +309,19 @@ impl<'a, 'de> Visitor<'de> for AliasVisitor<'a> {
   type Value = &'a str;
 
   fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      write!(f, "one of {:?}", self.aliases)
+    write!(f, "one of {:?}", self.aliases)
   }
 
   fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
   where
     E: de::Error,
   {
-    self.aliases
-        .iter()
-        .copied()
-        .find(|&a| v.eq_ignore_ascii_case(a))
-        .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Str(v), &self))
+    self
+      .aliases
+      .iter()
+      .copied()
+      .find(|&a| v.eq_ignore_ascii_case(a))
+      .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Str(v), &self))
   }
 }
 

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! impl_aliases {
       }
 
       impl fmt::Display for $lang {
-        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
           write!(f, "{:?}", self)
         }
       }


### PR DESCRIPTION
The main reason for this PR is that currently the dedicated language types such as `ast-grep-language::Rust` cannot be used with some `ast-grep-config` functions such as `ast-grep-config::from_yaml_string` because they are missing `serde::Deserialize` impls. The ability to use the dedicated lang type here rather than the composite enum `SupportLang` in cases where a particular language is expected could improve efficiency and simplify error handling.

This PR adds to lang types:
- `ALIAS` associated constant for list of language aliases
- `Debug` + `Display`
- `Deserialize`
- `Into<SupportLang>`

Feel free to make or suggest any changes you see fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced language handling with improved debugging support.
	- Introduced a new macro for defining language aliases and associated constants.
	- Added custom error structures for better error reporting related to language mismatches.

- **Improvements**
	- Streamlined API by allowing direct handling of language types, enhancing performance and usability.
	- Enhanced the `Html` struct for better debugging insights.
	- Improved error reporting with clearer messages for alias mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->