### PR TITLE
feat: Support passing rule config to SgNode match methods (`matches`, `has`, `inside`, `follows`, `precedes`)

### DIFF
--- a/crates/napi/__test__/index.spec.ts
+++ b/crates/napi/__test__/index.spec.ts
@@ -435,3 +435,52 @@ test('find node by range', t => {
   const byKind = sg.root().find(js.kind('template_string'))
   t.is(node!.id(), byKind!.id())
 })
+
+test('check if a node matches a rule using pattern', t => {
+  const sg = parse('console.log(123)')
+  const match = sg.root().find({ rule: { kind: 'call_expression' } })
+  t.assert(match!.matches('console.log($$$)'))
+  t.assert(!match!.matches('console.log'))
+})
+
+test('check if a node matches a rule using config', t => {
+  const sg = parse('console.log(123)')
+  const match = sg.root().find('console.log($$$)')
+  t.assert(match!.matches({ rule: { kind: 'call_expression' } }))
+  t.assert(!match!.matches({ rule: { kind: 'identifier' } }))
+})
+
+test('check if a node follows another using pattern', t => {
+  const sg = parse('const a = 1; const b = 2;')
+  const match = sg.root().find('const a = 1')
+  t.assert(match!.follows('const b = 2') === false)
+  t.assert(sg.root().find('const b = 2')!.follows('const a = 1'))
+})
+
+test('check if a node follows another using config', t => {
+  const sg = parse('const a = 1; const b = 2;')
+  const match = sg.root().find('const a = 1')
+  t.assert(match!.follows({ rule: { pattern: 'const b = 2' }}) === false) 
+  t.assert(sg.root().find('const b = 2')!.follows({ rule: { pattern: 'const a = 1' }}))
+})
+
+test('check if a node precedes another using pattern', t => {
+  const sg = parse('const a = 1; const b = 2;')
+  const match = sg.root().find('const a = 1')
+  t.assert(match!.precedes('const b = 2'))
+  t.assert(sg.root().find('const b = 2')!.precedes('const a = 1') === false)
+})
+
+test('check if a node is inside another using pattern', t => {
+  const sg = parse('if (true) { const x = 1; }')
+  const match = sg.root().find('const x = 1')
+  t.assert(match!.inside('if (true) { $$$ }'))
+  t.assert(!match!.inside('function() { $$$ }'))
+})
+
+test('check if a node has another using pattern', t => {
+  const sg = parse('if (true) { const x = 1; }')
+  const match = sg.root().find('if (true) { $$$ }')
+  t.assert(match!.has('const x = 1'))
+  t.assert(!match!.has('const y = 2'))
+})

--- a/crates/napi/__test__/index.spec.ts
+++ b/crates/napi/__test__/index.spec.ts
@@ -440,14 +440,14 @@ test('check if a node matches a rule using pattern', t => {
   const sg = parse('console.log(123)')
   const match = sg.root().find({ rule: { kind: 'call_expression' } })
   t.assert(match!.matches('console.log($$$)'))
-  t.assert(!match!.matches('console.log'))
+  t.assert(match!.matches('console.log') === false)
 })
 
 test('check if a node matches a rule using config', t => {
   const sg = parse('console.log(123)')
   const match = sg.root().find('console.log($$$)')
   t.assert(match!.matches({ rule: { kind: 'call_expression' } }))
-  t.assert(!match!.matches({ rule: { kind: 'identifier' } }))
+  t.assert(match!.matches({ rule: { kind: 'identifier' } }) === false)
 })
 
 test('check if a node follows another using pattern', t => {
@@ -471,16 +471,37 @@ test('check if a node precedes another using pattern', t => {
   t.assert(sg.root().find('const b = 2')!.precedes('const a = 1') === false)
 })
 
+test('check if a node precedes another using config', t => {
+  const sg = parse('const a = 1; const b = 2;')
+  const match = sg.root().find('const a = 1')
+  t.assert(match!.precedes({ rule: { pattern: 'const b = 2' }}))
+  t.assert(sg.root().find('const b = 2')!.precedes({ rule: { pattern: 'const a = 1' }}) === false)
+})
+
 test('check if a node is inside another using pattern', t => {
   const sg = parse('if (true) { const x = 1; }')
   const match = sg.root().find('const x = 1')
   t.assert(match!.inside('if (true) { $$$ }'))
-  t.assert(!match!.inside('function() { $$$ }'))
+  t.assert(match!.inside('function() { $$$ }') === false)
+})
+
+test('check if a node is inside another using config', t => {
+  const sg = parse('if (true) { const x = 1; }')
+  const match = sg.root().find('const x = 1')
+  t.assert(match!.inside({ rule: { pattern: 'if (true) { $$$ }' }}))
+  t.assert(match!.inside({ rule: { pattern: 'function() { $$$ }' }}) === false)
 })
 
 test('check if a node has another using pattern', t => {
   const sg = parse('if (true) { const x = 1; }')
   const match = sg.root().find('if (true) { $$$ }')
   t.assert(match!.has('const x = 1'))
-  t.assert(!match!.has('const y = 2'))
+  t.assert(match!.has('const y = 2') === false)
+})
+
+test('check if a node has another using config', t => {
+  const sg = parse('if (true) { const x = 1; }')
+  const match = sg.root().find('if (true) { $$$ }')
+  t.assert(match!.has({ rule: { pattern: 'const x = 1' }}))
+  t.assert(match!.has({ rule: { pattern: 'const y = 2' }}) === false)
 })

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -97,42 +97,54 @@ impl SgNode {
 #[napi]
 impl SgNode {
   #[napi]
-  pub fn matches(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+  pub fn matches(&self, m: Either3<String, u16, NapiConfig>) -> Result<bool> {
     let lang = *self.inner.lang();
     match m {
-      Either3::A(pattern) => self.inner.matches(Pattern::new(&pattern, lang)),
-      Either3::B(kind) => self.inner.matches(KindMatcher::from_id(kind)),
-      Either3::C(config) => self.inner.matches(config.parse_with(lang).unwrap()),
+      Either3::A(pattern) => Ok(self.inner.matches(Pattern::new(&pattern, lang))),
+      Either3::B(kind) => Ok(self.inner.matches(KindMatcher::from_id(kind))),
+      Either3::C(config) => {
+        let pattern = config.parse_with(lang)?;
+        Ok(self.inner.matches(pattern))
+      }
     }
   }
 
   #[napi]
-  pub fn inside(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+  pub fn inside(&self, m: Either3<String, u16, NapiConfig>) -> Result<bool> {
     let lang = *self.inner.lang();
     match m {
-      Either3::A(pattern) => self.inner.inside(Pattern::new(&pattern, lang)),
-      Either3::B(kind) => self.inner.inside(KindMatcher::from_id(kind)),
-      Either3::C(config) => self.inner.inside(config.parse_with(lang).unwrap()),
+      Either3::A(pattern) => Ok(self.inner.inside(Pattern::new(&pattern, lang))),
+      Either3::B(kind) => Ok(self.inner.inside(KindMatcher::from_id(kind))),
+      Either3::C(config) => {
+        let pattern = config.parse_with(lang)?;
+        Ok(self.inner.inside(pattern))
+      }
     }
   }
 
   #[napi]
-  pub fn has(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+  pub fn has(&self, m: Either3<String, u16, NapiConfig>) -> Result<bool> {
     let lang = *self.inner.lang();
     match m {
-      Either3::A(pattern) => self.inner.has(Pattern::new(&pattern, lang)),
-      Either3::B(kind) => self.inner.has(KindMatcher::from_id(kind)),
-      Either3::C(config) => self.inner.has(config.parse_with(lang).unwrap()),
+      Either3::A(pattern) => Ok(self.inner.has(Pattern::new(&pattern, lang))),
+      Either3::B(kind) => Ok(self.inner.has(KindMatcher::from_id(kind))),
+      Either3::C(config) => {
+        let pattern = config.parse_with(lang)?;
+        Ok(self.inner.has(pattern))
+      }
     }
   }
 
   #[napi]
-  pub fn precedes(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+  pub fn precedes(&self, m: Either3<String, u16, NapiConfig>) -> Result<bool> {
     let lang = *self.inner.lang();
     match m {
-      Either3::A(pattern) => self.inner.precedes(Pattern::new(&pattern, lang)),
-      Either3::B(kind) => self.inner.precedes(KindMatcher::from_id(kind)),
-      Either3::C(config) => self.inner.precedes(config.parse_with(lang).unwrap()),
+      Either3::A(pattern) => Ok(self.inner.precedes(Pattern::new(&pattern, lang))),
+      Either3::B(kind) => Ok(self.inner.precedes(KindMatcher::from_id(kind))),
+      Either3::C(config) => {
+        let pattern = config.parse_with(lang)?;
+        Ok(self.inner.precedes(pattern))
+      }
     }
   }
 

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -1,4 +1,4 @@
-use ast_grep_core::{matcher::KindMatcher, AstGrep, NodeMatch, Pattern, Position};
+use ast_grep_core::{matcher::KindMatcher, AstGrep, Matcher, NodeMatch, Pattern, Position};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -97,28 +97,53 @@ impl SgNode {
 #[napi]
 impl SgNode {
   #[napi]
-  pub fn matches(&self, m: String) -> bool {
-    self.inner.matches(&*m)
+  pub fn matches(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+    let lang = *self.inner.lang();
+    match m {
+      Either3::A(pattern) => self.inner.matches(Pattern::new(&pattern, lang)),
+      Either3::B(kind) => self.inner.matches(KindMatcher::from_id(kind)),
+      Either3::C(config) => self.inner.matches(config.parse_with(lang).unwrap()),
+    }
   }
 
   #[napi]
-  pub fn inside(&self, m: String) -> bool {
-    self.inner.inside(&*m)
+  pub fn inside(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+    let lang = *self.inner.lang();
+    match m {
+      Either3::A(pattern) => self.inner.inside(Pattern::new(&pattern, lang)),
+      Either3::B(kind) => self.inner.inside(KindMatcher::from_id(kind)),
+      Either3::C(config) => self.inner.inside(config.parse_with(lang).unwrap()),
+    }
   }
 
   #[napi]
-  pub fn has(&self, m: String) -> bool {
-    self.inner.has(&*m)
+  pub fn has(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+    let lang = *self.inner.lang();
+    match m {
+      Either3::A(pattern) => self.inner.has(Pattern::new(&pattern, lang)),
+      Either3::B(kind) => self.inner.has(KindMatcher::from_id(kind)),
+      Either3::C(config) => self.inner.has(config.parse_with(lang).unwrap()),
+    }
   }
 
   #[napi]
-  pub fn precedes(&self, m: String) -> bool {
-    self.inner.precedes(&*m)
+  pub fn precedes(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+    let lang = *self.inner.lang();
+    match m {
+      Either3::A(pattern) => self.inner.precedes(Pattern::new(&pattern, lang)),
+      Either3::B(kind) => self.inner.precedes(KindMatcher::from_id(kind)),
+      Either3::C(config) => self.inner.precedes(config.parse_with(lang).unwrap()),
+    }
   }
 
   #[napi]
-  pub fn follows(&self, m: String) -> bool {
-    self.inner.follows(&*m)
+  pub fn follows(&self, m: Either3<String, u16, NapiConfig>) -> bool {
+    let lang = *self.inner.lang();
+    match m {
+      Either3::A(pattern) => self.inner.follows(Pattern::new(&pattern, lang)),
+      Either3::B(kind) => self.inner.follows(KindMatcher::from_id(kind)),
+      Either3::C(config) => self.inner.follows(config.parse_with(lang).unwrap()),
+    }
   }
 
   #[napi]

--- a/crates/napi/types/sgnode.d.ts
+++ b/crates/napi/types/sgnode.d.ts
@@ -46,11 +46,11 @@ export declare class SgNode<
   isNamed(): boolean
   isNamedLeaf(): boolean
   text(): string
-  matches(m: string): boolean
-  inside(m: string): boolean
-  has(m: string): boolean
-  precedes(m: string): boolean
-  follows(m: string): boolean
+  matches(m: string | number | NapiConfig<M>): boolean
+  inside(m: string | number | NapiConfig<M>): boolean
+  has(m: string | number | NapiConfig<M>): boolean
+  precedes(m: string | number | NapiConfig<M>): boolean
+  follows(m: string | number | NapiConfig<M>): boolean
   /** Returns the string name of the node kind */
   kind(): T
   readonly kindToRefine: T

--- a/crates/pyo3/tests/test_simple.py
+++ b/crates/pyo3/tests/test_simple.py
@@ -1,4 +1,4 @@
-from ast_grep_py import SgRoot
+from ast_grep_py import SgRoot, Rule
 
 source = """
 function test() {
@@ -49,6 +49,13 @@ def test_matches():
     assert not node.matches(kind="number")
     assert node.matches(pattern="let a = 123")
     assert not node.matches(pattern="let b = 456")
+    assert node.matches(has=Rule(
+        kind="variable_declarator",
+        has=Rule(
+            kind="number",
+            pattern="123"
+        )
+    ))
 
 def test_inside():
     node = root.find(pattern="let $A = $B")


### PR DESCRIPTION
The PyO3 API supports passing Rule as the argument to `matches`, `has`, `inside`, `follows`, `precedes` methods, but the NAPI API doesn't. I have a use case where I have the SgNode instances, and I need to check if it matches a RuleConfig and checking with just the pattern string isn't sufficient for this case.

This also makes the PyO3 and the NAPI APIs more consistent in terms of functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added comprehensive test cases for node matching and relationship functionalities.
	- Enhanced test coverage for parsing and node relationship validation.

- **New Features**
	- Expanded method signatures to support more flexible node matching with multiple argument types.
	- Introduced new assertions in tests to validate node structures against defined rules.

- **Improvements**
	- Increased flexibility in node matching and relationship detection.
	- Improved error handling in node-related methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->