### PR TITLE
[PoC] feat: PoC for supertype matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
  "similar",
  "tempfile",
  "tokio",
- "tree-sitter-facade-sg",
+ "tree-sitter-facade-sg-codemod",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-typescript-codemod",
 ]
 
 [[package]]
@@ -165,8 +165,8 @@ dependencies = [
  "bit-set",
  "regex",
  "thiserror",
- "tree-sitter-facade-sg",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-facade-sg-codemod",
+ "tree-sitter-typescript-codemod",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-swift",
- "tree-sitter-typescript 0.23.2",
+ "tree-sitter-typescript",
  "tree-sitter-yaml",
 ]
 
@@ -240,7 +240,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "serde_json",
- "tree-sitter-facade-sg",
+ "tree-sitter-facade-sg-codemod",
 ]
 
 [[package]]
@@ -385,9 +385,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
 dependencies = [
  "shlex",
 ]
@@ -990,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1900,13 +1900,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67baf55e7e1b6806063b1e51041069c90afff16afcbbccd278d899f9d84bca4"
+checksum = "1a802c93485fb6781d27e27cb5927f6b00ff8d26b56c70af87267be7e99def97"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
@@ -1972,17 +1973,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-facade-sg"
-version = "0.24.5"
+name = "tree-sitter-facade-sg-codemod"
+version = "0.25.0-codemod.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195ab85ddd7df7ddac5b2e397ec6264816ae640346013002ceccf0f9b3578f1"
+checksum = "005f585c281b7d653eb465df3fd011c8c6e880b6453480a3bb5b1b3893d2d515"
 dependencies = [
  "js-sys",
  "tree-sitter",
  "tree-sitter-language",
  "wasm-bindgen",
  "web-sys",
- "web-tree-sitter-sg",
+ "web-tree-sitter-sg-codemod",
 ]
 
 [[package]]
@@ -2133,19 +2134,19 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript-codemod"
+version = "0.25.0-codemod.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e301b17f9159e7c3e0d0ab0ff5f290f21e0f6cc12916a2c132c194c6de42b0b1"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -2335,10 +2336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-tree-sitter-sg"
-version = "0.24.5"
+name = "web-tree-sitter-sg-codemod"
+version = "0.25.0-codemod.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cf7d34b16550f076d75b4a5d4673f1a9692f79787d040e3ac7ddb04e5c48a0"
+checksum = "46ca5bd700962a2e1a631b0244068d1a33b74682c7a7307379d78ab7b4a4e8a7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
-tree-sitter = { version = "0.24.5", package = "tree-sitter-facade-sg" }
+tree-sitter = { version = "0.25.0-codemod.2", package = "tree-sitter-facade-sg-codemod" }
 thiserror = "2.0.0"
 schemars = "0.8.17"
 anyhow = "1.0.82"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,4 +26,4 @@ thiserror.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = { package = "tree-sitter-typescript-codemod", version = "0.25.0-codemod.1" }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
       Some(TypeScript::Tsx)
     }
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,4 +23,4 @@ tree-sitter.workspace = true
 default = ["regex"]
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = { package = "tree-sitter-typescript-codemod", version = "0.25.0-codemod.1"}

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -86,7 +86,7 @@ mod test {
   pub struct Tsx;
   impl Language for Tsx {
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 }

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -8,6 +8,7 @@
 mod kind;
 mod node_match;
 mod pattern;
+mod supertype;
 #[cfg(feature = "regex")]
 mod text;
 
@@ -21,6 +22,7 @@ use std::borrow::Cow;
 pub use kind::{KindMatcher, KindMatcherError};
 pub use node_match::NodeMatch;
 pub use pattern::{Pattern, PatternError, PatternNode};
+pub use supertype::{SupertypeMatcher, SupertypeMatcherError};
 #[cfg(feature = "regex")]
 pub use text::{RegexMatcher, RegexMatcherError};
 

--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -30,10 +30,14 @@ pub struct KindMatcher<L: Language> {
 
 impl<L: Language> KindMatcher<L> {
   pub fn new(node_kind: &str, lang: L) -> Self {
+    let mut kind = lang
+      .get_ts_language()
+      .id_for_node_kind(node_kind, /*named*/ true);
+    if lang.get_ts_language().node_kind_is_supertype(kind) {
+      kind = 0;
+    }
     Self {
-      kind: lang
-        .get_ts_language()
-        .id_for_node_kind(node_kind, /*named*/ true),
+      kind,
       lang: PhantomData,
     }
   }

--- a/crates/core/src/matcher/supertype.rs
+++ b/crates/core/src/matcher/supertype.rs
@@ -1,0 +1,141 @@
+use super::Matcher;
+
+use crate::meta_var::MetaVarEnv;
+use crate::node::KindId;
+use crate::{Doc, Language, Node};
+
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+use bit_set::BitSet;
+use thiserror::Error;
+
+const TS_BUILTIN_SYM_END: KindId = 0;
+
+#[derive(Debug, Error)]
+pub enum SupertypeMatcherError {
+  #[error("Kind `{0}` is invalid.")]
+  InvalidKindName(String),
+}
+
+#[derive(Clone)]
+pub struct SupertypeMatcher<L: Language> {
+  supertype: KindId,
+  subtypes: BitSet,
+  lang: PhantomData<L>,
+}
+
+impl<L: Language> SupertypeMatcher<L> {
+  pub fn new(supertype_kind: &str, lang: L) -> Self {
+    let mut supertype_kind = lang
+      .get_ts_language()
+      .id_for_node_kind(supertype_kind, /*named*/ true);
+    if !lang
+      .get_ts_language()
+      .node_kind_is_supertype(supertype_kind)
+    {
+      supertype_kind = 0;
+    }
+    Self::from_id(supertype_kind, lang)
+  }
+
+  pub fn try_new(supertype_kind: &str, lang: L) -> Result<Self, SupertypeMatcherError> {
+    let s = Self::new(supertype_kind, lang);
+    if s.is_invalid() {
+      Err(SupertypeMatcherError::InvalidKindName(
+        supertype_kind.into(),
+      ))
+    } else {
+      Ok(s)
+    }
+  }
+
+  pub fn from_id(supertype: KindId, lang: L) -> Self {
+    let mut subtypes = BitSet::new();
+    for kind in lang.get_ts_language().subtypes_for_supertype(supertype) {
+      subtypes.insert(kind as usize);
+    }
+    Self {
+      supertype,
+      subtypes,
+      lang: PhantomData,
+    }
+  }
+
+  /// Whether the kind matcher contains undefined tree-sitter kind.
+  pub fn is_invalid(&self) -> bool {
+    self.supertype == TS_BUILTIN_SYM_END
+  }
+}
+
+impl<L: Language> Matcher<L> for SupertypeMatcher<L> {
+  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+    &self,
+    node: Node<'tree, D>,
+    _env: &mut Cow<MetaVarEnv<'tree, D>>,
+  ) -> Option<Node<'tree, D>> {
+    if self.subtypes.contains(node.kind_id() as usize) {
+      Some(node)
+    } else {
+      None
+    }
+  }
+
+  fn potential_kinds(&self) -> Option<BitSet> {
+    Some(self.subtypes.clone())
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::language::Tsx;
+  use crate::matcher::KindMatcher;
+  use crate::{Root, StrDoc};
+
+  fn pattern_node(s: &str) -> Root<StrDoc<Tsx>> {
+    Root::new(s, Tsx)
+  }
+  #[test]
+  fn test_supertype_match() {
+    let supertype_kind = "declaration";
+    let cand = pattern_node("class A { a = 123 }");
+    let cand = cand.root();
+    let pattern = SupertypeMatcher::new(supertype_kind, Tsx);
+    assert!(
+      pattern.find_node(cand.clone()).is_some(),
+      "goal: {}, candidate: {}",
+      supertype_kind,
+      cand.to_sexp(),
+    );
+  }
+
+  #[test]
+  fn test_supertype_non_match() {
+    let kind = "number";
+    let cand = pattern_node("const a = 123;");
+    let cand = cand.root();
+    let kind_pattern = KindMatcher::new(kind, Tsx);
+    let cand = cand.find(kind_pattern).unwrap().get_node().clone();
+    let supertype_kind = "declaration";
+    let pattern = SupertypeMatcher::new(supertype_kind, Tsx);
+
+    assert!(
+      pattern.find_node(cand.clone()).is_none(),
+      "goal: {}, candidate: {}",
+      kind,
+      cand.to_sexp(),
+    );
+  }
+
+  #[test]
+  fn test_kind_potential_kinds() {
+    let kind = "declaration";
+    let matcher = SupertypeMatcher::new(kind, Tsx);
+    let potential_kinds = matcher
+      .potential_kinds()
+      .expect("should have potential kinds");
+    // tsx's declaration should have 14 potential kinds
+    assert_eq!(potential_kinds.len(), 14);
+  }
+}

--- a/crates/dynamic/Cargo.toml
+++ b/crates/dynamic/Cargo.toml
@@ -17,7 +17,7 @@ ignore.workspace = true
 libloading = "0.8.3"
 serde.workspace = true
 thiserror.workspace = true
-tree-sitter-native = { version = "0.24.4", package = "tree-sitter" }
+tree-sitter-native = { version = "0.25.1", package = "tree-sitter" }
 
 [dev-dependencies]
 serde_yaml.workspace = true


### PR DESCRIPTION
Tree-sitter recently added APIs for getting supertype info. Currently, if you want to match all expressions, you need to use an `any` rule for each of the expression types.

```yaml
any:
  - kind: call_expression
  -  kind: assignment_expression
  - ...
```

With supertypes, you can simply do:

```yaml
supertype: expression
```

which will match all expressions.

Also, currently, ast-grep accepts super types as kinds, but it never matches any nodes. Meaning that,

```yaml
kind: expression
```

doesn't produce an invalid_kind error, yet it doesn't match anything.

## 🚫 NOTE

- This change, requires updates in the facade crate to upgrade tree-sitter to the latest version and expose these nodes.
- It also requires all the language parsers to be rebuilt and regenerated using the latest version of `tree-sitter-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced rule matching now allows for specifying node supertypes, providing users with more expressive criteria for pattern detection.
  
- **Chores**
  - Upgraded core dependencies, including updates to `tree-sitter` and `tree-sitter-typescript`, to bolster overall stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->