### PR TITLE
feat: support character based column number

### DIFF
--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -107,6 +107,10 @@ impl Content for Wrapper {
     let s = String::from_utf16_lossy(bytes);
     Cow::Owned(s)
   }
+  fn get_char_column(&self, column: usize, _offset: usize) -> usize {
+    // utf-16 is 2 bytes per character, this is O(1) operation!
+    column / 2
+  }
 }
 
 fn pos_for_byte_offset(input: &[u16], byte_offset: usize) -> Point {

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -43,8 +43,7 @@ impl SgNode {
   fn to_pos(&self, pos: Position, offset: usize) -> Pos {
     Pos {
       line: pos.row() as u32,
-      // TODO: remove the division by 2 hack
-      column: pos.column(&self.inner) as u32 / 2,
+      column: pos.column(&self.inner) as u32,
       index: offset as u32 / 2,
     }
   }

--- a/crates/pyo3/tests/test_range.py
+++ b/crates/pyo3/tests/test_range.py
@@ -48,5 +48,4 @@ def test_unicode():
     assert node is not None
     assert node.range().start.index == 5
     assert node.range().start.line == 0
-    # TODO: Fix this, it should be 5 in character
-    # assert node.range().start.column == 5
+    assert node.range().start.column == 5


### PR DESCRIPTION
BREAKING CHANGE: now column returns character based offset in line previously it returns byte based offset. fix #1594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `byte_offset` field in the `Position` struct for improved source code position representation.
	- Added `get_char_column` method to the `Content` trait for character column calculations, accommodating UTF-8 and UTF-16 encodings.

- **Bug Fixes**
	- Updated position calculations in `SgNode` methods for consistency and clarity.

- **Tests**
	- Enhanced `test_unicode` function to ensure the correctness of column index assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->