### PR TITLE
feat: support `cargo binstall`

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -54,7 +54,7 @@ assert_cmd = "2.0.14"
 predicates = "3.1.0"
 tempfile = "3.10.1"
 
-
+# Support cargo bininstall, https://github.com/ast-grep/ast-grep/issues/1742
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/app-{ target }{ archive-suffix }"
 bin-dir = "app-{ target }/{ bin }{ binary-ext }"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -53,3 +53,9 @@ clap_complete = "4.5.2"
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 tempfile = "3.10.1"
+
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/app-{ target }{ archive-suffix }"
+bin-dir = "app-{ target }/{ bin }{ binary-ext }"
+disabled-strategies = ["quick-install"]


### PR DESCRIPTION
After merge `cargo binstall ast-grep` should be able to download binaries from github,
obviously I couldn't test this yet because changes are needed in master, instead one can override the manifest with changes in current branch and use `cargo binstall --manifest-path . --force ast-grep` to test this branch.

Closes #1742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package metadata for improved binary installation configuration
	- Added specific installation settings for package distribution
	- Refined package configuration to optimize download and installation processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->