### PR TITLE
feat(scan): support context, before/after flags

### DIFF
--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -110,6 +110,8 @@ impl<W: WriteColor + Send + Sync> ColoredPrinter<W> {
 
   pub fn context(mut self, context: (u16, u16)) -> Self {
     self.context = context;
+    self.config.start_context_lines = context.0 as usize;
+    self.config.end_context_lines = context.1 as usize;
     self
   }
 

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -116,39 +116,6 @@ pub struct RunArg {
   /// and to disable heading when piping to another program or redirected to files.
   #[clap(long, default_value = "auto", value_name = "WHEN")]
   heading: Heading,
-
-  // context related options
-  /// Show NUM lines after each match.
-  ///
-  /// It conflicts with both the -C/--context flag.
-  #[clap(
-    short = 'A',
-    long,
-    default_value = "0",
-    conflicts_with = "context",
-    value_name = "NUM"
-  )]
-  after: u16,
-
-  /// Show NUM lines before each match.
-  ///
-  /// It conflicts with both the -C/--context flag.
-  #[clap(
-    short = 'B',
-    long,
-    default_value = "0",
-    conflicts_with = "context",
-    value_name = "NUM"
-  )]
-  before: u16,
-
-  /// Show NUM lines around each match.
-  ///
-  /// This is equivalent to providing both the
-  /// -B/--before and -A/--after flags with the same value.
-  /// It conflicts with both the -B/--before and -A/--after flags.
-  #[clap(short = 'C', long, default_value = "0", value_name = "NUM")]
-  context: u16,
 }
 
 impl RunArg {
@@ -170,10 +137,10 @@ impl RunArg {
 // Every run will include Search or Replace
 // Search or Replace by arguments `pattern` and `rewrite` passed from CLI
 pub fn run_with_pattern(arg: RunArg) -> Result<()> {
-  let context = if arg.context != 0 {
-    (arg.context, arg.context)
+  let context = if arg.output.context != 0 {
+    (arg.output.context, arg.output.context)
   } else {
-    (arg.before, arg.after)
+    (arg.output.before, arg.output.after)
   };
   if let Some(json) = arg.output.json {
     let printer = JSONPrinter::stdout(json).context(context);
@@ -405,10 +372,10 @@ mod test {
         json: None,
         update_all: false,
         tracing: Default::default(),
+        before: 0,
+        after: 0,
+        context: 0,
       },
-      before: 0,
-      after: 0,
-      context: 0,
     }
   }
 

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -74,6 +74,11 @@ pub struct ScanArg {
 
 pub fn run_with_config(arg: ScanArg) -> Result<()> {
   register_custom_language(arg.config.clone())?;
+  let context = if arg.output.context != 0 {
+    (arg.output.context, arg.output.context)
+  } else {
+    (arg.output.before, arg.output.after)
+  };
   if let Some(_format) = &arg.format {
     let printer = CloudPrinter::stdout();
     return run_scan(arg, printer);
@@ -82,7 +87,9 @@ pub fn run_with_config(arg: ScanArg) -> Result<()> {
     let printer = JSONPrinter::stdout(json);
     return run_scan(arg, printer);
   }
-  let printer = ColoredPrinter::stdout(arg.output.color).style(arg.report_style);
+  let printer = ColoredPrinter::stdout(arg.output.color)
+    .style(arg.report_style)
+    .context(context);
   let interactive = arg.output.needs_interactive();
   if interactive {
     let from_stdin = arg.input.stdin;
@@ -383,6 +390,9 @@ rule:
         update_all: false,
         color: ColorArg::Never,
         tracing: Default::default(),
+        before: 0,
+        after: 0,
+        context: 0,
       },
       format: None,
     }

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -153,6 +153,39 @@ pub struct OutputArgs {
   /// tracing information outputs to stderr and does not affect the result of the search.
   #[clap(long, default_value = "nothing", value_name = "LEVEL")]
   pub tracing: Tracing,
+
+  // context related options
+  /// Show NUM lines after each match.
+  ///
+  /// It conflicts with both the -C/--context flag.
+  #[clap(
+    short = 'A',
+    long,
+    default_value = "0",
+    conflicts_with = "context",
+    value_name = "NUM"
+  )]
+  pub after: u16,
+
+  /// Show NUM lines before each match.
+  ///
+  /// It conflicts with both the -C/--context flag.
+  #[clap(
+    short = 'B',
+    long,
+    default_value = "0",
+    conflicts_with = "context",
+    value_name = "NUM"
+  )]
+  pub before: u16,
+
+  /// Show NUM lines around each match.
+  ///
+  /// This is equivalent to providing both the
+  /// -B/--before and -A/--after flags with the same value.
+  /// It conflicts with both the -B/--before and -A/--after flags.
+  #[clap(short = 'C', long, default_value = "0", value_name = "NUM")]
+  pub context: u16,
 }
 
 impl OutputArgs {


### PR DESCRIPTION
Add support for `--before`, `--after` | `--context` CLI flags for `sg
scan`, matching the existing flags for `sg fix`

When developing complex rules (often those that necessitate a yaml rule
file to begin with), this context can be instrumental in evaluating the
quality of a fix.

Addresses https://github.com/ast-grep/ast-grep/issues/1549.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced output capabilities for run and scan commands by allowing users to specify context lines before and after matches.
	- Introduced new command-line arguments for better control over output context in the CLI.

- **Bug Fixes**
	- Improved error handling in scanning functionalities to ensure robust rule parsing and configuration management.

- **Documentation**
	- Updated command-line argument documentation to reflect new context handling features and conflict rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->