### PR TITLE
feat: add severity override

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -17,25 +17,11 @@ use crate::print::{
   ReportStyle, SimpleFile,
 };
 use crate::utils::ErrorContext as EC;
-use crate::utils::{filter_file_interactive, InputArgs, OutputArgs};
+use crate::utils::{filter_file_interactive, InputArgs, OutputArgs, SeverityArg};
 use crate::utils::{FileTrace, RuleTrace, ScanTrace};
 use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 
 type AstGrep = ast_grep_core::AstGrep<StrDoc<SgLang>>;
-
-#[derive(Args, Debug)]
-struct SeverityArg {
-  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
-  pub error: Option<Vec<String>>,
-  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
-  pub warning: Option<Vec<String>>,
-  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
-  pub info: Option<Vec<String>>,
-  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
-  pub hint: Option<Vec<String>>,
-  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
-  pub off: Option<Vec<String>>,
-}
 
 #[derive(Args)]
 pub struct ScanArg {

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -23,6 +23,20 @@ use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 
 type AstGrep = ast_grep_core::AstGrep<StrDoc<SgLang>>;
 
+#[derive(Args, Debug)]
+struct SeverityArg {
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub error: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub warning: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub info: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub hint: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub off: Option<Vec<String>>,
+}
+
 #[derive(Args)]
 pub struct ScanArg {
   /// Path to ast-grep root config, default is sgconfig.yml.
@@ -58,6 +72,10 @@ pub struct ScanArg {
 
   #[clap(long, default_value = "rich", conflicts_with = "json")]
   report_style: ReportStyle,
+
+  /// severity related options
+  #[clap(flatten)]
+  severity: SeverityArg,
 
   /// input related options
   #[clap(flatten)]
@@ -363,6 +381,13 @@ rule:
         follow: false,
         globs: vec![],
         threads: 0,
+      },
+      severity: SeverityArg {
+        error: None,
+        warning: None,
+        info: None,
+        hint: None,
+        off: None,
       },
       output: OutputArgs {
         interactive: false,

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -228,6 +228,20 @@ impl NoIgnore {
   }
 }
 
+#[derive(Args, Debug)]
+pub struct SeverityArg {
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub error: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub warning: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub info: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub hint: Option<Vec<String>>,
+  #[clap(long, action = clap::ArgAction::Append, value_name = "RULE_ID", num_args(0..), require_equals = true)]
+  pub off: Option<Vec<String>>,
+}
+
 #[cfg(test)]
 mod test {
   use super::*;

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -121,14 +121,14 @@ pub struct OutputArgs {
   /// Output matches in structured JSON .
   ///
   /// If this flag is set, ast-grep will output matches in JSON format.
-  /// You can pass optional value to this flag by using `--json=<style>` syntax
+  /// You can pass optional value to this flag by using `--json=<STYLE>` syntax
   /// to further control how JSON object is formatted and printed. ast-grep will `pretty`-print JSON if no value is passed.
   /// Note, the json flag must use `=` to specify its value.
   /// It conflicts with interactive.
   #[clap(
       long,
       conflicts_with = "interactive",
-      value_name="style",
+      value_name="STYLE",
       num_args(0..=1),
       require_equals = true,
       default_missing_value = "pretty"

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -1,10 +1,11 @@
 mod args;
 mod debug_query;
 mod error_context;
+mod rule_overwrite;
 mod tracing;
 mod worker;
 
-pub use args::{InputArgs, OutputArgs};
+pub use args::{InputArgs, OutputArgs, SeverityArg};
 pub use debug_query::DebugFormat;
 pub use error_context::{exit_with_error, ErrorContext};
 pub use tracing::{FileTrace, RuleTrace, RunTrace, ScanTrace, Tracing};

--- a/crates/cli/src/utils/rule_overwrite.rs
+++ b/crates/cli/src/utils/rule_overwrite.rs
@@ -37,6 +37,30 @@ impl RuleOverwrite {
       &mut by_rule_id,
       &mut default_severity,
     );
+    read_severity(
+      Severity::Warning,
+      &cli.warning,
+      &mut by_rule_id,
+      &mut default_severity,
+    );
+    read_severity(
+      Severity::Info,
+      &cli.info,
+      &mut by_rule_id,
+      &mut default_severity,
+    );
+    read_severity(
+      Severity::Hint,
+      &cli.hint,
+      &mut by_rule_id,
+      &mut default_severity,
+    );
+    read_severity(
+      Severity::Off,
+      &cli.off,
+      &mut by_rule_id,
+      &mut default_severity,
+    );
     Ok(Self {
       default_severity,
       by_rule_id,

--- a/crates/cli/src/utils/rule_overwrite.rs
+++ b/crates/cli/src/utils/rule_overwrite.rs
@@ -1,0 +1,69 @@
+use super::SeverityArg;
+
+use anyhow::Result;
+use ast_grep_config::{SerializableRuleConfig, Severity};
+use ast_grep_core::Language;
+
+use std::collections::HashMap;
+
+struct RuleOverwrite {
+  default_severity: Option<Severity>,
+  by_rule_id: HashMap<String, Severity>,
+}
+
+fn read_severity(
+  severity: Severity,
+  ids: &Option<Vec<String>>,
+  by_rule_id: &mut HashMap<String, Severity>,
+  default_severity: &mut Option<Severity>,
+) {
+  let Some(ids) = ids.as_ref() else { return };
+  if ids.is_empty() {
+    *default_severity = Some(severity);
+    return;
+  }
+  for id in ids {
+    by_rule_id.insert(id.clone(), severity.clone());
+  }
+}
+
+impl RuleOverwrite {
+  pub fn new(cli: SeverityArg) -> Result<Self> {
+    let mut default_severity = None;
+    let mut by_rule_id = HashMap::new();
+    read_severity(
+      Severity::Error,
+      &cli.error,
+      &mut by_rule_id,
+      &mut default_severity,
+    );
+    Ok(Self {
+      default_severity,
+      by_rule_id,
+    })
+  }
+
+  pub fn find(&self, id: &str) -> OverwriteResult {
+    let severity = self
+      .by_rule_id
+      .get(id)
+      .cloned()
+      .or_else(|| self.default_severity.clone());
+    OverwriteResult { severity }
+  }
+}
+
+pub struct OverwriteResult {
+  pub severity: Option<Severity>,
+}
+
+impl OverwriteResult {
+  pub fn overwrite<L>(&self, rule: &mut SerializableRuleConfig<L>)
+  where
+    L: Language,
+  {
+    if let Some(severity) = &self.severity {
+      rule.severity = severity.clone();
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option for specifying severity levels during the scanning process, enhancing user control over rule evaluations.
	- Added functionality for managing rule severities, allowing users to define default severities and customize severities for specific rules.

- **Documentation**
	- Updated documentation for the JSON output parameter to reflect a change in the expected casing for the style parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->