### PR TITLE
refactor: rename --tracing to --inspect

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -152,7 +152,7 @@ fn run_pattern_with_printer(arg: RunArg, printer: impl Printer + 'static) -> Res
   } else if arg.lang.is_some() {
     RunWithSpecificLang::new(arg, printer)?.run_path()
   } else {
-    let trace = arg.output.tracing.run_trace();
+    let trace = arg.output.inspect.run_trace();
     RunWithInferredLang {
       arg,
       printer,
@@ -244,7 +244,7 @@ impl<Printer> RunWithSpecificLang<Printer> {
     } else {
       None
     };
-    let stats = arg.output.tracing.run_trace();
+    let stats = arg.output.inspect.run_trace();
     Ok(Self {
       arg,
       printer,
@@ -364,7 +364,7 @@ mod test {
         interactive: false,
         json: None,
         update_all: false,
-        tracing: Default::default(),
+        inspect: Default::default(),
       },
       context: ContextArgs {
         before: 0,

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -127,7 +127,7 @@ impl<P: Printer> ScanWithConfig<P> {
       rule_trace = r_stats;
       configs
     };
-    let trace = arg.output.tracing.scan_trace(rule_trace);
+    let trace = arg.output.inspect.scan_trace(rule_trace);
     Ok(Self {
       arg,
       printer,
@@ -392,7 +392,7 @@ rule:
         json: None,
         update_all: false,
         color: ColorArg::Never,
-        tracing: Default::default(),
+        inspect: Default::default(),
       },
       context: ContextArgs {
         before: 0,

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -1,7 +1,7 @@
 use crate::lang::SgLang;
 use crate::print::{ColorArg, JsonStyle};
 use crate::utils::ErrorContext as EC;
-use crate::utils::Tracing;
+use crate::utils::Granularity;
 
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
@@ -147,13 +147,13 @@ pub struct OutputArgs {
   #[clap(long, default_value = "auto", value_name = "WHEN")]
   pub color: ColorArg,
 
-  /// Show tracing information for file/rule discovery and scanning.
+  /// Inspect information for file/rule discovery and scanning.
   ///
-  /// This flag helps user to inspect ast-grep's internal filtering of files and rules.
-  /// tracing will output how many and why files and rules are scanned and skipped.
-  /// tracing information outputs to stderr and does not affect the result of the search.
+  /// This flag helps user to observe ast-grep's internal filtering of files and rules.
+  /// Inspection will output how many and why files and rules are scanned and skipped.
+  /// Inspection outputs to stderr and does not affect the result of the search.
   #[clap(long, default_value = "nothing", value_name = "GRANULARITY")]
-  pub tracing: Tracing,
+  pub inspect: Granularity,
 }
 
 impl OutputArgs {

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -1,15 +1,15 @@
 mod args;
 mod debug_query;
 mod error_context;
+mod inspect;
 mod rule_overwrite;
-mod tracing;
 mod worker;
 
 pub use args::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs};
 pub use debug_query::DebugFormat;
 pub use error_context::{exit_with_error, ErrorContext};
+pub use inspect::{FileTrace, Granularity, RuleTrace, RunTrace, ScanTrace};
 pub use rule_overwrite::RuleOverwrite;
-pub use tracing::{FileTrace, RuleTrace, RunTrace, ScanTrace, Tracing};
 pub use worker::{Items, PathWorker, StdInWorker, Worker};
 
 use crate::lang::SgLang;


### PR DESCRIPTION
BREAKING CHANGE: --trace is more aligned with existing tools so the CLI arg is renamed to --inspect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `inspect` module, replacing the previous `tracing` functionality.
	- Updated terminology for tracing levels, now referred to as `Granularity`.

- **Bug Fixes**
	- Ensured all references to the `tracing` field are updated to `inspect`, maintaining functionality.

- **Documentation**
	- Clarified documentation comments related to the `inspect` field for better understanding.

- **Refactor**
	- Renamed fields and updated method calls to align with the new `inspect` terminology throughout the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->