### PR TITLE
chore(readme): cargo binstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Try the [online playground](https://ast-grep.github.io/playground.html) for a ta
 See more screenshots on the [website](https://ast-grep.github.io/).
 
 ## Installation
-You can install it from [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [pip](https://pypi.org/), [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html), [homebrew](https://brew.sh/), [scoop](https://scoop.sh/) or [MacPorts](https://www.macports.org)!
+You can install it from [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [pip](https://pypi.org/), [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html),  [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), [homebrew](https://brew.sh/), [scoop](https://scoop.sh/) or [MacPorts](https://www.macports.org)!
 
 ```bash
 npm install --global @ast-grep/cli
 pip install ast-grep-cli
 cargo install ast-grep --locked
+cargo binstall ast-grep
 
 # install via homebrew, thank @henryhchchc
 brew install ast-grep


### PR DESCRIPTION
After #1744 was merged `cargo binstall ast-grep` works as expected and artifacts are downloaded instead of compiling from source.

I think you can now safely add it to the readme.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with an additional installation method for `ast-grep` using `cargo-binstall`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->