### PR TITLE
feat: semi-structured tracing output

### DIFF
--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -57,6 +57,6 @@ fn test_inspect() -> Result<()> {
     .assert()
     .success()
     .stdout(contains("alert(1)"))
-    .stderr(contains("Files scanned: 2"));
+    .stderr(contains("scannedFileCount=2"));
   Ok(())
 }


### PR DESCRIPTION
fix #1574 BREAKING CHANGE: now inspect has new format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced output clarity and structure for tracing information with new printing methods in the `TraceInfo` struct.
	- Improved comparability of the `Granularity` enum with additional traits.

- **Bug Fixes**
	- Updated error message format in test assertions to align with the new structured output.

- **Refactor**
	- Streamlined printing logic in `TraceInfo` by integrating existing methods into new structured print methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->