### PR TITLE
test: add test for unicode range test

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -697,4 +697,23 @@ if (a) {
     assert_eq!(edit.position, 15);
     assert_eq!(edit.deleted_length, 8);
   }
+
+  #[test]
+  fn test_ascii_pos() {
+    let root = Tsx.ast_grep("a");
+    let root = root.root();
+    let node = root.find("$A").expect("should exist");
+    assert_eq!(node.start_pos(), (0, 0));
+    assert_eq!(node.end_pos(), (0, 1));
+  }
+
+  #[test]
+  #[ignore = "TODO: fix column to be unicode character"]
+  fn test_unicode_pos() {
+    let root = Tsx.ast_grep("🦀");
+    let root = root.root();
+    let node = root.find("$A").expect("should exist");
+    assert_eq!(node.start_pos(), (0, 0));
+    assert_eq!(node.end_pos(), (0, 1));
+  }
 }

--- a/crates/pyo3/tests/test_range.py
+++ b/crates/pyo3/tests/test_range.py
@@ -47,3 +47,6 @@ def test_unicode():
     node = root.find(pattern="console.log($A)")
     assert node is not None
     assert node.range().start.index == 5
+    assert node.range().start.line == 0
+    # TODO: Fix this, it should be 5 in character
+    # assert node.range().start.column == 5


### PR DESCRIPTION
part of #1594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added new test cases for validating node positions with ASCII and Unicode characters.
	- Enhanced the `test_unicode` function to assert the line number of the node's range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->