### PR TITLE
refactor: move stdErr into inspect mod

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -189,10 +189,7 @@ impl<P: Printer> Worker for RunWithInferredLang<P> {
       }
     }
     printer.after_print()?;
-    // TODO: better handle output format
-    if let Some(trace) = self.trace.print() {
-      eprintln!("{}", trace);
-    }
+    self.trace.print()?;
     Ok(())
   }
 }
@@ -207,9 +204,7 @@ impl<P: Printer> PathWorker for RunWithInferredLang<P> {
 
   fn produce_item(&self, path: &Path) -> Option<Vec<Self::Item>> {
     let lang = SgLang::from_path(path)?;
-    if let Some(n) = self.trace.print_file(path, lang) {
-      eprintln!("{}", n);
-    }
+    self.trace.print_file(path, lang).ok()?;
     let matcher = self.arg.build_pattern(lang).ok()?;
     // match sub region
     if let Some(sub_langs) = lang.injectable_sg_langs() {
@@ -267,9 +262,7 @@ impl<P: Printer> Worker for RunWithSpecificLang<P> {
       has_matches = true;
     }
     printer.after_print()?;
-    if let Some(stats) = self.stats.print() {
-      eprintln!("{}", stats);
-    }
+    self.stats.print()?;
     if !has_matches && self.pattern.has_error() {
       Err(anyhow::anyhow!(EC::PatternHasError))
     } else {
@@ -291,9 +284,7 @@ impl<P: Printer> PathWorker for RunWithSpecificLang<P> {
     let pattern = self.pattern.clone();
     let lang = arg.lang.expect("must present");
     let path_lang = SgLang::from_path(path)?;
-    if let Some(trace) = self.stats.print_file(path, path_lang) {
-      eprintln!("{trace}");
-    }
+    self.stats.print_file(path, path_lang).ok()?;
     let ret = if path_lang == lang {
       filter_file_pattern(path, lang, Some(pattern), std::iter::empty())?
     } else {

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -177,9 +177,7 @@ impl<P: Printer> Worker for ScanWithConfig<P> {
       )?;
     }
     self.printer.after_print()?;
-    if let Some(trace) = self.trace.print() {
-      eprintln!("{}", trace);
-    }
+    self.trace.print()?;
     if error_count > 0 {
       Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
     } else {

--- a/crates/cli/src/utils/inspect.rs
+++ b/crates/cli/src/utils/inspect.rs
@@ -14,13 +14,11 @@ use crate::lang::SgLang;
 use ast_grep_config::RuleConfig;
 
 use clap::ValueEnum;
-use serde::{Deserialize, Serialize};
 
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[derive(Clone, Copy, ValueEnum, Serialize, Deserialize, Default, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, ValueEnum, Default, PartialEq, Debug)]
 pub enum Granularity {
   /// Do not show any tracing information
   #[default]
@@ -51,8 +49,7 @@ impl Granularity {
 
 // total = scanned + skipped
 //       = (matched + unmatched) + skipped
-#[derive(Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct FileTrace {
   files_scanned: AtomicUsize,
   files_skipped: AtomicUsize,
@@ -77,13 +74,9 @@ impl FileTrace {
   }
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TraceInfo<T> {
   pub level: Granularity,
-  #[serde(flatten)]
   pub file_trace: FileTrace,
-  #[serde(flatten)]
   pub inner: T,
 }
 
@@ -134,10 +127,8 @@ impl TraceInfo<RuleTrace> {
   }
 }
 
-#[derive(Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct RuleTrace {
-  #[serde(skip_serializing)]
   pub effective_rule_count: usize,
   pub skipped_rule_count: usize,
 }

--- a/crates/cli/src/utils/inspect.rs
+++ b/crates/cli/src/utils/inspect.rs
@@ -103,7 +103,9 @@ impl<W: Write + Sync> TraceInfo<(), W> {
       Granularity::Nothing => Ok(()),
       Granularity::Summary | Granularity::Entity => {
         let mut w = self.output.lock().expect("lock should not be poisoned");
-        self.file_trace.print(&mut *w)
+        self.file_trace.print(&mut *w)?;
+        writeln!(&mut *w)?;
+        Ok(())
       }
     }
   }
@@ -113,7 +115,9 @@ impl<W: Write + Sync> TraceInfo<(), W> {
       Granularity::Nothing | Granularity::Summary => Ok(()),
       Granularity::Entity => {
         let mut w = self.output.lock().expect("lock should not be poisoned");
-        self.file_trace.print_file(&mut *w, path, lang)
+        self.file_trace.print_file(&mut *w, path, lang)?;
+        writeln!(&mut *w)?;
+        Ok(())
       }
     }
   }
@@ -127,7 +131,7 @@ impl<W: Write> TraceInfo<RuleTrace, W> {
       Granularity::Summary | Granularity::Entity => {
         let mut w = self.output.lock().expect("lock should not be poisoned");
         self.file_trace.print(&mut *w)?;
-        write!(&mut *w, "\n{}", self.inner.print())?;
+        writeln!(&mut *w, "\n{}", self.inner.print())?;
         Ok(())
       }
     }
@@ -139,7 +143,7 @@ impl<W: Write> TraceInfo<RuleTrace, W> {
       Granularity::Entity => {
         let mut w = self.output.lock().expect("lock should not be poisoned");
         self.file_trace.print_file(&mut *w, path, lang)?;
-        write!(&mut *w, ", applied {len} rule(s)")?;
+        writeln!(&mut *w, ", applied {len} rule(s)")?;
         Ok(())
       }
     }
@@ -182,7 +186,7 @@ mod test {
       0
     );
     assert!(run_trace.print().is_ok());
-    assert_eq!(ret, "Files scanned: 0, Files skipped: 0");
+    assert_eq!(ret, "Files scanned: 0, Files skipped: 0\n");
 
     let mut ret = String::new();
     let rule_stats = RuleTrace {
@@ -204,7 +208,7 @@ mod test {
     assert!(scan_trace.print().is_ok());
     assert_eq!(
       ret,
-      "Files scanned: 0, Files skipped: 0\nEffective rules: 10, Skipped rules: 2"
+      "Files scanned: 0, Files skipped: 0\nEffective rules: 10, Skipped rules: 2\n"
     );
   }
 

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -112,9 +112,7 @@ fn filter(
   rule_stats: &ScanTrace,
 ) -> Option<PreScan> {
   let rules = configs.get_rule_from_lang(path, lang);
-  if let Some(rule_stats) = rule_stats.print_file(path, lang, &rules) {
-    eprintln!("{}", rule_stats);
-  }
+  rule_stats.print_file(path, lang, &rules).ok()?;
   let combined = CombinedScan::new(rules);
   let pre_scan = combined.find(grep);
   if pre_scan.hit_set.is_empty() {

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -47,3 +47,16 @@ fn test_js_in_html() -> Result<()> {
     .stdout(contains("alert(456)"));
   Ok(())
 }
+
+#[test]
+fn test_inspect() -> Result<()> {
+  let dir = create_test_files([("a.js", "alert(1)"), ("b.js", "alert(456)")])?;
+  Command::cargo_bin("sg")?
+    .current_dir(dir.path())
+    .args(["-p", "alert($A)", "-l", "js", "--inspect", "entity"])
+    .assert()
+    .success()
+    .stdout(contains("alert(1)"))
+    .stderr(contains("Files scanned: 2"));
+  Ok(())
+}


### PR DESCRIPTION
fix #1575 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced output handling and error reporting for trace and stats in various structures.
	- Improved tracing functionality for the AST-grep scanning process with more robust output management.
	- Added a new test function to validate the inspect feature in the command-line tool.

- **Bug Fixes**
	- Streamlined error handling in `consume_items` methods for better clarity and performance.

- **Documentation**
	- Updated comments and formatting for improved code clarity.

- **Chores**
	- Minor adjustments to method signatures and struct definitions to enhance maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->