### PR TITLE
fix: `cargo test --profile release`

### DIFF
--- a/crates/cli/src/verify/test_case.rs
+++ b/crates/cli/src/verify/test_case.rs
@@ -187,6 +187,7 @@ mod tests {
 
   #[test]
   #[should_panic]
+  #[cfg(debug_assertions)]
   fn test_unmatching_id() {
     let rule_config = get_rule_config("pattern: let x = $A");
     let test_case = TestCase {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test case verification with debug-mode specific panic handling for unmatching test case IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Before:

```
$ cargo test --profile release --package ast-grep --lib -- verify::test_case::tests::test_unmatching_id --exact --show-output 
    Finished `release` profile [optimized] target(s) in 4m 15s
     Running unittests src/lib.rs (target/release/deps/ast_grep-be9c87dda6ebfebd)

running 1 test
test verify::test_case::tests::test_unmatching_id - should panic ... FAILED

successes:

successes:

failures:

---- verify::test_case::tests::test_unmatching_id stdout ----
note: test did not panic as expected

failures:
    verify::test_case::tests::test_unmatching_id

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 90 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p ast-grep --lib`
```

After
```
$ cargo test --profile release --package ast-grep --lib -- verify::test_case::tests::test_unmatching_id --exact --show-output
    Buil    Finished `release` profile [optimized] target(s) in 2m 55s
     Running unittests src/lib.rs (target/release/deps/ast_grep-be9c87dda6ebfebd)

running 0 tests

successes:

successes:

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 90 filtered out; finished in 0.00s
```