### PR TITLE
chore: improve types by inferring type map from passed lang

### DIFF
--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -46,6 +46,7 @@
     "build:debug": "napi build --no-const-enum --dts ignore.d.ts --platform",
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "pretest": "ts-node scripts/generateTypes.ts --test-only",
+    "posttest": "ts-node scripts/cleanup.ts",
     "test": "tsc --noEmit && ava",
     "version": "napi version",
     "lint": "biome lint --fix && biome format --write",

--- a/crates/napi/scripts/cleanup.ts
+++ b/crates/napi/scripts/cleanup.ts
@@ -1,0 +1,45 @@
+import { readdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const root = path.resolve(__dirname, '..')
+const dirs = {
+  root,
+  types: path.join(root, 'types'),
+  lang: path.join(root, 'lang'),
+}
+
+async function cleanup() {
+  try {
+    const files = await readdir(dirs.lang)
+
+    await Promise.all(
+      files
+        .filter(file => file.endsWith('.d.ts'))
+        .map(async file => {
+          const filePath = path.join(dirs.lang, file)
+          await unlink(filePath)
+          console.log(`Deleted: ${filePath}`)
+        }),
+    )
+
+    const existingTypesSource = await readFile(
+      path.join(dirs.types, 'lang.d.ts'),
+      'utf8',
+    )
+
+    const newSource = existingTypesSource.replace(
+      /export type LanguageNodeTypes = \{[^{}]*\}/,
+      'export type LanguageNodeTypes = Record<never, never>',
+    )
+
+    await writeFile(path.join(dirs.types, 'lang.d.ts'), newSource)
+  } catch (e) {
+    console.error('Error during cleanup:', e)
+    throw e
+  }
+}
+
+cleanup().catch(error => {
+  console.error('Error:', error)
+  process.exit(1)
+})

--- a/crates/napi/types/api.d.ts
+++ b/crates/napi/types/api.d.ts
@@ -1,6 +1,6 @@
 import type { SgNode, SgRoot } from './sgnode'
 import type { NapiConfig, FindConfig, FileOption } from './config'
-import type { NapiLang } from './lang'
+import type { NapiLang, LanguageNodeTypes } from './lang'
 import type { NamedKinds, TypesMap } from './staticTypes'
 
 export declare function parseFiles<M extends TypesMap>(
@@ -8,10 +8,10 @@ export declare function parseFiles<M extends TypesMap>(
   callback: (err: null | Error, result: SgRoot<M>) => void,
 ): Promise<number>
 /** Parse a string to an ast-grep instance */
-export declare function parse<M extends TypesMap>(
-  lang: NapiLang,
+export declare function parse<M extends TypesMap, L extends NapiLang>(
+  lang: L,
   src: string,
-): SgRoot<M>
+): SgRoot<L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M>
 /**
  * Parse a string to an ast-grep instance asynchronously in threads.
  * It utilize multiple CPU cores when **concurrent processing sources**.
@@ -19,28 +19,39 @@ export declare function parse<M extends TypesMap>(
  * Please refer to libuv doc, nodejs' underlying runtime
  * for its default behavior and performance tuning tricks.
  */
-export declare function parseAsync<M extends TypesMap>(
-  lang: NapiLang,
+export declare function parseAsync<M extends TypesMap, L extends NapiLang>(
+  lang: L,
   src: string,
-): Promise<SgRoot<M>>
+): Promise<SgRoot<L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M>>
 /** Get the `kind` number from its string name. */
-export declare function kind<M extends TypesMap>(
-  lang: NapiLang,
-  kindName: NamedKinds<M>,
+export declare function kind<M extends TypesMap, L extends NapiLang>(
+  lang: L,
+  kindName: NamedKinds<
+    L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M
+  >,
 ): number
 /** Compile a string to ast-grep Pattern. */
-export declare function pattern<M extends TypesMap>(
-  lang: NapiLang,
+export declare function pattern<M extends TypesMap, L extends NapiLang>(
+  lang: L,
   pattern: string,
-): NapiConfig<M>
+): Promise<
+  NapiConfig<L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M>
+>
 /**
  * Discover and parse multiple files in Rust.
  * `lang` specifies the language.
  * `config` specifies the file path and matcher.
  * `callback` will receive matching nodes found in a file.
  */
-export declare function findInFiles<M extends TypesMap>(
-  lang: NapiLang,
-  config: FindConfig<M>,
-  callback: (err: null | Error, result: SgNode<M>[]) => void,
+export declare function findInFiles<M extends TypesMap, L extends NapiLang>(
+  lang: L,
+  config: FindConfig<
+    L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M
+  >,
+  callback: (
+    err: null | Error,
+    result: SgNode<
+      L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M
+    >[],
+  ) => void,
 ): Promise<number>

--- a/crates/napi/types/api.d.ts
+++ b/crates/napi/types/api.d.ts
@@ -1,6 +1,6 @@
 import type { SgNode, SgRoot } from './sgnode'
 import type { NapiConfig, FindConfig, FileOption } from './config'
-import type { NapiLang, LanguageNodeTypes } from './lang'
+import type { NapiLang, LanguageNodeTypes, CustomLang } from './lang'
 import type { NamedKinds, TypesMap } from './staticTypes'
 
 export declare function parseFiles<M extends TypesMap>(
@@ -8,7 +8,10 @@ export declare function parseFiles<M extends TypesMap>(
   callback: (err: null | Error, result: SgRoot<M>) => void,
 ): Promise<number>
 /** Parse a string to an ast-grep instance */
-export declare function parse<M extends TypesMap, L extends NapiLang>(
+export declare function parse<
+  M extends TypesMap,
+  L extends NapiLang = CustomLang,
+>(
   lang: L,
   src: string,
 ): SgRoot<L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M>
@@ -19,19 +22,28 @@ export declare function parse<M extends TypesMap, L extends NapiLang>(
  * Please refer to libuv doc, nodejs' underlying runtime
  * for its default behavior and performance tuning tricks.
  */
-export declare function parseAsync<M extends TypesMap, L extends NapiLang>(
+export declare function parseAsync<
+  M extends TypesMap,
+  L extends NapiLang = CustomLang,
+>(
   lang: L,
   src: string,
 ): Promise<SgRoot<L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M>>
 /** Get the `kind` number from its string name. */
-export declare function kind<M extends TypesMap, L extends NapiLang>(
+export declare function kind<
+  M extends TypesMap,
+  L extends NapiLang = CustomLang,
+>(
   lang: L,
   kindName: NamedKinds<
     L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M
   >,
 ): number
 /** Compile a string to ast-grep Pattern. */
-export declare function pattern<M extends TypesMap, L extends NapiLang>(
+export declare function pattern<
+  M extends TypesMap,
+  L extends NapiLang = CustomLang,
+>(
   lang: L,
   pattern: string,
 ): Promise<
@@ -43,7 +55,10 @@ export declare function pattern<M extends TypesMap, L extends NapiLang>(
  * `config` specifies the file path and matcher.
  * `callback` will receive matching nodes found in a file.
  */
-export declare function findInFiles<M extends TypesMap, L extends NapiLang>(
+export declare function findInFiles<
+  M extends TypesMap,
+  L extends NapiLang = CustomLang,
+>(
   lang: L,
   config: FindConfig<
     L extends keyof LanguageNodeTypes ? LanguageNodeTypes[L] : M

--- a/crates/napi/types/lang.d.ts
+++ b/crates/napi/types/lang.d.ts
@@ -1,3 +1,5 @@
+export type LanguageNodeTypes = Record<never, never>
+
 export enum Lang {
   Html = 'Html',
   JavaScript = 'JavaScript',


### PR DESCRIPTION
### Changes

- Added a stub type to the codebase that gets transformed into a mapper type after typegen phase to support inferring types from lang param in API's generic functions but at the same time keep the codebase functional when the node types are not available
- Added cleanup `posttest` script that cleans up changes after running typegen inside test

I really wanted to do the changes in `crates/napi/scripts/generateTypes.ts` using `ast-grep` itself, but I assumed that binary could be not available while running this script, so instead I did it with native TS.

The solution is a bit hacky and potentially difficult to maintain, but I'd argue that typegen is pretty hacky in itself anyways. I tried to keep the changes as minimal as possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced type support for language parsing with more flexible type handling
  - Added new script for cleaning up TypeScript declaration files

- **Tests**
  - Added new test case for validating TypeScript language node type parsing

- **Chores**
  - Updated type declarations and function signatures to improve type safety
  - Restructured directory path management in type generation scripts

These updates improve the library's type system and provide more robust language parsing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->