### PR TITLE
refactor: expose new struct Position for abstracting column

### DIFF
--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -1,10 +1,7 @@
 use super::SgLang;
 use crate::utils::ErrorContext as EC;
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::{
-  language::{TSPoint, TSRange},
-  Doc, Language, Node, StrDoc,
-};
+use ast_grep_core::{language::TSRange, Doc, Language, Node, StrDoc};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -168,9 +165,9 @@ fn extract_custom_inject(
 fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let r = node.range();
   let start = node.start_pos();
-  let sp = TSPoint::new(start.0 as u32, start.1 as u32);
+  let sp = start.ts_point();
   let end = node.end_pos();
-  let ep = TSPoint::new(end.0 as u32, end.1 as u32);
+  let ep = end.ts_point();
   TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
 }
 

--- a/crates/cli/src/print/cloud_print.rs
+++ b/crates/cli/src/print/cloud_print.rs
@@ -94,8 +94,8 @@ fn print_rule<'a, W: Write + Send + Sync>(
   let title = &rule.id;
   let name = path.display();
   for m in matches {
-    let line = m.start_pos().0 + 1;
-    let end_line = m.end_pos().0 + 1;
+    let line = m.start_pos().row() + 1;
+    let end_line = m.end_pos().row() + 1;
     let message = rule.get_message(&m);
     writeln!(
       &mut writer,

--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -267,7 +267,7 @@ impl<'a> MatchMerger<'a> {
   fn new(nm: &NodeMatch<'a, SgLang>, (before, after): (u16, u16)) -> Self {
     let display = nm.display_context(before as usize, after as usize);
     let last_start_line = display.start_line + 1;
-    let last_end_line = nm.end_pos().0 + 1;
+    let last_end_line = nm.end_pos().row() + 1;
     let last_trailing = display.trailing;
     let last_end_offset = nm.range().end;
     Self {
@@ -296,7 +296,7 @@ impl<'a> MatchMerger<'a> {
   fn conclude_match(&mut self, nm: &NodeMatch<'a, SgLang>) {
     let display = self.display(nm);
     self.last_start_line = display.start_line + 1;
-    self.last_end_line = nm.end_pos().0 + 1;
+    self.last_end_line = nm.end_pos().row() + 1;
     self.last_trailing = display.trailing;
     self.last_end_offset = nm.range().end;
   }

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -82,7 +82,7 @@ impl<P: Printer> Printer for InteractivePrinter<P> {
     utils::run_in_alternate_screen(|| {
       let matches: Vec<_> = matches.collect();
       let first_match = match matches.first() {
-        Some(n) => n.start_pos().0,
+        Some(n) => n.start_pos().row(),
         None => return Ok(()),
       };
       let file_path = PathBuf::from(file.name().to_string());
@@ -174,7 +174,7 @@ fn print_diff_and_prompt_action(
       'y' => Ok((true, false)),
       'a' => Ok((true, true)),
       'e' => {
-        let pos = diff.node_match.start_pos().0;
+        let pos = diff.node_match.start_pos().row();
         open_in_editor(path, pos)?;
         Ok((false, false))
       }
@@ -193,7 +193,7 @@ fn print_matches_and_confirm_next<'a>(
   let printer = &interactive.inner;
   let matches: Vec<_> = matches.collect();
   let first_match = match matches.first() {
-    Some(n) => n.start_pos().0,
+    Some(n) => n.start_pos().row(),
     None => return Ok(()),
   };
   printer.print_matches(matches.into_iter(), path)?;

--- a/crates/cli/src/print/json_print.rs
+++ b/crates/cli/src/print/json_print.rs
@@ -29,8 +29,11 @@ macro_rules! Diffs {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// Zero-based character position in a file.
 struct Position {
+  /// Zero-based line number
   line: usize,
+  /// Zero-based character column in a line
   column: usize,
 }
 
@@ -143,12 +146,12 @@ fn get_range(n: &Node<'_, SgLang>) -> Range {
   Range {
     byte_offset: n.range(),
     start: Position {
-      line: start_pos.0,
-      column: start_pos.1,
+      line: start_pos.row(),
+      column: start_pos.column(n),
     },
     end: Position {
-      line: end_pos.0,
-      column: end_pos.1,
+      line: end_pos.row(),
+      column: end_pos.column(n),
     },
   }
 }

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -18,9 +18,9 @@ impl Suppressions {
     if !node.kind().contains("comment") || !node.text().contains(IGNORE_TEXT) {
       return;
     }
-    let line = node.start_pos().0;
+    let line = node.start_pos().row();
     let suppress_next_line = if let Some(prev) = node.prev() {
-      prev.start_pos().0 != line
+      prev.start_pos().row() != line
     } else {
       true
     };
@@ -39,7 +39,7 @@ impl Suppressions {
   }
 
   fn check_suppression<D: Doc>(&mut self, node: &Node<D>) -> MaySuppressed {
-    let line = node.start_pos().0;
+    let line = node.start_pos().row();
     if let Some(sup) = self.0.get_mut(&line) {
       MaySuppressed::Yes(sup)
     } else {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,7 +23,7 @@ mod node;
 pub use language::Language;
 pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
-pub use node::Node;
+pub use node::{Node, Position};
 pub use source::{Doc, StrDoc};
 
 #[doc(hidden)]

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,5 +1,5 @@
 use super::pre_process_pattern;
-use ast_grep_core::language::{TSPoint, TSRange};
+use ast_grep_core::language::TSRange;
 use ast_grep_core::Language;
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
 use std::collections::HashMap;
@@ -68,9 +68,9 @@ fn find_lang<D: Doc>(node: &Node<D>) -> Option<String> {
 fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let r = node.range();
   let start = node.start_pos();
-  let sp = TSPoint::new(start.0 as u32, start.1 as u32);
+  let sp = start.ts_point();
   let end = node.end_pos();
-  let ep = TSPoint::new(end.0 as u32, end.1 as u32);
+  let ep = end.ts_point();
   TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
 }
 

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -57,16 +57,16 @@ pub fn diagnostic_to_code_action(
 }
 
 fn convert_node_to_range<D: Doc>(node_match: &Node<D>) -> Range {
-  let (start_row, start_col) = node_match.start_pos();
-  let (end_row, end_col) = node_match.end_pos();
+  let start = node_match.start_pos();
+  let end = node_match.end_pos();
   Range {
     start: Position {
-      line: start_row as u32,
-      character: start_col as u32,
+      line: start.row() as u32,
+      character: start.column(node_match) as u32,
     },
     end: Position {
-      line: end_row as u32,
-      character: end_col as u32,
+      line: end.row() as u32,
+      character: end.column(node_match) as u32,
     },
   }
 }

--- a/crates/pyo3/src/range.rs
+++ b/crates/pyo3/src/range.rs
@@ -1,5 +1,5 @@
 use crate::unicode_position::UnicodePosition;
-use ast_grep_core::{Doc, Node};
+use ast_grep_core::{Doc, Node, Position};
 use pyo3::prelude::*;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -50,10 +50,10 @@ impl Pos {
   }
 }
 
-fn to_pos(pos: (usize, usize), offset: usize) -> Pos {
+fn to_pos<D: Doc>(node: &Node<D>, pos: Position, offset: usize) -> Pos {
   Pos {
-    line: pos.0,
-    column: pos.1,
+    line: pos.row(),
+    column: pos.column(node),
     index: offset,
   }
 }
@@ -105,8 +105,8 @@ impl Range {
     let start = positioner.byte_to_char(byte_range.start);
     let end = positioner.byte_to_char(byte_range.end);
     Range {
-      start: to_pos(start_pos, start),
-      end: to_pos(end_pos, end),
+      start: to_pos(node, start_pos, start),
+      end: to_pos(node, end_pos, end),
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: part of #1594 

In following up PRs, the Position struct will translate byte column to character column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `Position` struct for handling positions in source code, improving clarity and functionality.
  - Enhanced the public interface by making the `Position` type accessible alongside `Node`.

- **Improvements**
  - Simplified position handling in various components, including `SgNode`, `InteractivePrinter`, and `CloudPrinter`, by using method calls instead of tuple indexing.
  - Improved error handling in file operations and diagnostics.

- **Documentation**
  - Added comments to the `Position` struct for better understanding of its fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->