### PR TITLE
[RFC] feat(napi): Typed SgNode and SgRoot

### DIFF
--- a/crates/napi/__test__/index.spec.ts
+++ b/crates/napi/__test__/index.spec.ts
@@ -265,7 +265,7 @@ test('find in files with meta var', async t => {
 test('find in files with filename', async t => {
   let findInFiles = countedPromise(ts.findInFiles)
   await findInFiles({
-    paths: ['./'],
+    paths: ['./__test__/'],
     matcher: {
       rule: {kind: 'await_expression'},
     },
@@ -291,7 +291,7 @@ test('tsx should not find ts file', async t => {
 test('find with language globs', async t => {
   let findInFiles = countedPromise(tsx.findInFiles)
   await findInFiles({
-    paths: ['./'],
+    paths: ['./__test__/'],
     matcher: {
       rule: {kind: 'await_expression'},
     },

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -16,12 +16,11 @@ import RubyNodeTypesMap from "./types/Ruby-node-types";
 import PhpNodeTypesMap from "./types/Php-node-types";
 import ElixirNodeTypesMap from "./types/Elixir-node-types";
 import KotlinNodeTypesMap from "./types/Kotlin-node-types";
-import SwiftNodeTypesMap from "./types/Swift-node-types";
 import HaskellNodeTypesMap from "./types/Haskell-node-types";
 import ScalaNodeTypesMap from "./types/Scala-node-types";
-import LuaNodeTypesMap from "./types/Lua-node-types";
 import BashNodeTypesMap from "./types/Bash-node-types";
 import YamlNodeTypesMap from "./types/Yaml-node-types";
+import LuaNodeTypesMap from "./types/Lua-node-types";
 export {
   JavaScriptNodeTypesMap,
   TypeScriptNodeTypesMap,
@@ -40,12 +39,11 @@ export {
   PhpNodeTypesMap,
   ElixirNodeTypesMap,
   KotlinNodeTypesMap,
-  SwiftNodeTypesMap,
   HaskellNodeTypesMap,
   ScalaNodeTypesMap,
-  LuaNodeTypesMap,
   BashNodeTypesMap,
-  YamlNodeTypesMap
+  YamlNodeTypesMap,
+  LuaNodeTypesMap
 };
 /* tslint:disable */
 /* eslint-disable */

--- a/crates/napi/index.d.ts
+++ b/crates/napi/index.d.ts
@@ -1,3 +1,52 @@
+import type { FieldNames, FieldSgNode, NodeTypesMap } from "./types/node-types";
+import JavaScriptNodeTypesMap from "./types/JavaScript-node-types";
+import TypeScriptNodeTypesMap from "./types/TypeScript-node-types";
+import TsxNodeTypesMap from "./types/Tsx-node-types";
+import JavaNodeTypesMap from "./types/Java-node-types";
+import PythonNodeTypesMap from "./types/Python-node-types";
+import RustNodeTypesMap from "./types/Rust-node-types";
+import CNodeTypesMap from "./types/C-node-types";
+import CppNodeTypesMap from "./types/Cpp-node-types";
+import GoNodeTypesMap from "./types/Go-node-types";
+import HtmlNodeTypesMap from "./types/Html-node-types";
+import CssNodeTypesMap from "./types/Css-node-types";
+import JsonNodeTypesMap from "./types/Json-node-types";
+import CSharpNodeTypesMap from "./types/CSharp-node-types";
+import RubyNodeTypesMap from "./types/Ruby-node-types";
+import PhpNodeTypesMap from "./types/Php-node-types";
+import ElixirNodeTypesMap from "./types/Elixir-node-types";
+import KotlinNodeTypesMap from "./types/Kotlin-node-types";
+import SwiftNodeTypesMap from "./types/Swift-node-types";
+import HaskellNodeTypesMap from "./types/Haskell-node-types";
+import ScalaNodeTypesMap from "./types/Scala-node-types";
+import LuaNodeTypesMap from "./types/Lua-node-types";
+import BashNodeTypesMap from "./types/Bash-node-types";
+import YamlNodeTypesMap from "./types/Yaml-node-types";
+export {
+  JavaScriptNodeTypesMap,
+  TypeScriptNodeTypesMap,
+  TsxNodeTypesMap,
+  JavaNodeTypesMap,
+  PythonNodeTypesMap,
+  RustNodeTypesMap,
+  CNodeTypesMap,
+  CppNodeTypesMap,
+  GoNodeTypesMap,
+  HtmlNodeTypesMap,
+  CssNodeTypesMap,
+  JsonNodeTypesMap,
+  CSharpNodeTypesMap,
+  RubyNodeTypesMap,
+  PhpNodeTypesMap,
+  ElixirNodeTypesMap,
+  KotlinNodeTypesMap,
+  SwiftNodeTypesMap,
+  HaskellNodeTypesMap,
+  ScalaNodeTypesMap,
+  LuaNodeTypesMap,
+  BashNodeTypesMap,
+  YamlNodeTypesMap
+};
 /* tslint:disable */
 /* eslint-disable */
 
@@ -108,13 +157,18 @@ export declare function pattern(lang: Lang, pattern: string): NapiConfig
  * `callback` will receive matching nodes found in a file.
  */
 export declare function findInFiles(lang: Lang, config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
-export declare class SgNode {
+export declare class SgNode<
+  M extends NodeTypesMap = NodeTypesMap,
+  T extends keyof M = keyof M
+> {
   range(): Range
   isLeaf(): boolean
   isNamed(): boolean
   isNamedLeaf(): boolean
   /** Returns the string name of the node kind */
-  kind(): string
+  kind(): T
+  /** Check if the node is the same kind as the given `kind` string */
+  is<K extends T>(kind: K): this is SgNode<M, K> & this
   text(): string
   matches(m: string): boolean
   inside(m: string): boolean
@@ -126,17 +180,17 @@ export declare class SgNode {
   getTransformed(m: string): string | null
   /** Returns the node's SgRoot */
   getRoot(): SgRoot
-  children(): Array<SgNode>
+  children(): Array<SgNode<M>>
   /** Returns the node's id */
   id(): number
-  find(matcher: string | number | NapiConfig): SgNode | null
-  findAll(matcher: string | number | NapiConfig): Array<SgNode>
+  find(matcher: string | number | NapiConfig): SgNode<M> | null
+  findAll(matcher: string | number | NapiConfig): Array<SgNode<M>>
   /** Finds the first child node in the `field` */
-  field(name: string): SgNode | null
+  field<F extends FieldNames<M[T]>>(name: F): FieldSgNode<M, T, F>
   /** Finds all the children nodes in the `field` */
-  fieldChildren(name: string): Array<SgNode>
+  fieldChildren<F extends FieldNames<M[T]>>(name: F): Exclude<FieldSgNode<M, T, F>, null>[]
   parent(): SgNode | null
-  child(nth: number): SgNode | null
+  child(nth: number): SgNode<M> | null
   ancestors(): Array<SgNode>
   next(): SgNode | null
   nextAll(): Array<SgNode>
@@ -146,9 +200,9 @@ export declare class SgNode {
   commitEdits(edits: Array<Edit>): string
 }
 /** Represents the parsed tree of code. */
-export declare class SgRoot {
+export declare class SgRoot<M extends NodeTypesMap = NodeTypesMap> {
   /** Returns the root SgNode of the ast-grep instance. */
-  root(): SgNode
+  root(): SgNode<M>
   /**
    * Returns the path of the file if it is discovered by ast-grep's `findInFiles`.
    * Returns `"anonymous"` if the instance is created by `lang.parse(source)`.
@@ -157,7 +211,7 @@ export declare class SgRoot {
 }
 export declare namespace html {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<HtmlNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -165,7 +219,7 @@ export declare namespace html {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<HtmlNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -175,11 +229,11 @@ export declare namespace html {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<HtmlNodeTypesMap>[]) => void): Promise<number>
 }
 export declare namespace js {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<JavaScriptNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -187,7 +241,7 @@ export declare namespace js {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<JavaScriptNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -197,11 +251,11 @@ export declare namespace js {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<JavaScriptNodeTypesMap>[]) => void): Promise<number>
 }
 export declare namespace jsx {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<JavaScriptNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -209,7 +263,7 @@ export declare namespace jsx {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<JavaScriptNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -219,11 +273,11 @@ export declare namespace jsx {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<JavaScriptNodeTypesMap>[]) => void): Promise<number>
 }
 export declare namespace ts {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<TypeScriptNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -231,7 +285,7 @@ export declare namespace ts {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<TypeScriptNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -241,11 +295,11 @@ export declare namespace ts {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<TypeScriptNodeTypesMap>[]) => void): Promise<number>
 }
 export declare namespace tsx {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<TsxNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -253,7 +307,7 @@ export declare namespace tsx {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<TsxNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -263,11 +317,11 @@ export declare namespace tsx {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<TsxNodeTypesMap>[]) => void): Promise<number>
 }
 export declare namespace css {
   /** Parse a string to an ast-grep instance */
-  export function parse(src: string): SgRoot
+  export function parse(src: string): SgRoot<CssNodeTypesMap>
   /**
    * Parse a string to an ast-grep instance asynchronously in threads.
    * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -275,7 +329,7 @@ export declare namespace css {
    * Please refer to libuv doc, nodejs' underlying runtime
    * for its default behavior and performance tuning tricks.
    */
-  export function parseAsync(src: string): Promise<SgRoot>
+  export function parseAsync(src: string): Promise<SgRoot<CssNodeTypesMap>>
   /** Get the `kind` number from its string name. */
   export function kind(kindName: string): number
   /** Compile a string to ast-grep Pattern. */
@@ -285,5 +339,5 @@ export declare namespace css {
    * `config` specifies the file path and matcher.
    * `callback` will receive matching nodes found in a file.
    */
-  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode[]) => void): Promise<number>
+  export function findInFiles(config: FindConfig, callback: (err: null | Error, result: SgNode<CssNodeTypesMap>[]) => void): Promise<number>
 }

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -43,19 +43,19 @@
   "scripts": {
     "artifacts": "napi artifacts",
     "build": "napi build --no-const-enum --platform --release && yarn run typegen",
-    "build:debug": "napi build --no-const-enum --platform",
+    "build:debug": "napi build --no-const-enum --platform && yarn run typegen",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "ava",
     "version": "napi version",
-    "typegen": "tsx scripts/generate-types.ts"
+    "typegen": "ts-node scripts/generate-types.ts"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.18.4",
     "@types/node": "^22.10.2",
     "ava": "6.2.0",
     "chalk": "5.3.0",
+    "smol-toml": "^1.3.1",
     "ts-node": "10.9.2",
-    "tsx": "^4.19.2",
     "typescript": "5.7.2"
   },
   "ava": {

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -16,7 +16,8 @@
   "files": [
     "manual.d.ts",
     "index.d.ts",
-    "index.js"
+    "index.js",
+    "types/*.ts"
   ],
   "napi": {
     "name": "ast-grep-napi",
@@ -41,17 +42,20 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --no-const-enum --platform --release",
+    "build": "napi build --no-const-enum --platform --release && yarn run typegen",
     "build:debug": "napi build --no-const-enum --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "ava",
-    "version": "napi version"
+    "version": "napi version",
+    "typegen": "tsx scripts/generate-types.ts"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.18.4",
+    "@types/node": "^22.10.2",
     "ava": "6.2.0",
     "chalk": "5.3.0",
     "ts-node": "10.9.2",
+    "tsx": "^4.19.2",
     "typescript": "5.7.2"
   },
   "ava": {

--- a/crates/napi/scripts/constants.ts
+++ b/crates/napi/scripts/constants.ts
@@ -1,0 +1,93 @@
+import { Lang } from "..";
+
+export const languageNodeTypesTagVersionOverrides: Partial<
+  Record<Lang, string>
+> = {
+  // The latest version is not tagged yet, so we have to use the latest available tag
+  [Lang.Kotlin]: "0.3.8",
+};
+
+export const languagesCrateNames: Record<Lang, string> = {
+  [Lang.JavaScript]: "tree-sitter-javascript",
+  [Lang.TypeScript]: "tree-sitter-typescript",
+  [Lang.Tsx]: "tree-sitter-typescript",
+  [Lang.Java]: "tree-sitter-java",
+  [Lang.Python]: "tree-sitter-python",
+  [Lang.Rust]: "tree-sitter-rust",
+  [Lang.C]: "tree-sitter-c",
+  [Lang.Cpp]: "tree-sitter-cpp",
+  [Lang.Go]: "tree-sitter-go",
+  [Lang.Html]: "tree-sitter-html",
+  [Lang.Css]: "tree-sitter-css",
+  [Lang.Json]: "tree-sitter-json",
+  [Lang.CSharp]: "tree-sitter-c-sharp",
+  [Lang.Ruby]: "tree-sitter-ruby",
+  [Lang.Php]: "tree-sitter-php",
+  [Lang.Elixir]: "tree-sitter-elixir",
+  [Lang.Kotlin]: "tree-sitter-kotlin",
+  [Lang.Swift]: "tree-sitter-swift",
+  [Lang.Haskell]: "tree-sitter-haskell",
+  [Lang.Scala]: "tree-sitter-scala",
+  [Lang.Lua]: "tree-sitter-lua",
+  [Lang.Bash]: "tree-sitter-bash",
+  [Lang.Yaml]: "tree-sitter-yaml",
+  [Lang.Sql]: "tree-sitter-sql",
+};
+
+export const languagesNodeTypesUrls = {
+  [Lang.JavaScript]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.TypeScript]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-typescript/refs/tags/{{TAG}}/typescript/src/node-types.json",
+  [Lang.Tsx]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-typescript/refs/tags/{{TAG}}/tsx/src/node-types.json",
+  [Lang.Java]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-java/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Python]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-python/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Rust]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-rust/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.C]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-c/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Cpp]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-cpp/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Go]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-go/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Html]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-html/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Css]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-css/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Json]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-json/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.CSharp]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-c-sharp/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Ruby]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-ruby/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Php]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-php/refs/tags/{{TAG}}/php/src/node-types.json",
+  [Lang.Elixir]:
+    "https://raw.githubusercontent.com/elixir-lang/tree-sitter-elixir/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Kotlin]:
+    "https://raw.githubusercontent.com/fwcd/tree-sitter-kotlin/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Haskell]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-haskell/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Scala]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-scala/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Bash]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-bash/refs/tags/{{TAG}}/src/node-types.json",
+  [Lang.Yaml]:
+    "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-yaml/refs/tags/{{TAG}}/src/node-types.json",
+  // The Lua tree-sitter repo does not have tags
+  [Lang.Lua]:
+    "https://raw.githubusercontent.com/tjdevries/tree-sitter-lua/refs/heads/master/src/node-types.json",
+  // Not available for SQL and Swift - They don't have node-types.json in their repo contents
+};
+
+export const languageLibs = {
+  js: Lang.JavaScript,
+  jsx: Lang.JavaScript,
+  ts: Lang.TypeScript,
+  tsx: Lang.Tsx,
+  css: Lang.Css,
+  html: Lang.Html,
+};

--- a/crates/napi/scripts/generate-types.ts
+++ b/crates/napi/scripts/generate-types.ts
@@ -1,0 +1,264 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { Edit, kind, Lang, parseAsync } from "../index";
+import { Rule } from "../manual";
+import { NodeTypeSchema } from "../types/node-types";
+
+const languagesNodeTypesUrls = {
+  [Lang.JavaScript]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/heads/master/src/node-types.json",
+  [Lang.TypeScript]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-typescript/refs/heads/master/typescript/src/node-types.json",
+  [Lang.Tsx]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-typescript/refs/heads/master/tsx/src/node-types.json",
+  [Lang.Java]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-java/refs/heads/master/src/node-types.json",
+  [Lang.Python]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-python/refs/heads/master/src/node-types.json",
+  [Lang.Rust]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-rust/refs/heads/master/src/node-types.json",
+  [Lang.C]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-c/refs/heads/master/src/node-types.json",
+  [Lang.Cpp]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-cpp/refs/heads/master/src/node-types.json",
+  [Lang.Go]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-go/refs/heads/master/src/node-types.json",
+  [Lang.Html]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-html/refs/heads/master/src/node-types.json",
+  [Lang.Css]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-css/refs/heads/master/src/node-types.json",
+  [Lang.Json]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-json/refs/heads/master/src/node-types.json",
+  [Lang.CSharp]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-c-sharp/refs/heads/master/src/node-types.json",
+  [Lang.Ruby]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-ruby/refs/heads/master/src/node-types.json",
+  [Lang.Php]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-php/refs/heads/master/php/src/node-types.json",
+  [Lang.Elixir]:
+    "https://raw.githubusercontent.com/elixir-lang/tree-sitter-elixir/refs/heads/main/src/node-types.json",
+  [Lang.Kotlin]:
+    "https://raw.githubusercontent.com/fwcd/tree-sitter-kotlin/refs/heads/main/src/node-types.json",
+  [Lang.Swift]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-swift/refs/heads/master/src/node-types.json",
+  [Lang.Haskell]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-haskell/refs/heads/master/src/node-types.json",
+  [Lang.Scala]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-scala/refs/heads/master/src/node-types.json",
+  [Lang.Lua]:
+    "https://raw.githubusercontent.com/tjdevries/tree-sitter-lua/refs/heads/master/src/node-types.json",
+  [Lang.Bash]:
+    "https://raw.githubusercontent.com/tree-sitter/tree-sitter-bash/refs/heads/master/src/node-types.json",
+  [Lang.Yaml]:
+    "https://raw.githubusercontent.com/ikatyang/tree-sitter-yaml/refs/heads/master/src/node-types.json",
+  // Not available for SQL
+};
+
+const dirname = new URL(".", import.meta.url).pathname;
+
+async function generateLangNodeTypes() {
+  for (const [lang, url] of Object.entries(languagesNodeTypesUrls)) {
+    const nodeTypesResponse = await fetch(url);
+    const nodeTypes = (await nodeTypesResponse.json()) as NodeTypeSchema[];
+
+    const nodeTypeMap = Object.fromEntries(
+      nodeTypes.map((node) => [node.type, node])
+    );
+
+    await writeFile(
+      path.join(dirname, "..", "types", `${lang}-node-types.ts`),
+      `type ${lang}NodeTypesMap = ${JSON.stringify(nodeTypeMap, null, 2)};
+
+export default ${lang}NodeTypesMap;
+`
+    );
+  }
+}
+
+async function updateIndexDts() {
+  const indexDtsPath = path.join(dirname, "..", "index.d.ts");
+  const indexDtsSource = await readFile(indexDtsPath, "utf8");
+  const sgRoot = await parseAsync(Lang.TypeScript, indexDtsSource);
+
+  const root = sgRoot.root();
+
+  const createMatchClassMethodRule = (methodName: string): Rule => ({
+    kind: "method_signature",
+    has: {
+      field: "name",
+      regex: `^${methodName}$`,
+    },
+  });
+
+  const createMatchClassDeclarationRule = (className: string): Rule => ({
+    kind: "class_declaration",
+    inside: {
+      kind: "ambient_declaration",
+      inside: {
+        kind: "export_statement",
+      },
+    },
+    has: {
+      field: "name",
+      regex: `^${className}$`,
+    },
+  });
+
+  const createMatchSgReturningFunctionSignatureRule = (
+    namespace: string
+  ): Rule => ({
+    all: [
+      {
+        any: [
+          {
+            kind: "type_annotation",
+            regex: "SgNode",
+            inside: {
+              kind: "required_parameter",
+              inside: {
+                kind: "function_type",
+                stopBy: "end",
+              }
+            },
+          },
+          {
+            kind: "type_annotation",
+            regex: "SgRoot",
+            nthChild: {
+              position: 1,
+              reverse: true,
+            },
+            inside: {
+              kind: "function_signature",
+            },
+          },
+        ],
+      },
+      {
+        inside: {
+          kind: "internal_module",
+          stopBy: "end",
+          has: {
+            field: "name",
+            regex: `^${namespace}$`,
+          },
+        },
+      },
+    ],
+  });
+
+  const sgRootClass = root.find({
+    rule: createMatchClassDeclarationRule("SgRoot"),
+  });
+  const sgRootClassTypeParametersRemovalEdit = sgRootClass!
+    .field("type_parameters")
+    ?.replace("");
+  const sgRootNameEdit = sgRootClass!
+    .field("name")!
+    .replace("SgRoot<M extends NodeTypesMap = NodeTypesMap>");
+
+  const sgNodeClass = root.find({
+    rule: createMatchClassDeclarationRule("SgNode"),
+  });
+
+  const sgNodeClassTypeParametersRemovalEdit = sgNodeClass!
+    .field("type_parameters")
+    ?.replace("");
+  const sgNodeClassNameEdit = sgNodeClass!.field("name")!.replace(`SgNode<
+  M extends NodeTypesMap = NodeTypesMap,
+  T extends keyof M = keyof M
+>`);
+
+  const isMethodEdit = sgNodeClass!
+    .find({
+      rule: createMatchClassMethodRule("is"),
+    })!
+    .replace(`is<K extends T>(kind: K): this is SgNode<M, K> & this`);
+
+  const fieldMethodEdit = sgNodeClass!
+    .find({
+      rule: createMatchClassMethodRule("field"),
+    })!
+    .replace(
+      `field<F extends FieldNames<M[T]>>(name: F): FieldSgNode<M, T, F>`
+    );
+
+  const fieldChildrenMethodEdit = sgNodeClass!
+    .find({
+      rule: createMatchClassMethodRule("fieldChildren"),
+    })!
+    .replace(
+      `fieldChildren<F extends FieldNames<M[T]>>(name: F): Exclude<FieldSgNode<M, T, F>, null>[]`
+    );
+
+  const langLibs = {
+    js: Lang.JavaScript,
+    jsx: Lang.JavaScript,
+    ts: Lang.TypeScript,
+    tsx: Lang.Tsx,
+    css: Lang.Css,
+    html: Lang.Html,
+  };
+
+  const updateLibEdits: Edit[] = [];
+
+  for (const [ns, lang] of Object.entries(langLibs)) {
+    const langNodeTypesMapNodes = root.findAll({
+      rule: createMatchSgReturningFunctionSignatureRule(ns),
+    })!;
+
+    for (const langNodeTypesMap of langNodeTypesMapNodes) {
+      const edit = langNodeTypesMap.replace(
+        langNodeTypesMap
+          ?.text()
+          .replace(/SgRoot|SgNode/g, (match) => `${match}<${lang}NodeTypesMap>`)
+      );
+      updateLibEdits.push(edit);
+    }
+  }
+
+  const typesImportStatement =
+    'import type { FieldNames, FieldSgNode, NodeTypesMap } from "./types/node-types";';
+
+  const importStatements = [typesImportStatement];
+  for (const lang of Object.keys(languagesNodeTypesUrls)) {
+    importStatements.push(
+      `import ${lang}NodeTypesMap from "./types/${lang}-node-types";`
+    );
+  }
+  const exportStatement = `export {\n${Object.keys(languagesNodeTypesUrls)
+    .map((lang) => `  ${lang}NodeTypesMap`)
+    .join(",\n")}\n};`;
+
+  const updatedSource = root.commitEdits(
+    [
+      {
+        startPos: 0,
+        endPos: 0,
+        insertedText: importStatements.join("\n") + "\n",
+      },
+      {
+        startPos: 0,
+        endPos: 0,
+        insertedText: exportStatement + "\n",
+      },
+      sgRootClassTypeParametersRemovalEdit,
+      sgNodeClassTypeParametersRemovalEdit,
+      sgRootNameEdit,
+      sgNodeClassNameEdit,
+      isMethodEdit,
+      fieldMethodEdit,
+      fieldChildrenMethodEdit,
+      ...updateLibEdits,
+    ].filter((edit) => edit !== undefined)
+  );
+
+  await writeFile(indexDtsPath, updatedSource);
+}
+
+async function main() {
+  await generateLangNodeTypes();
+  await updateIndexDts();
+}
+
+void main();

--- a/crates/napi/scripts/rules.ts
+++ b/crates/napi/scripts/rules.ts
@@ -1,0 +1,66 @@
+import { Rule } from "../manual";
+
+export const createMatchClassMethodRule = (methodName: string): Rule => ({
+  kind: "method_signature",
+  has: {
+    field: "name",
+    regex: `^${methodName}$`,
+  },
+});
+
+export const createMatchClassDeclarationRule = (className: string): Rule => ({
+  kind: "class_declaration",
+  inside: {
+    kind: "ambient_declaration",
+    inside: {
+      kind: "export_statement",
+    },
+  },
+  has: {
+    field: "name",
+    regex: `^${className}$`,
+  },
+});
+
+export const createMatchSgReturningFunctionSignatureRule = (
+  namespace: string
+): Rule => ({
+  all: [
+    {
+      any: [
+        {
+          kind: "type_annotation",
+          regex: "SgNode",
+          inside: {
+            kind: "required_parameter",
+            inside: {
+              kind: "function_type",
+              stopBy: "end",
+            },
+          },
+        },
+        {
+          kind: "type_annotation",
+          regex: "SgRoot",
+          nthChild: {
+            position: 1,
+            reverse: true,
+          },
+          inside: {
+            kind: "function_signature",
+          },
+        },
+      ],
+    },
+    {
+      inside: {
+        kind: "internal_module",
+        stopBy: "end",
+        has: {
+          field: "name",
+          regex: `^${namespace}$`,
+        },
+      },
+    },
+  ],
+});

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -75,9 +75,14 @@ impl SgNode {
     self.inner.is_named_leaf()
   }
   /// Returns the string name of the node kind
-  #[napi]
+  #[napi(ts_return_type = "T")]
   pub fn kind(&self) -> String {
     self.inner.kind().to_string()
+  }
+  /// Check if the node is the same kind as the given `kind` string
+  #[napi]
+  pub fn is(&self, kind: String) -> bool {
+    self.inner.kind() == kind
   }
   #[napi]
   pub fn text(&self) -> String {
@@ -158,7 +163,7 @@ impl SgNode {
     let root = self.inner.clone_owner(env)?;
     Ok(root)
   }
-  #[napi]
+  #[napi(ts_return_type = "Array<SgNode<M>>")]
   pub fn children(&self, reference: Reference<SgNode>, env: Env) -> Result<Vec<SgNode>> {
     let children = reference.inner.children().map(NodeMatch::from);
     Self::from_iter_to_vec(&reference, env, children)
@@ -170,7 +175,7 @@ impl SgNode {
     Ok(self.inner.node_id() as u32)
   }
 
-  #[napi]
+  #[napi(ts_return_type = "SgNode<M> | null")]
   pub fn find(
     &self,
     reference: Reference<SgNode>,
@@ -209,7 +214,7 @@ impl SgNode {
     }
   }
 
-  #[napi]
+  #[napi(ts_return_type = "Array<SgNode<M>>")]
   pub fn find_all(
     &self,
     reference: Reference<SgNode>,
@@ -288,7 +293,7 @@ impl SgNode {
     Self::transpose_option(reference, env, node)
   }
 
-  #[napi]
+  #[napi(ts_return_type = "SgNode<M> | null")]
   pub fn child(&self, reference: Reference<SgNode>, env: Env, nth: u32) -> Result<Option<SgNode>> {
     let inner = reference.inner.child(nth as usize).map(NodeMatch::from);
     Self::transpose_option(reference, env, inner)
@@ -371,7 +376,7 @@ pub struct SgRoot(pub(super) AstGrep<JsDoc>, pub(super) String);
 #[napi]
 impl SgRoot {
   /// Returns the root SgNode of the ast-grep instance.
-  #[napi]
+  #[napi(ts_return_type = "SgNode<M>")]
   pub fn root(&self, root_ref: Reference<SgRoot>, env: Env) -> Result<SgNode> {
     let inner = root_ref.share_with(env, |root| Ok(root.0.root().into()))?;
     Ok(SgNode { inner })

--- a/crates/napi/tsconfig.json
+++ b/crates/napi/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2022",
     "strict": true,
     "moduleResolution": "node",
-    "module": "CommonJS",
+    "module": "ES2022",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,

--- a/crates/napi/tsconfig.json
+++ b/crates/napi/tsconfig.json
@@ -1,13 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2018",
     "strict": true,
     "moduleResolution": "node",
-    "module": "ES2022",
+    "module": "CommonJS",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
+  },
+  "ts-node": {
+    "transpileOnly": true
   },
   "include": ["."],
   "exclude": ["node_modules"]

--- a/crates/napi/types/.gitignore
+++ b/crates/napi/types/.gitignore
@@ -1,0 +1,2 @@
+*.ts
+!node-types.ts

--- a/crates/napi/types/node-types.ts
+++ b/crates/napi/types/node-types.ts
@@ -1,0 +1,62 @@
+import { SgNode } from "..";
+
+export type NodeTypeSchema<
+  ParentType extends string = string,
+  FieldTypes extends string = string,
+  ChildTypes extends string = string
+> = {
+  type: ParentType;
+  named: boolean;
+  root?: boolean;
+  subtypes?: NodeTypeSchema<ParentType, FieldTypes, ChildTypes>[];
+  fields?: {
+    [key: string]: {
+      multiple: boolean;
+      required: boolean;
+      types: ReadonlyArray<{ type: FieldTypes; named: boolean }>;
+    };
+  };
+  children?: {
+    multiple: boolean;
+    required: boolean;
+    types: ReadonlyArray<{ type: ChildTypes; named: boolean }>;
+  };
+};
+
+export type NodeTypesMap = Record<string, NodeTypeSchema>;
+
+export type FieldNames<N extends NodeTypeSchema> = N["fields"] extends Record<
+  string,
+  any
+>
+  ? keyof N["fields"]
+  : string;
+
+export type FieldTypeMeta<
+  Map extends NodeTypeSchema,
+  F extends FieldNames<Map>
+> = Map["fields"] extends Record<
+  string,
+  { types: ReadonlyArray<{ type: string }> }
+>
+  ? Map["fields"][F]
+  : {
+      required: false;
+      types: [{ type: string }];
+    };
+
+type GetSafeFieldType<
+  Map extends NodeTypesMap,
+  K extends keyof Map,
+  F extends FieldNames<Map[K]>,
+  M extends FieldTypeMeta<Map[K], F> = FieldTypeMeta<Map[K], F>
+> = M["types"][number]["type"];
+
+export type FieldSgNode<
+  Map extends NodeTypesMap,
+  K extends keyof Map,
+  F extends FieldNames<Map[K]>,
+  M extends FieldTypeMeta<Map[K], F> = FieldTypeMeta<Map[K], F>
+> = M["required"] extends true
+  ? SgNode<Map, GetSafeFieldType<Map, K, F>>
+  : SgNode<Map, GetSafeFieldType<Map, K, F>> | null;

--- a/crates/napi/yarn.lock
+++ b/crates/napi/yarn.lock
@@ -9,126 +9,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@esbuild/aix-ppc64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz#51299374de171dbd80bb7d838e1cfce9af36f353"
-  integrity sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==
-
-"@esbuild/android-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz#58565291a1fe548638adb9c584237449e5e14018"
-  integrity sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==
-
-"@esbuild/android-arm@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.23.1.tgz#5eb8c652d4c82a2421e3395b808e6d9c42c862ee"
-  integrity sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==
-
-"@esbuild/android-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.23.1.tgz#ae19d665d2f06f0f48a6ac9a224b3f672e65d517"
-  integrity sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==
-
-"@esbuild/darwin-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz#05b17f91a87e557b468a9c75e9d85ab10c121b16"
-  integrity sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==
-
-"@esbuild/darwin-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz#c58353b982f4e04f0d022284b8ba2733f5ff0931"
-  integrity sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==
-
-"@esbuild/freebsd-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz#f9220dc65f80f03635e1ef96cfad5da1f446f3bc"
-  integrity sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==
-
-"@esbuild/freebsd-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz#69bd8511fa013b59f0226d1609ac43f7ce489730"
-  integrity sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==
-
-"@esbuild/linux-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz#8050af6d51ddb388c75653ef9871f5ccd8f12383"
-  integrity sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==
-
-"@esbuild/linux-arm@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz#ecaabd1c23b701070484990db9a82f382f99e771"
-  integrity sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==
-
-"@esbuild/linux-ia32@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz#3ed2273214178109741c09bd0687098a0243b333"
-  integrity sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==
-
-"@esbuild/linux-loong64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz#a0fdf440b5485c81b0fbb316b08933d217f5d3ac"
-  integrity sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==
-
-"@esbuild/linux-mips64el@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz#e11a2806346db8375b18f5e104c5a9d4e81807f6"
-  integrity sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==
-
-"@esbuild/linux-ppc64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz#06a2744c5eaf562b1a90937855b4d6cf7c75ec96"
-  integrity sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==
-
-"@esbuild/linux-riscv64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz#65b46a2892fc0d1af4ba342af3fe0fa4a8fe08e7"
-  integrity sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==
-
-"@esbuild/linux-s390x@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz#e71ea18c70c3f604e241d16e4e5ab193a9785d6f"
-  integrity sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==
-
-"@esbuild/linux-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz#d47f97391e80690d4dfe811a2e7d6927ad9eed24"
-  integrity sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==
-
-"@esbuild/netbsd-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz#44e743c9778d57a8ace4b72f3c6b839a3b74a653"
-  integrity sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==
-
-"@esbuild/openbsd-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz#05c5a1faf67b9881834758c69f3e51b7dee015d7"
-  integrity sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==
-
-"@esbuild/openbsd-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz#2e58ae511bacf67d19f9f2dcd9e8c5a93f00c273"
-  integrity sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==
-
-"@esbuild/sunos-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz#adb022b959d18d3389ac70769cef5a03d3abd403"
-  integrity sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==
-
-"@esbuild/win32-arm64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz#84906f50c212b72ec360f48461d43202f4c8b9a2"
-  integrity sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==
-
-"@esbuild/win32-ia32@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz#5e3eacc515820ff729e90d0cb463183128e82fac"
-  integrity sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==
-
-"@esbuild/win32-x64@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz#81fd50d11e2c32b2d6241470e3185b70c7b30699"
-  integrity sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==
-
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -612,36 +492,6 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-esbuild@~0.23.0:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.23.1.tgz#40fdc3f9265ec0beae6f59824ade1bd3d3d2dab8"
-  integrity sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.23.1"
-    "@esbuild/android-arm" "0.23.1"
-    "@esbuild/android-arm64" "0.23.1"
-    "@esbuild/android-x64" "0.23.1"
-    "@esbuild/darwin-arm64" "0.23.1"
-    "@esbuild/darwin-x64" "0.23.1"
-    "@esbuild/freebsd-arm64" "0.23.1"
-    "@esbuild/freebsd-x64" "0.23.1"
-    "@esbuild/linux-arm" "0.23.1"
-    "@esbuild/linux-arm64" "0.23.1"
-    "@esbuild/linux-ia32" "0.23.1"
-    "@esbuild/linux-loong64" "0.23.1"
-    "@esbuild/linux-mips64el" "0.23.1"
-    "@esbuild/linux-ppc64" "0.23.1"
-    "@esbuild/linux-riscv64" "0.23.1"
-    "@esbuild/linux-s390x" "0.23.1"
-    "@esbuild/linux-x64" "0.23.1"
-    "@esbuild/netbsd-x64" "0.23.1"
-    "@esbuild/openbsd-arm64" "0.23.1"
-    "@esbuild/openbsd-x64" "0.23.1"
-    "@esbuild/sunos-x64" "0.23.1"
-    "@esbuild/win32-arm64" "0.23.1"
-    "@esbuild/win32-ia32" "0.23.1"
-    "@esbuild/win32-x64" "0.23.1"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -738,11 +588,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 gauge@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
@@ -767,13 +612,6 @@ get-east-asian-width@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
   integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
-
-get-tsconfig@^4.7.5:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.8.1.tgz#8995eb391ae6e1638d251118c7b56de7eb425471"
-  integrity sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==
-  dependencies:
-    resolve-pkg-maps "^1.0.0"
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -1164,11 +1002,6 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve-pkg-maps@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
-  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
-
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -1239,6 +1072,11 @@ slice-ansi@^5.0.0:
   dependencies:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
+
+smol-toml@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/smol-toml/-/smol-toml-1.3.1.tgz#d9084a9e212142e3cab27ef4e2b8e8ba620bfe15"
+  integrity sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1335,7 +1173,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-ts-node@10.9.2:
+ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -1353,16 +1191,6 @@ ts-node@10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
-
-tsx@^4.19.2:
-  version "4.19.2"
-  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.19.2.tgz#2d7814783440e0ae42354d0417d9c2989a2ae92c"
-  integrity sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==
-  dependencies:
-    esbuild "~0.23.0"
-    get-tsconfig "^4.7.5"
-  optionalDependencies:
-    fsevents "~2.3.3"
 
 type-fest@^0.13.1:
   version "0.13.1"

--- a/crates/napi/yarn.lock
+++ b/crates/napi/yarn.lock
@@ -9,6 +9,126 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@esbuild/aix-ppc64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz#51299374de171dbd80bb7d838e1cfce9af36f353"
+  integrity sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==
+
+"@esbuild/android-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz#58565291a1fe548638adb9c584237449e5e14018"
+  integrity sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==
+
+"@esbuild/android-arm@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.23.1.tgz#5eb8c652d4c82a2421e3395b808e6d9c42c862ee"
+  integrity sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==
+
+"@esbuild/android-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.23.1.tgz#ae19d665d2f06f0f48a6ac9a224b3f672e65d517"
+  integrity sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==
+
+"@esbuild/darwin-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz#05b17f91a87e557b468a9c75e9d85ab10c121b16"
+  integrity sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==
+
+"@esbuild/darwin-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz#c58353b982f4e04f0d022284b8ba2733f5ff0931"
+  integrity sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==
+
+"@esbuild/freebsd-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz#f9220dc65f80f03635e1ef96cfad5da1f446f3bc"
+  integrity sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==
+
+"@esbuild/freebsd-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz#69bd8511fa013b59f0226d1609ac43f7ce489730"
+  integrity sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==
+
+"@esbuild/linux-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz#8050af6d51ddb388c75653ef9871f5ccd8f12383"
+  integrity sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==
+
+"@esbuild/linux-arm@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz#ecaabd1c23b701070484990db9a82f382f99e771"
+  integrity sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==
+
+"@esbuild/linux-ia32@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz#3ed2273214178109741c09bd0687098a0243b333"
+  integrity sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==
+
+"@esbuild/linux-loong64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz#a0fdf440b5485c81b0fbb316b08933d217f5d3ac"
+  integrity sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==
+
+"@esbuild/linux-mips64el@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz#e11a2806346db8375b18f5e104c5a9d4e81807f6"
+  integrity sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==
+
+"@esbuild/linux-ppc64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz#06a2744c5eaf562b1a90937855b4d6cf7c75ec96"
+  integrity sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==
+
+"@esbuild/linux-riscv64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz#65b46a2892fc0d1af4ba342af3fe0fa4a8fe08e7"
+  integrity sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==
+
+"@esbuild/linux-s390x@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz#e71ea18c70c3f604e241d16e4e5ab193a9785d6f"
+  integrity sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==
+
+"@esbuild/linux-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz#d47f97391e80690d4dfe811a2e7d6927ad9eed24"
+  integrity sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==
+
+"@esbuild/netbsd-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz#44e743c9778d57a8ace4b72f3c6b839a3b74a653"
+  integrity sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==
+
+"@esbuild/openbsd-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz#05c5a1faf67b9881834758c69f3e51b7dee015d7"
+  integrity sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==
+
+"@esbuild/openbsd-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz#2e58ae511bacf67d19f9f2dcd9e8c5a93f00c273"
+  integrity sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==
+
+"@esbuild/sunos-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz#adb022b959d18d3389ac70769cef5a03d3abd403"
+  integrity sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==
+
+"@esbuild/win32-arm64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz#84906f50c212b72ec360f48461d43202f4c8b9a2"
+  integrity sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==
+
+"@esbuild/win32-ia32@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz#5e3eacc515820ff729e90d0cb463183128e82fac"
+  integrity sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==
+
+"@esbuild/win32-x64@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz#81fd50d11e2c32b2d6241470e3185b70c7b30699"
+  integrity sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -100,6 +220,13 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@types/node@^22.10.2":
+  version "22.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.2.tgz#a485426e6d1fdafc7b0d4c7b24e2c78182ddabb9"
+  integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
+  dependencies:
+    undici-types "~6.20.0"
 
 "@vercel/nft@^0.27.5":
   version "0.27.5"
@@ -485,6 +612,36 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+esbuild@~0.23.0:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.23.1.tgz#40fdc3f9265ec0beae6f59824ade1bd3d3d2dab8"
+  integrity sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.23.1"
+    "@esbuild/android-arm" "0.23.1"
+    "@esbuild/android-arm64" "0.23.1"
+    "@esbuild/android-x64" "0.23.1"
+    "@esbuild/darwin-arm64" "0.23.1"
+    "@esbuild/darwin-x64" "0.23.1"
+    "@esbuild/freebsd-arm64" "0.23.1"
+    "@esbuild/freebsd-x64" "0.23.1"
+    "@esbuild/linux-arm" "0.23.1"
+    "@esbuild/linux-arm64" "0.23.1"
+    "@esbuild/linux-ia32" "0.23.1"
+    "@esbuild/linux-loong64" "0.23.1"
+    "@esbuild/linux-mips64el" "0.23.1"
+    "@esbuild/linux-ppc64" "0.23.1"
+    "@esbuild/linux-riscv64" "0.23.1"
+    "@esbuild/linux-s390x" "0.23.1"
+    "@esbuild/linux-x64" "0.23.1"
+    "@esbuild/netbsd-x64" "0.23.1"
+    "@esbuild/openbsd-arm64" "0.23.1"
+    "@esbuild/openbsd-x64" "0.23.1"
+    "@esbuild/sunos-x64" "0.23.1"
+    "@esbuild/win32-arm64" "0.23.1"
+    "@esbuild/win32-ia32" "0.23.1"
+    "@esbuild/win32-x64" "0.23.1"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -581,6 +738,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 gauge@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
@@ -605,6 +767,13 @@ get-east-asian-width@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
   integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
+
+get-tsconfig@^4.7.5:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.8.1.tgz#8995eb391ae6e1638d251118c7b56de7eb425471"
+  integrity sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -995,6 +1164,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -1180,6 +1354,16 @@ ts-node@10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+tsx@^4.19.2:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.19.2.tgz#2d7814783440e0ae42354d0417d9c2989a2ae92c"
+  integrity sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==
+  dependencies:
+    esbuild "~0.23.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 type-fest@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
@@ -1189,6 +1373,11 @@ typescript@5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
When using `napi`, I generally don't know what fields and kinds I'm dealing with for each language. I need to use either ast-grep or treesitter playgrounds with some sample code to know what's possible and it's generally not a good DX and might lead to (1) not covering edge cases (2) type errors

I added a script that downloads compiled treesitter node-types from the corresponding repos that's a processed version of the TS grammars that allows us to have some context about the possible kinds and fields.

I created a napi script that post-processes the index.d.ts file. Alternatively, I could introduce some proc-macros in the rust code, but that was way harder to implement and a huge headache and wasn't sure even if it's gonna work. The limitation is basically in napi not support type parameters like having it output `class SgNode<T, M>` instead of `class SgNode`. And also dynamically craft the type parameters with the macro. Happy to hop on a call on Discord to explain in more details.

https://github.com/user-attachments/assets/c7705a91-92c2-4511-be78-b0bf75a4825f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for various programming languages in the API.
	- Introduced new methods for improved type safety in node handling.
	- Added a new script for generating TypeScript node type definitions.
	- New TypeScript type definitions for node schemas to enhance expressiveness.
	- Introduced constants for programming languages and their metadata.

- **Bug Fixes**
	- Updated method signatures for better clarity and type safety.

- **Documentation**
	- Modifications to the `.gitignore` to better manage TypeScript files.

- **Chores**
	- Updated package dependencies and build scripts in `package.json`.
	- Updated TypeScript configuration for faster transpilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->