### PR TITLE
Introducing ast-grep Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
    <img src="https://img.shields.io/github/stars/ast-grep/ast-grep?style=social" alt="Badge"/>
    <img src="https://img.shields.io/github/forks/ast-grep/ast-grep?style=social" alt="Badge"/>
    <img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/HerringtonDarkholme?style=social">
+   <a href="https://gurubase.io/g/ast-grep"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20ast-grep%20Guru-006BFF"></a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
    <img src="https://img.shields.io/github/stars/ast-grep/ast-grep?style=social" alt="Badge"/>
    <img src="https://img.shields.io/github/forks/ast-grep/ast-grep?style=social" alt="Badge"/>
    <img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/HerringtonDarkholme?style=social">
-   <a href="https://gurubase.io/g/ast-grep"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20ast-grep%20Guru-006BFF"></a>
+   <a href="https://gurubase.io/g/ast-grep"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20ast--grep%20Guru-006BFF"></a>
 </p>
 
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ast-grep Guru](https://gurubase.io/g/ast-grep) to Gurubase. ast-grep Guru uses the data from this repo and data from the [docs](https://ast-grep.github.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "ast-grep Guru", which highlights that ast-grep now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ast-grep Guru in Gurubase, just let me know that's totally fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new badge in the README to promote the Gurubase platform for user inquiries related to the `ast-grep` project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->