### PR TITLE
PoC: Read files with specified encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "clap_complete",
  "codespan-reporting",
  "crossterm 0.28.1",
+ "encoding_rs",
  "ignore",
  "inquire",
  "predicates",
@@ -667,6 +668,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ atty = "0.2.14"
 clap = { version = "4.5.4", features = ["derive"] }
 codespan-reporting = "0.11.1"
 crossterm = "0.28.0"
+encoding_rs = "0.8.34"
 ignore.workspace = true
 regex.workspace = true
 inquire = "0.7.5"

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -216,15 +216,16 @@ impl PathWorker for RunWithInferredLang {
     let lang = SgLang::from_path(path)?;
     self.trace.print_file(path, lang).ok()?;
     let matcher = self.arg.build_pattern(lang).ok()?;
+    let encoding = self.arg.input.encoding;
     // match sub region
     if let Some(sub_langs) = lang.injectable_sg_langs() {
       let matchers = sub_langs.filter_map(|l| {
         let pattern = self.arg.build_pattern(l).ok()?;
         Some((l, pattern))
       });
-      filter_file_pattern(path, lang, Some(matcher), matchers)
+      filter_file_pattern(path, lang, Some(matcher), matchers, encoding)
     } else {
-      filter_file_pattern(path, lang, Some(matcher), std::iter::empty())
+      filter_file_pattern(path, lang, Some(matcher), std::iter::empty(), encoding)
     }
   }
 }
@@ -290,10 +291,17 @@ impl PathWorker for RunWithSpecificLang {
     let lang = arg.lang.expect("must present");
     let path_lang = SgLang::from_path(path)?;
     self.stats.print_file(path, path_lang).ok()?;
+    let encoding = arg.input.encoding;
     let ret = if path_lang == lang {
-      filter_file_pattern(path, lang, Some(pattern), std::iter::empty())?
+      filter_file_pattern(path, lang, Some(pattern), std::iter::empty(), encoding)?
     } else {
-      filter_file_pattern(path, path_lang, None, std::iter::once((lang, pattern)))?
+      filter_file_pattern(
+        path,
+        path_lang,
+        None,
+        std::iter::once((lang, pattern)),
+        encoding,
+      )?
     };
     Some(ret.into_iter().map(|n| n.0).collect())
   }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -210,7 +210,8 @@ impl PathWorker for ScanWithConfig {
     self.arg.input.walk_langs(langs.into_iter())
   }
   fn produce_item(&self, path: &Path) -> Option<Vec<Self::Item>> {
-    filter_file_interactive(path, &self.configs, &self.trace)
+    let encoding = self.arg.input.encoding;
+    filter_file_interactive(path, &self.configs, &self.trace, encoding)
   }
 }
 

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -5,6 +5,7 @@ use crate::utils::Granularity;
 
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
+use encoding_rs::Encoding;
 use ignore::{
   overrides::{Override, OverrideBuilder},
   WalkBuilder, WalkParallel,
@@ -59,6 +60,15 @@ pub struct InputArgs {
   /// heuristics.
   #[clap(short = 'j', long, default_value = "0", value_name = "NUM")]
   pub threads: usize,
+
+  /// Treat files as encoded with this encoding
+  #[clap(long, default_value = "UTF-8", value_parser = parse_encoding)]
+  pub encoding: &'static Encoding,
+}
+
+fn parse_encoding(encoding_label: &str) -> Result<&'static Encoding, String> {
+  Encoding::for_label(encoding_label.as_bytes())
+    .ok_or_else(|| format!("Unsupported encoding: {}", encoding_label))
 }
 
 impl InputArgs {


### PR DESCRIPTION
As discussed in issue #1465 I have implemented an initial version where you can specify encoding as command line parameter. Let me know if this is good enough or if it needs to be improved. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying file encoding when processing files
  - Introduced ability to read files with custom character encodings

- **Improvements**
  - Enhanced file reading functionality to handle different encoding formats
  - Added encoding validation and parsing mechanisms

- **Dependencies**
  - Added `encoding_rs` library version 0.8.34 to project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->