### PR TITLE
Update README.md with MacOS instructions

### DIFF
--- a/crates/pyo3/README.md
+++ b/crates/pyo3/README.md
@@ -47,6 +47,13 @@ source venv/bin/activate
 pip install maturin[patchelf]
 ```
 
+### MacOS: Install `patchelf` and `maturin`
+
+```shell
+brew install patchelf
+pip install maturin
+```
+
 ### Build bindings
 
 ```shell


### PR DESCRIPTION
The version of patchelf (0.17.2.1) included if installing using `pip install maturin[patchelf]` does not build on MacOS, but `maturin` works OK if you install `patchelf` separately from `brew`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
    - Updated README with MacOS-specific installation instructions for development dependencies
    - Added steps to install `patchelf` and `maturin` for MacOS users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->