### PR TITLE
chore: Remove unused `Matcher` import

### DIFF
--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -1,4 +1,4 @@
-use ast_grep_core::{matcher::KindMatcher, AstGrep, Matcher, NodeMatch, Pattern, Position};
+use ast_grep_core::{matcher::KindMatcher, AstGrep, NodeMatch, Pattern, Position};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 


### PR DESCRIPTION
Sorry for the oversight in the previous PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed an unused import in the source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->