### PR TITLE
fix: remove unused suppression fields

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ast_grep_config::{
-  from_yaml_string, CombinedScan, PreScan, RuleCollection, RuleConfig, SerializableRule,
-  SerializableRuleConfig, SerializableRuleCore, Severity,
+  from_yaml_string, CombinedScan, PreScan, RuleCollection, RuleConfig, Severity,
 };
 use ast_grep_core::{NodeMatch, StrDoc};
+use ast_grep_language::SupportLang;
 use clap::Args;
 use ignore::WalkParallel;
 
@@ -173,32 +173,11 @@ impl<P: Printer> Worker for ScanWithConfig<P> {
 }
 
 fn unused_suppression_rule_config(overwrite: &RuleOverwrite) -> RuleConfig<SgLang> {
-  let rule: SerializableRule = serde_json::from_str(r#"{"any": []}"#).unwrap();
-  let core = SerializableRuleCore {
-    rule,
-    constraints: None,
-    fix: serde_json::from_str(r#""""#).unwrap(),
-    transform: None,
-    utils: None,
-  };
   let severity = overwrite
     .find("unused-suppression")
     .severity
     .unwrap_or(Severity::Hint);
-  let config = SerializableRuleConfig::<SgLang> {
-    core,
-    id: "unused-suppression".to_string(),
-    severity,
-    files: None,
-    ignores: None,
-    language: "rust".parse().unwrap(),
-    message: "Unused 'ast-grep-ignore' directive.".into(),
-    metadata: None,
-    note: None,
-    rewriters: None,
-    url: None,
-  };
-  RuleConfig::try_from(config, &Default::default()).unwrap()
+  CombinedScan::unused_config(severity, SupportLang::Rust.into())
 }
 
 impl<P: Printer> PathWorker for ScanWithConfig<P> {

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -161,13 +161,6 @@ impl<P: Printer> Worker for ScanWithConfig<P> {
         }
         match_rule_on_file(path, matches, rule, &file_content, &self.printer)?;
       }
-      error_count += print_unused_suppressions(
-        path,
-        scanned.unused_suppressions,
-        &self.unused_suppression_rule,
-        &file_content,
-        &self.printer,
-      )?;
     }
     self.printer.after_print()?;
     self.trace.print()?;
@@ -206,23 +199,6 @@ fn unused_suppression_rule_config(overwrite: &RuleOverwrite) -> RuleConfig<SgLan
     url: None,
   };
   RuleConfig::try_from(config, &Default::default()).unwrap()
-}
-
-fn print_unused_suppressions(
-  path: &Path,
-  matches: Vec<NodeMatch<StrDoc<SgLang>>>,
-  rule_config: &RuleConfig<SgLang>,
-  file_content: &String,
-  printer: &impl Printer,
-) -> Result<usize> {
-  let count = match rule_config.severity {
-    Severity::Error => matches.len(),
-    // skip printing turned-off rule
-    Severity::Off => return Ok(0),
-    _ => 0,
-  };
-  match_rule_on_file(path, matches, rule_config, file_content, printer)?;
-  Ok(count)
 }
 
 impl<P: Printer> PathWorker for ScanWithConfig<P> {

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -161,6 +161,21 @@ fn test_scan_unused_suppression() -> Result<()> {
 }
 
 #[test]
+fn test_scan_unused_suppression_off() -> Result<()> {
+  let dir = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/rule.yml", RULE1),
+    ("test.ts", "None(123) // ast-grep-ignore"),
+  ])?;
+  Command::cargo_bin("sg")?
+    .current_dir(dir.path())
+    .args(["scan", "--off"])
+    .assert()
+    .success();
+  Ok(())
+}
+
+#[test]
 fn test_severity_override() -> Result<()> {
   let dir = setup()?;
   Command::cargo_bin("sg")?

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet};
 pub struct ScanResult<'t, 'r, D: Doc, L: Language> {
   pub diffs: Vec<(&'r RuleConfig<L>, NodeMatch<'t, D>)>,
   pub matches: Vec<(&'r RuleConfig<L>, Vec<NodeMatch<'t, D>>)>,
-  pub unused_suppressions: Vec<NodeMatch<'t, D>>,
 }
 
 /// store the index to the rule and the matched node
@@ -46,11 +45,7 @@ impl<'t, D: Doc> ScanResultInner<'t, D> {
         matches.push((rule, supprs));
       }
     }
-    ScanResult {
-      diffs,
-      matches,
-      unused_suppressions: vec![],
-    }
+    ScanResult { diffs, matches }
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed unused suppression reporting functionality from the scanning process.
	- Simplified scan result structure by eliminating unused suppressions tracking.

- **Changes**
	- Removed `unused_suppressions` field from scan results.
	- Eliminated printing of unused suppression rules during scans.
	- Introduced a new method for configuring unused suppression rules.
	- Enhanced diagnostics generation by adding checks for empty rules.

- **Tests**
	- Added a test for scanning functionality with unused suppression turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->