### PR TITLE
feat(napi): Expose node id via SgNode

### DIFF
--- a/crates/napi/__test__/index.spec.ts
+++ b/crates/napi/__test__/index.spec.ts
@@ -219,6 +219,13 @@ test('show good error message for invalid arg', async t => {
   })
 })
 
+test('get node id', async t => {
+  const sg = parse('console.log(123)')
+  const nodeWithPattern = sg.root().find('console.log($$$)')
+  const nodeWithKind = sg.root().find(kind('call_expression'))
+  t.is(nodeWithPattern!.id(), nodeWithKind!.id())
+})
+
 test('find in files', async t => {
   let findInFiles = countedPromise(ts.findInFiles)
   await findInFiles({

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -127,6 +127,8 @@ export declare class SgNode {
   /** Returns the node's SgRoot */
   getRoot(): SgRoot
   children(): Array<SgNode>
+  /** Returns the node's id */
+  id(): number
   find(matcher: string | number | NapiConfig): SgNode | null
   findAll(matcher: string | number | NapiConfig): Array<SgNode>
   /** Finds the child node in the `field` */

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -162,6 +162,12 @@ impl SgNode {
     Self::from_iter_to_vec(&reference, env, children)
   }
 
+  /// Returns the node's id
+  #[napi]
+  pub fn id(&self) -> Result<u32> {
+    Ok(self.inner.node_id() as u32)
+  }
+
   #[napi]
   pub fn find(
     &self,


### PR DESCRIPTION
This PR exposes node_id via `SgNode`. It's useful to check whether the results of two separate `find` operations are identical when using the NAPI API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `id()` for the `SgNode` class, allowing users to retrieve the unique identifier of each node.
- **Enhancements**
	- Improved functionality for tracking and referencing nodes within the abstract syntax tree (AST).
- **Tests**
	- Added a new test case to verify the consistency of node IDs across different querying methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->