### PR TITLE
[WIP] Remove tree sitter wasm facade and compile ast-grep to WASM with an API almost identical to the napi one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
 name = "ast-grep-wasm"
 version = "0.36.0"
 dependencies = [
+ "ast-grep-config",
  "ast-grep-core",
  "ast-grep-language",
  "cc",
@@ -269,7 +270,10 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "thiserror",
+ "tree-sitter",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wee_alloc",
 ]
@@ -1003,10 +1007,11 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1533,6 +1538,12 @@ dependencies = [
  "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -2311,23 +2322,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if 1.0.0",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2336,21 +2348,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2358,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2371,9 +2384,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -2402,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
  "similar",
  "tempfile",
  "tokio",
- "tree-sitter-facade-sg",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ dependencies = [
  "bit-set",
  "regex",
  "thiserror",
- "tree-sitter-facade-sg",
+ "tree-sitter",
  "tree-sitter-typescript 0.21.2",
 ]
 
@@ -240,7 +240,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "serde_json",
- "tree-sitter-facade-sg",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -609,9 +609,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",
@@ -990,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1919,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.4"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67baf55e7e1b6806063b1e51041069c90afff16afcbbccd278d899f9d84bca4"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
 dependencies = [
  "cc",
  "regex",
@@ -1988,20 +1988,6 @@ checksum = "e45d444647b4fd53d8fd32474c1b8bedc1baa22669ce3a78d083e365fa9a2d3f"
 dependencies = [
  "cc",
  "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-facade-sg"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195ab85ddd7df7ddac5b2e397ec6264816ae640346013002ceccf0f9b3578f1"
-dependencies = [
- "js-sys",
- "tree-sitter",
- "tree-sitter-language",
- "wasm-bindgen",
- "web-sys",
- "web-tree-sitter-sg",
 ]
 
 [[package]]
@@ -2303,18 +2289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,17 +2325,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web-tree-sitter-sg"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cf7d34b16550f076d75b4a5d4673f1a9692f79787d040e3ac7ddb04e5c48a0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "regex",
  "thiserror",
  "tree-sitter",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-swift",
- "tree-sitter-typescript 0.23.2",
+ "tree-sitter-typescript",
  "tree-sitter-yaml",
 ]
 
@@ -255,6 +255,23 @@ dependencies = [
  "pyo3",
  "pythonize",
  "serde",
+]
+
+[[package]]
+name = "ast-grep-wasm"
+version = "0.36.0"
+dependencies = [
+ "ast-grep-core",
+ "ast-grep-language",
+ "cc",
+ "console_error_panic_hook",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -304,7 +321,7 @@ checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -361,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -385,12 +402,18 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -489,6 +512,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "convert_case"
@@ -623,7 +656,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -636,7 +669,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "hashbrown",
  "lock_api",
@@ -809,7 +842,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "windows-targets 0.52.6",
@@ -840,7 +873,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crunchy",
 ]
 
@@ -989,7 +1022,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-targets 0.52.6",
 ]
 
@@ -1048,6 +1081,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
@@ -1111,7 +1150,7 @@ version = "2.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "convert_case",
  "napi-derive-backend",
  "proc-macro2",
@@ -1204,7 +1243,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1329,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.0",
  "indoc",
  "libc",
  "memoffset",
@@ -1535,6 +1574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1598,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1707,7 +1763,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "getrandom",
  "once_cell",
@@ -1756,7 +1812,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -2138,16 +2194,6 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
@@ -2269,7 +2315,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -2286,6 +2332,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2318,6 +2376,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2408,18 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-members = ["crates/*", "xtask", "benches"]
+members = [
+  "crates/*",
+  "xtask",
+  "benches"
+]
 default-members = ["crates/*"]
 resolver = "2"
 
@@ -8,9 +12,7 @@ lto = true
 
 [workspace.package]
 version = "0.36.0"
-authors = [
-  "Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>",
-]
+authors = ["Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT"
 documentation = "https://ast-grep.github.io/guide/introduction.html"
@@ -32,8 +34,6 @@ regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
 tree-sitter = { version = "0.24.7" }
-
-
 thiserror = "2.0.0"
 schemars = "0.8.17"
 anyhow = "1.0.82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-  "crates/*",
-  "xtask",
-  "benches"
-]
+members = ["crates/*", "xtask", "benches"]
 default-members = ["crates/*"]
 resolver = "2"
 
@@ -12,7 +8,9 @@ lto = true
 
 [workspace.package]
 version = "0.36.0"
-authors = ["Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>"]
+authors = [
+  "Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>",
+]
 edition = "2021"
 license = "MIT"
 documentation = "https://ast-grep.github.io/guide/introduction.html"
@@ -33,8 +31,8 @@ ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
-# tree-sitter = { version = "0.24.5", package = "tree-sitter-facade-sg" }
-tree-sitter = { version = "0.24.4" }
+tree-sitter = { version = "0.24.7" }
+
 
 thiserror = "2.0.0"
 schemars = "0.8.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
-tree-sitter = { version = "0.24.5", package = "tree-sitter-facade-sg" }
+# tree-sitter = { version = "0.24.5", package = "tree-sitter-facade-sg" }
+tree-sitter = { version = "0.24.4" }
+
 thiserror = "2.0.0"
 schemars = "0.8.17"
 anyhow = "1.0.82"

--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -168,7 +168,12 @@ fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let sp = start.ts_point();
   let end = node.end_pos();
   let ep = end.ts_point();
-  TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
+  TSRange {
+    start_byte: r.start,
+    end_byte: r.end,
+    start_point: sp,
+    end_point: ep,
+  }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -189,8 +189,8 @@ impl From<ts::Point> for Pos {
   #[inline]
   fn from(pt: ts::Point) -> Self {
     Pos {
-      row: pt.row(),
-      column: pt.column(),
+      row: pt.row as u32,
+      column: pt.column as u32,
     }
   }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,4 +26,4 @@ thiserror.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = "0.23.2"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
       Some(TypeScript::Tsx)
     }
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -29,7 +29,7 @@ fn field_name_to_id<L: Language>(
   };
   let ts_lang = env.lang.get_ts_language();
   match ts_lang.field_id_for_name(&field) {
-    Some(id) => Ok(Some(id)),
+    Some(id) => Ok(Some(id.into())),
     None => Err(RuleSerializeError::InvalidField(field)),
   }
 }
@@ -621,7 +621,7 @@ mod test {
     let inside = Inside {
       stop_by: StopBy::End,
       outer: Rule::Kind(KindMatcher::new("for_statement", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx.get_ts_language().field_id_for_name("condition").map(|id| id.into()),
     };
     let rule = make_rule("a = 1", Rule::Inside(Box::new(inside)));
     test_found(&["for (;a = 1;) {}"], &rule);
@@ -633,7 +633,7 @@ mod test {
     let has = Has {
       stop_by: StopBy::End,
       inner: Rule::Pattern(Pattern::new("a = 1", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx.get_ts_language().field_id_for_name("condition").map(|id| id.into()),
     };
     let rule = o::All::new(vec![
       Rule::Kind(KindMatcher::new("for_statement", TS::Tsx)),
@@ -674,13 +674,13 @@ mod test {
     let inside = Inside {
       stop_by: StopBy::Rule(Rule::Pattern(Pattern::new("var $C", TS::Tsx))),
       outer: Rule::Pattern(Pattern::new("var a = $A", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx.get_ts_language().field_id_for_name("condition").map(|id| id.into()),
     };
     assert_eq!(inside.defined_vars(), ["A", "C"].into_iter().collect());
     let has = Has {
       stop_by: StopBy::Rule(Rule::Kind(KindMatcher::new("for_statement", TS::Tsx))),
       inner: Rule::Pattern(Pattern::new("var a = $A", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx.get_ts_language().field_id_for_name("condition").map(|id| id.into()),
     };
     assert_eq!(has.defined_vars(), ["A"].into_iter().collect());
   }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,4 +23,4 @@ tree-sitter.workspace = true
 default = ["regex"]
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = "0.23.2"

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -86,7 +86,7 @@ mod test {
   pub struct Tsx;
   impl Language for Tsx {
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 }

--- a/crates/dynamic/Cargo.toml
+++ b/crates/dynamic/Cargo.toml
@@ -17,7 +17,7 @@ ignore.workspace = true
 libloading = "0.8.3"
 serde.workspace = true
 thiserror.workspace = true
-tree-sitter-native = { version = "0.24.4", package = "tree-sitter" }
+tree-sitter.workspace = true
 
 [dev-dependencies]
 serde_yaml.workspace = true

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -5,7 +5,7 @@ use ignore::types::{Types, TypesBuilder};
 use libloading::{Error as LibError, Library, Symbol};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tree_sitter_native::{Language as NativeTS, LANGUAGE_VERSION, MIN_COMPATIBLE_LANGUAGE_VERSION};
+use tree_sitter::{Language as NativeTS, LANGUAGE_VERSION, MIN_COMPATIBLE_LANGUAGE_VERSION};
 
 use std::borrow::Cow;
 use std::fs::canonicalize;

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -36,7 +36,7 @@ tree-sitter-ruby = { version = "0.23.0", optional = true }
 tree-sitter-rust = { version = "0.23.0", optional = true }
 tree-sitter-scala = { version = "0.23.0", optional = true }
 tree-sitter-swift = { version = "0.7.0", optional = true }
-tree-sitter-typescript= { version = "0.23.2", optional = true }
+tree-sitter-typescript = { version = "0.23.2", optional = true }
 tree-sitter-yaml = { version = "0.7.0", optional = true }
 
 [features]
@@ -67,6 +67,13 @@ builtin-parser = [
 napi-lang = [
   "tree-sitter-css",
   "tree-sitter-html",
+  "tree-sitter-javascript",
+  "tree-sitter-typescript",
+]
+wasm-lang = [
+  "tree-sitter-c",
+  "tree-sitter-cpp",
+  "tree-sitter-c-sharp",
   "tree-sitter-javascript",
   "tree-sitter-typescript",
 ]

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -71,7 +71,12 @@ fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let sp = start.ts_point();
   let end = node.end_pos();
   let ep = end.ts_point();
-  TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
+  TSRange {
+    start_byte: r.start,
+    end_byte: r.end,
+    start_point: sp,
+    end_point: ep,
+  }
 }
 
 #[cfg(test)]

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -51,6 +51,7 @@ macro_rules! into_wasm_lang {
   };
 }
 #[cfg(not(feature = "wasm-lang"))]
+#[allow(unused_macros)]
 macro_rules! into_wasm_lang {
   ($lang: path) => {
     unimplemented!(
@@ -135,6 +136,11 @@ pub fn language_tsx() -> TSLanguage {
 pub fn language_tsx() -> TSLanguage {
   into_napi_lang!(tree_sitter_typescript::LANGUAGE_TSX)
 }
+#[cfg(all(not(feature = "builtin-parser"), feature = "wasm-lang"))]
+pub fn language_typescript() -> TSLanguage {
+  into_wasm_lang!(tree_sitter_typescript, LANGUAGE_TYPESCRIPT)
+}
+#[cfg(not(feature = "wasm-lang"))]
 pub fn language_typescript() -> TSLanguage {
   into_napi_lang!(tree_sitter_typescript::LANGUAGE_TYPESCRIPT)
 }

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -41,6 +41,24 @@ macro_rules! into_napi_lang {
   };
 }
 
+#[cfg(all(not(feature = "builtin-parser"), feature = "wasm-lang"))]
+macro_rules! into_wasm_lang {
+  ($lang: ident, $field: ident) => {
+    $lang::$field.into()
+  };
+  ($lang: ident) => {
+    into_lang!($lang, LANGUAGE)
+  };
+}
+#[cfg(not(feature = "wasm-lang"))]
+macro_rules! into_wasm_lang {
+  ($lang: path) => {
+    unimplemented!(
+      "WebAssembly tree-sitter parser is not implemented when feature flag [wasm-lang] is off."
+    )
+  };
+}
+
 use ast_grep_core::language::TSLanguage;
 
 pub fn language_bash() -> TSLanguage {
@@ -52,6 +70,11 @@ pub fn language_c() -> TSLanguage {
 pub fn language_cpp() -> TSLanguage {
   into_lang!(tree_sitter_cpp)
 }
+#[cfg(all(not(feature = "builtin-parser"), feature = "wasm-lang"))]
+pub fn language_c_sharp() -> TSLanguage {
+  into_wasm_lang!(tree_sitter_c_sharp)
+}
+#[cfg(not(feature = "wasm-lang"))]
 pub fn language_c_sharp() -> TSLanguage {
   into_lang!(tree_sitter_c_sharp)
 }
@@ -103,6 +126,12 @@ pub fn language_scala() -> TSLanguage {
 pub fn language_swift() -> TSLanguage {
   into_lang!(tree_sitter_swift)
 }
+
+#[cfg(all(not(feature = "builtin-parser"), feature = "wasm-lang"))]
+pub fn language_tsx() -> TSLanguage {
+  into_wasm_lang!(tree_sitter_typescript, LANGUAGE_TSX)
+}
+#[cfg(not(feature = "wasm-lang"))]
 pub fn language_tsx() -> TSLanguage {
   into_napi_lang!(tree_sitter_typescript::LANGUAGE_TSX)
 }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -19,7 +19,7 @@ ast-grep-language = { path = "../language", features = ["napi-lang"], default-fe
 ast-grep-dynamic.workspace = true
 
 napi = { version = "2.16.4", features = ["serde-json", "napi4", "error_anyhow"] }
-napi-derive = "2.16.3"
+napi-derive = "2.16.4"
 
 ignore.workspace = true
 tree-sitter.workspace = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ast-grep-wasm"
+edition = "2021"
+description = "WebAssembly bindings for ast-grep"
+license = "MIT"
+authors = ["Mo Mohebifar <mo@codemod.com>"]
+version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ast-grep-core = { path = "../core" }
+ast-grep-language = { path = "../language", features = ["wasm-lang"], default-features = false  }
+wasm-bindgen = "0.2.92"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde-wasm-bindgen = "0.6.5"
+js-sys = "0.3.69"
+console_error_panic_hook = "0.1.7"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.42"
+
+[build-dependencies]
+cc = "1.0"
+
+# Enable the wee_alloc feature for smaller code size
+[features]
+default = ["wee_alloc"]
+wee_alloc = ["dep:wee_alloc"]
+exhaustive-parser = []
+
+[dependencies.wee_alloc]
+version = "0.4.5"
+optional = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -10,14 +10,18 @@ version.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ast-grep-core = { path = "../core" }
-ast-grep-language = { path = "../language", features = ["wasm-lang"], default-features = false  }
-wasm-bindgen = "0.2.92"
+ast-grep-core.workspace = true
+ast-grep-config.workspace = true
+ast-grep-language = { path = "../language", features = ["wasm-lang"], default-features = false }
+console_error_panic_hook = "0.1.7"
+js-sys = "0.3.69"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-wasm-bindgen = "0.6.5"
-js-sys = "0.3.69"
-console_error_panic_hook = "0.1.7"
+thiserror.workspace = true
+tree-sitter.workspace = true
+wasm-bindgen = "0.2.92"
+wasm-bindgen-futures = "0.4.50"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"

--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -2,7 +2,7 @@
 
 export OUT_DIR=pkg
 export CFLAGS_wasm32_unknown_unknown="-I$(pwd)/wasm-sysroot -Wbad-function-cast -Wcast-function-type -fno-builtin" RUSTFLAGS="-Zwasm-c-abi=spec"
-export AST_GREP_RULE='{"id":"fix-wasm-js-node","language":"javascript","rule":{"pattern":"input = fetch(input);","inside":{"pattern":"function __wbg_init($$$) {$$$}","stopBy":"end"}},"fix":"if (!!process.versions.node) {\n  const fs = await import(\"fs/promises\");\n  input = fs.readFile(input);\n} else {\n  input = fetch(input);\n}\n"}'
+export AST_GREP_RULE='{"id":"fix-wasm-js-node","language":"javascript","rule":{"pattern":"module_or_path = fetch(module_or_path);","inside":{"pattern":"function __wbg_init($$$) {$$$}","stopBy":"end"}},"fix":"if (!!process.versions.node) {\n  const fs = await import(\"fs/promises\");\n  module_or_path = fs.readFile(module_or_path);\n} else {\n  module_or_path = fetch(module_or_path);\n}\n"}'
 
 wasm-pack build --release --target web --out-dir $OUT_DIR --features "exhaustive-parser" \
 	-Z build-std=panic_abort,std -Z build-std-features=panic_immediate_abort

--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export OUT_DIR=pkg
+export CFLAGS_wasm32_unknown_unknown="-I$(pwd)/wasm-sysroot -Wbad-function-cast -Wcast-function-type -fno-builtin" RUSTFLAGS="-Zwasm-c-abi=spec"
+export AST_GREP_RULE='{"id":"fix-wasm-js-node","language":"javascript","rule":{"pattern":"input = fetch(input);","inside":{"pattern":"function __wbg_init($$$) {$$$}","stopBy":"end"}},"fix":"if (!!process.versions.node) {\n  const fs = await import(\"fs/promises\");\n  input = fs.readFile(input);\n} else {\n  input = fetch(input);\n}\n"}'
+
+wasm-pack build --release --target web --out-dir $OUT_DIR --features "exhaustive-parser" \
+	-Z build-std=panic_abort,std -Z build-std-features=panic_immediate_abort
+
+# Make the WASM module work with Node.js as Node does not support fetch for file:// URLs
+cargo run --manifest-path ../cli/Cargo.toml -- scan --inline-rules "$AST_GREP_RULE" -U $OUT_DIR/ast_grep_wasm.js

--- a/crates/wasm/src/config.rs
+++ b/crates/wasm/src/config.rs
@@ -1,0 +1,41 @@
+use ast_grep_config::{
+  DeserializeEnv, RuleConfig, RuleCore, RuleCoreError, SerializableRuleConfig, SerializableRuleCore,
+};
+use ast_grep_language::SupportLang;
+use thiserror::Error;
+use wasm_bindgen::{JsError, JsValue};
+
+#[derive(Error, Debug)]
+pub enum WasmConfigError {
+  #[error("Fail to parse yaml as RuleConfig")]
+  Parse(#[from] serde_wasm_bindgen::Error),
+
+  #[error("Fail to parse yaml as Rule.")]
+  Core(#[from] RuleCoreError),
+}
+
+pub fn try_get_rule_config(config: JsValue) -> Result<RuleConfig<SupportLang>, JsError> {
+  let config: SerializableRuleConfig<SupportLang> = serde_wasm_bindgen::from_value(config)?;
+  RuleConfig::try_from(config, &Default::default()).map_err(dump_error)
+}
+
+pub fn parse_config_from_js_value(
+  lang: SupportLang,
+  rule: JsValue,
+) -> Result<RuleCore<SupportLang>, WasmConfigError> {
+  let mut rule: SerializableRuleCore =
+    serde_wasm_bindgen::from_value(rule).map_err(WasmConfigError::Parse)?;
+  rule.fix = None;
+  let env = DeserializeEnv::new(lang);
+  rule.get_matcher(env).map_err(WasmConfigError::Core)
+}
+
+fn dump_error(err: impl std::error::Error) -> JsError {
+  let mut errors = vec![err.to_string()];
+  let mut err: &dyn std::error::Error = &err;
+  while let Some(e) = err.source() {
+    errors.push(e.to_string());
+    err = e;
+  }
+  JsError::new(&format!("{}", errors.join("\n")))
+}

--- a/crates/wasm/src/dump_tree.rs
+++ b/crates/wasm/src/dump_tree.rs
@@ -1,0 +1,195 @@
+use ast_grep_core::{matcher::PatternNode, Language, Node, Pattern, StrDoc};
+use ast_grep_language::SupportLang;
+use serde::{Deserialize, Serialize};
+use tree_sitter as ts;
+use wasm_bindgen::prelude::JsError;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DumpNode {
+  id: usize,
+  field: Option<String>,
+  kind: String,
+  start: Pos,
+  end: Pos,
+  is_named: bool,
+  children: Vec<DumpNode>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Pos {
+  row: u32,
+  column: u32,
+}
+
+impl From<ts::Point> for Pos {
+  #[inline]
+  fn from(pt: ts::Point) -> Self {
+    Pos {
+      row: pt.row as u32,
+      column: pt.column as u32,
+    }
+  }
+}
+
+pub fn dump_one_node(cursor: &mut ts::TreeCursor, target: &mut Vec<DumpNode>) {
+  let node = cursor.node();
+  let kind = if node.is_missing() {
+    format!("MISSING {}", node.kind())
+  } else {
+    node.kind().to_string()
+  };
+  let start = node.start_position().into();
+  let end = node.end_position().into();
+  let field = cursor.field_name().map(|c| c.to_string());
+  let mut children = vec![];
+  if cursor.goto_first_child() {
+    dump_nodes(cursor, &mut children);
+    cursor.goto_parent();
+  }
+  target.push(DumpNode {
+    id: node.id(),
+    field,
+    kind,
+    start,
+    end,
+    children,
+    is_named: node.is_named(),
+  })
+}
+
+fn dump_nodes(cursor: &mut ts::TreeCursor, target: &mut Vec<DumpNode>) {
+  loop {
+    dump_one_node(cursor, target);
+    if !cursor.goto_next_sibling() {
+      break;
+    }
+  }
+}
+
+pub fn dump_pattern(
+  lang: SupportLang,
+  query: String,
+  selector: Option<String>,
+) -> Result<PatternTree, JsError> {
+  let processed = lang.pre_process_pattern(&query);
+  let root = lang.ast_grep(processed);
+  let pattern = if let Some(sel) = selector {
+    Pattern::contextual(&query, &sel, lang)?
+  } else {
+    Pattern::try_new(&query, lang)?
+  };
+  let found = root
+    .root()
+    .find(&pattern)
+    .ok_or_else(|| JsError::new("pattern node not found"))?;
+  let ret = dump_pattern_tree(root.root(), found.node_id(), &pattern.node);
+  Ok(ret)
+}
+
+fn dump_pattern_tree(
+  node: Node<StrDoc<SupportLang>>,
+  node_id: usize,
+  pattern: &PatternNode,
+) -> PatternTree {
+  if node.node_id() == node_id {
+    return dump_pattern_impl(node, pattern);
+  }
+  let children: Vec<_> = node
+    .children()
+    .map(|n| dump_pattern_tree(n, node_id, pattern))
+    .collect();
+  let ts = node.get_ts_node();
+  let text = if children.is_empty() {
+    Some(node.text().into())
+  } else {
+    None
+  };
+  let kind = if ts.is_missing() {
+    format!("MISSING {}", node.kind())
+  } else {
+    node.kind().to_string()
+  };
+  PatternTree {
+    kind,
+    start: ts.start_position().into(),
+    end: ts.end_position().into(),
+    is_named: node.is_named(),
+    children,
+    text,
+    pattern: None,
+  }
+}
+
+fn dump_pattern_impl(node: Node<StrDoc<SupportLang>>, pattern: &PatternNode) -> PatternTree {
+  use PatternNode as PN;
+  let ts = node.get_ts_node();
+  let kind = if ts.is_missing() {
+    format!("MISSING {}", node.kind())
+  } else {
+    node.kind().to_string()
+  };
+  match pattern {
+    PN::MetaVar { .. } => {
+      let lang = node.lang();
+      let expando = lang.expando_char();
+      let text = node.text().to_string();
+      let text = text.replace(expando, "$");
+      PatternTree {
+        kind,
+        start: ts.start_position().into(),
+        end: ts.end_position().into(),
+        is_named: true,
+        children: vec![],
+        text: Some(text),
+        pattern: Some(PatternKind::MetaVar),
+      }
+    }
+    PN::Terminal { is_named, .. } => PatternTree {
+      kind,
+      start: ts.start_position().into(),
+      end: ts.end_position().into(),
+      is_named: *is_named,
+      children: vec![],
+      text: Some(node.text().into()),
+      pattern: Some(PatternKind::Terminal),
+    },
+    PN::Internal { children, .. } => {
+      let children = children
+        .iter()
+        .zip(node.children())
+        .map(|(pn, n)| dump_pattern_impl(n, pn))
+        .collect();
+      PatternTree {
+        kind,
+        start: ts.start_position().into(),
+        end: ts.end_position().into(),
+        is_named: true,
+        children,
+        text: None,
+        pattern: Some(PatternKind::Internal),
+      }
+    }
+  }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum PatternKind {
+  Terminal,
+  MetaVar,
+  Internal,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatternTree {
+  kind: String,
+  start: Pos,
+  end: Pos,
+  is_named: bool,
+  children: Vec<PatternTree>,
+  text: Option<String>,
+  pattern: Option<PatternKind>,
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,0 +1,138 @@
+#![cfg_attr(target_arch = "wasm32", feature(c_variadic))]
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm_libc;
+
+use ast_grep_core::{AstGrep, Language};
+use ast_grep_language::SupportLang;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+// A macro to provide `println!(..)`-style syntax for `console.log` logging.
+#[allow(unused_macros)]
+macro_rules! log {
+    ($($t:tt)*) => (web_sys::console::log_1(&format!($($t)*).into()))
+}
+
+// Initialize panic hook for better error messages
+fn init_panic_hook() {
+  console_error_panic_hook::set_once();
+}
+
+#[derive(Serialize, Deserialize)]
+struct Position {
+  row: usize,
+  column: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NodeRange {
+  start: Position,
+  end: Position,
+}
+
+// Wrapper for AstGrep to expose to JavaScript
+#[wasm_bindgen]
+pub struct SgRoot {
+  inner: AstGrep<ast_grep_core::StrDoc<ast_grep_language::SupportLang>>,
+}
+
+// Wrapper for Node to expose to JavaScript
+#[wasm_bindgen]
+pub struct SgNode {
+  root: SgRoot,
+  node: ast_grep_core::Node<'static, ast_grep_core::StrDoc<ast_grep_language::SupportLang>>,
+}
+
+#[wasm_bindgen]
+impl SgNode {
+  #[wasm_bindgen(getter)]
+  pub fn text(&self) -> String {
+    self.node.text().to_string()
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn kind(&self) -> String {
+    self.node.kind().to_string()
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn range(&self) -> JsValue {
+    let byte_range = self.node.range();
+    let start_pos = self.node.start_pos();
+    let end_pos = self.node.end_pos();
+
+    let result = NodeRange {
+      start: Position {
+        row: start_pos.line(),
+        column: start_pos.column(&self.node),
+      },
+      end: Position {
+        row: end_pos.line(),
+        column: end_pos.column(&self.node),
+      },
+    };
+
+    serde_wasm_bindgen::to_value(&result).unwrap()
+  }
+}
+
+#[wasm_bindgen]
+impl SgRoot {
+  #[wasm_bindgen]
+  pub fn root(&self) -> Result<SgNode, JsError> {
+    // This is a workaround for the lifetime issue
+    // We're creating a new SgRoot with the same inner value
+    let root = SgRoot {
+      inner: AstGrep::new(self.inner.source(), *self.inner.lang()),
+    };
+
+    // This is unsafe but necessary due to lifetime constraints
+    // The node is tied to the root's lifetime, but we need to return it separately
+    let node = unsafe { std::mem::transmute(root.inner.root()) };
+
+    Ok(SgNode { root, node })
+  }
+
+  #[wasm_bindgen]
+  pub fn source(&self) -> String {
+    self.inner.source().to_string()
+  }
+}
+
+#[wasm_bindgen(js_name = parse)]
+pub fn parse(lang: String, src: String) -> Result<SgRoot, JsError> {
+  init_panic_hook();
+
+  let lang =
+    SupportLang::from_str(&lang).map_err(|e| JsError::new(&format!("Language error: {}", e)))?;
+
+  let ast_grep = AstGrep::new(src, lang);
+
+  Ok(SgRoot { inner: ast_grep })
+}
+
+#[wasm_bindgen(js_name = kind)]
+pub fn kind(lang: String, kind_name: String) -> Result<u16, JsError> {
+  init_panic_hook();
+
+  let lang =
+    SupportLang::from_str(&lang).map_err(|e| JsError::new(&format!("Language error: {}", e)))?;
+
+  let kind = lang
+    .get_ts_language()
+    .id_for_node_kind(&kind_name, /* named */ true);
+
+  Ok(kind)
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+  init_panic_hook();
+}

--- a/crates/wasm/src/sg_node.rs
+++ b/crates/wasm/src/sg_node.rs
@@ -1,0 +1,476 @@
+use ast_grep_config::RuleCore;
+use ast_grep_core::{matcher::KindMatcher, AstGrep, NodeMatch, Pattern, StrDoc};
+use ast_grep_language::SupportLang;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+
+use crate::config::parse_config_from_js_value;
+
+pub enum JsMatcher {
+  Pattern(String),
+  Kind(u16),
+  Config(RuleCore<SupportLang>),
+}
+
+// We may not need these anymore as we're using the types.d.ts file
+// But keeping them for clarity in the Rust code
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "NodeRange")]
+  pub type INodeRange;
+
+  #[wasm_bindgen(typescript_type = "Matcher")]
+  pub type IMatcher;
+
+  #[wasm_bindgen(typescript_type = "Edit")]
+  pub type IEdit;
+
+  #[wasm_bindgen(typescript_type = "Edit[]")]
+  pub type IEditArray;
+}
+
+#[derive(Serialize, Deserialize)]
+struct Position {
+  row: usize,
+  column: usize,
+  index: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NodeRange {
+  start: Position,
+  end: Position,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Edit {
+  /// The start position of the edit
+  pub start_pos: u32,
+  /// The end position of the edit
+  pub end_pos: u32,
+  /// The text to be inserted
+  pub inserted_text: String,
+}
+
+// Node struct that holds a reference to the root
+#[wasm_bindgen(skip_typescript)]
+pub struct SgNode {
+  // Use Rc to reference count the root, ensuring it stays alive as long as any nodes exist
+  pub(crate) root: Rc<SgRoot>,
+  pub(crate) inner: NodeMatch<'static, StrDoc<SupportLang>>,
+}
+
+#[wasm_bindgen]
+impl SgNode {
+  #[wasm_bindgen]
+  pub fn text(&self) -> String {
+    self.inner.text().to_string()
+  }
+
+  /// Check if the node is the same kind as the given `kind` string
+  #[wasm_bindgen]
+  pub fn is(&self, kind: String) -> bool {
+    self.inner.kind() == kind
+  }
+
+  #[wasm_bindgen]
+  pub fn kind(&self) -> String {
+    self.inner.kind().to_string()
+  }
+
+  #[wasm_bindgen]
+  pub fn range(&self) -> INodeRange {
+    let start_pos = self.inner.start_pos();
+    let end_pos = self.inner.end_pos();
+    let byte_range = self.inner.range();
+
+    let result = NodeRange {
+      start: Position {
+        row: start_pos.line(),
+        column: start_pos.column(&self.inner),
+        index: byte_range.start,
+      },
+      end: Position {
+        row: end_pos.line(),
+        column: end_pos.column(&self.inner),
+        index: byte_range.end,
+      },
+    };
+
+    serde_wasm_bindgen::to_value(&result).unwrap().into()
+  }
+
+  /// Check if the node is a leaf node (has no children)
+  #[wasm_bindgen(js_name = isLeaf)]
+  pub fn is_leaf(&self) -> bool {
+    self.inner.is_leaf()
+  }
+
+  /// Check if the node is a named node
+  #[wasm_bindgen(js_name = isNamed)]
+  pub fn is_named(&self) -> bool {
+    self.inner.is_named()
+  }
+
+  /// Check if the node is a named leaf node
+  #[wasm_bindgen(js_name = isNamedLeaf)]
+  pub fn is_named_leaf(&self) -> bool {
+    self.inner.is_named_leaf()
+  }
+
+  /// Find a node matching the given pattern, kind, or config
+  #[wasm_bindgen]
+  pub fn find(&self, value: IMatcher) -> Option<SgNode> {
+    let lang = *self.inner.lang();
+    let matcher = convert_js_matcher(value.into(), lang);
+
+    match matcher {
+      JsMatcher::Pattern(pattern) => {
+        let pattern = Pattern::new(&pattern, lang);
+        self.inner.find(pattern).map(|node| SgNode {
+          root: self.root.clone(),
+          inner: node,
+        })
+      }
+      JsMatcher::Kind(kind) => {
+        let matcher = KindMatcher::from_id(kind);
+        self.inner.find(matcher).map(|node| SgNode {
+          root: self.root.clone(),
+          inner: node,
+        })
+      }
+      JsMatcher::Config(config) => self.inner.find(config).map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node,
+      }),
+    }
+  }
+
+  /// Find all nodes matching the given pattern, kind, or config
+  #[wasm_bindgen(js_name = findAll)]
+  pub fn find_all(&self, value: IMatcher) -> Vec<SgNode> {
+    let lang = *self.inner.lang();
+    let matcher = convert_js_matcher(value.into(), lang);
+
+    match matcher {
+      JsMatcher::Pattern(pattern) => {
+        let pattern = Pattern::new(&pattern, lang);
+        self
+          .inner
+          .find_all(pattern)
+          .map(|node| SgNode {
+            root: self.root.clone(),
+            inner: node,
+          })
+          .collect()
+      }
+      JsMatcher::Kind(kind) => {
+        let matcher = KindMatcher::from_id(kind);
+        self
+          .inner
+          .find_all(matcher)
+          .map(|node| SgNode {
+            root: self.root.clone(),
+            inner: node,
+          })
+          .collect()
+      }
+      JsMatcher::Config(config) => self
+        .inner
+        .find_all(config)
+        .map(|node| SgNode {
+          root: self.root.clone(),
+          inner: node,
+        })
+        .collect(),
+    }
+  }
+
+  /// Check if the node matches the given pattern, kind, or config
+  #[wasm_bindgen]
+  pub fn matches(&self, value: IMatcher) -> bool {
+    let lang = *self.inner.lang();
+    let matcher = convert_js_matcher(value.into(), lang);
+
+    match matcher {
+      JsMatcher::Pattern(pattern) => {
+        let pattern = Pattern::new(&pattern, lang);
+        self.inner.matches(pattern)
+      }
+      JsMatcher::Kind(kind) => {
+        let matcher = KindMatcher::from_id(kind);
+        self.inner.matches(matcher)
+      }
+      JsMatcher::Config(config) => self.inner.matches(config),
+    }
+  }
+
+  /// Check if the node is inside a node matching the given pattern, kind, or config
+  #[wasm_bindgen]
+  pub fn inside(&self, value: IMatcher) -> bool {
+    let lang = *self.inner.lang();
+    let matcher = convert_js_matcher(value.into(), lang);
+
+    match matcher {
+      JsMatcher::Pattern(pattern) => {
+        let pattern = Pattern::new(&pattern, lang);
+        self.inner.inside(pattern)
+      }
+      JsMatcher::Kind(kind) => {
+        let matcher = KindMatcher::from_id(kind);
+        self.inner.inside(matcher)
+      }
+      JsMatcher::Config(config) => self.inner.inside(config),
+    }
+  }
+
+  /// Check if the node has a child matching the given pattern, kind, or config
+  #[wasm_bindgen]
+  pub fn has(&self, value: IMatcher) -> bool {
+    let lang = *self.inner.lang();
+    let matcher = convert_js_matcher(value.into(), lang);
+
+    match matcher {
+      JsMatcher::Pattern(pattern) => {
+        let pattern = Pattern::new(&pattern, lang);
+        self.inner.has(pattern)
+      }
+      JsMatcher::Kind(kind) => {
+        let matcher = KindMatcher::from_id(kind);
+        self.inner.has(matcher)
+      }
+      JsMatcher::Config(config) => self.inner.has(config),
+    }
+  }
+
+  /// Get the parent node
+  #[wasm_bindgen]
+  pub fn parent(&self) -> Option<SgNode> {
+    self.inner.parent().map(|node| SgNode {
+      root: self.root.clone(),
+      inner: node.into(),
+    })
+  }
+
+  /// Get a child node at the given index
+  #[wasm_bindgen]
+  pub fn child(&self, nth: usize) -> Option<SgNode> {
+    self.inner.child(nth).map(|node| SgNode {
+      root: self.root.clone(),
+      inner: node.into(),
+    })
+  }
+
+  /// Get all child nodes
+  #[wasm_bindgen]
+  pub fn children(&self) -> Vec<SgNode> {
+    self
+      .inner
+      .children()
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node.into(),
+      })
+      .collect()
+  }
+
+  /// Get all ancestor nodes
+  #[wasm_bindgen]
+  pub fn ancestors(&self) -> Vec<SgNode> {
+    self
+      .inner
+      .ancestors()
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node.into(),
+      })
+      .collect()
+  }
+
+  /// Get the next sibling node
+  #[wasm_bindgen]
+  pub fn next(&self) -> Option<SgNode> {
+    self.inner.next().map(|node| SgNode {
+      root: self.root.clone(),
+      inner: node.into(),
+    })
+  }
+
+  /// Get all next sibling nodes
+  #[wasm_bindgen(js_name = nextAll)]
+  pub fn next_all(&self) -> Vec<SgNode> {
+    self
+      .inner
+      .next_all()
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node.into(),
+      })
+      .collect()
+  }
+
+  /// Get the previous sibling node
+  #[wasm_bindgen]
+  pub fn prev(&self) -> Option<SgNode> {
+    self.inner.prev().map(|node| SgNode {
+      root: self.root.clone(),
+      inner: node.into(),
+    })
+  }
+
+  /// Get all previous sibling nodes
+  #[wasm_bindgen(js_name = prevAll)]
+  pub fn prev_all(&self) -> Vec<SgNode> {
+    self
+      .inner
+      .prev_all()
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node.into(),
+      })
+      .collect()
+  }
+
+  /// Get a field node by name
+  #[wasm_bindgen]
+  pub fn field(&self, name: String) -> Option<SgNode> {
+    self.inner.field(&name).map(|node| SgNode {
+      root: self.root.clone(),
+      inner: node.into(),
+    })
+  }
+
+  /// Get all field children by name
+  #[wasm_bindgen(js_name = fieldChildren)]
+  pub fn field_children(&self, name: String) -> Vec<SgNode> {
+    self
+      .inner
+      .field_children(&name)
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node.into(),
+      })
+      .collect()
+  }
+
+  #[wasm_bindgen(js_name = getMatch)]
+  pub fn get_match(&self, m: String) -> Result<Option<SgNode>, JsError> {
+    let node = self
+      .inner
+      .get_env()
+      .get_match(&m)
+      .cloned()
+      .map(NodeMatch::from)
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node,
+      });
+
+    Ok(node)
+  }
+
+  #[wasm_bindgen(js_name = getMultipleMatches)]
+  pub fn get_multiple_matches(&self, m: String) -> Result<Vec<SgNode>, JsError> {
+    let nodes = self
+      .inner
+      .get_env()
+      .get_multiple_matches(&m)
+      .into_iter()
+      .map(NodeMatch::from)
+      .map(|node| SgNode {
+        root: self.root.clone(),
+        inner: node,
+      })
+      .collect();
+
+    Ok(nodes)
+  }
+
+  #[wasm_bindgen(js_name = "commitEdits")]
+  pub fn commit_edits(&self, edits: IEditArray) -> Result<String, JsError> {
+    let mut edits: Vec<Edit> = serde_wasm_bindgen::from_value(edits.into())?;
+    edits.sort_by_key(|edit| edit.start_pos);
+    let mut new_content = String::new();
+    let old_content = self.text();
+
+    let offset = self.inner.range().start;
+    let mut start = 0;
+    for diff in edits {
+      let pos = diff.start_pos as usize - offset;
+      // skip overlapping edits
+      if start > pos {
+        continue;
+      }
+      new_content.push_str(&old_content[start..pos]);
+      new_content.push_str(&diff.inserted_text);
+      start = diff.end_pos as usize - offset;
+    }
+    // add trailing statements
+    new_content.push_str(&old_content[start..]);
+    Ok(new_content)
+  }
+
+  #[wasm_bindgen]
+  pub fn replace(&self, text: String) -> IEdit {
+    let byte_range = self.inner.range();
+    serde_wasm_bindgen::to_value(&Edit {
+      start_pos: byte_range.start as u32,
+      end_pos: byte_range.end as u32,
+      inserted_text: text,
+    })
+    .unwrap()
+    .into()
+  }
+}
+
+// Wrapper for AstGrep to expose to JavaScript
+#[wasm_bindgen(skip_typescript)]
+pub struct SgRoot {
+  pub(crate) inner: AstGrep<StrDoc<SupportLang>>,
+}
+
+#[wasm_bindgen]
+impl SgRoot {
+  #[wasm_bindgen]
+  pub fn root(&self) -> Result<SgNode, JsError> {
+    // Create a new SgRoot with the same source and language
+    let root = Rc::new(SgRoot {
+      inner: AstGrep::new(self.inner.source(), *self.inner.lang()),
+    });
+
+    // Create a NodeMatch from the root node
+    // We need to use a safe approach to handle the lifetime
+    let node = {
+      let node = root.inner.root();
+      // Convert to NodeMatch which is safer to work with
+      NodeMatch::from(node)
+    };
+
+    // Use a type with 'static lifetime but ensure it's tied to the root's lifetime
+    // through the Rc reference counting
+    let node: NodeMatch<'static, _> = unsafe {
+      // This is still unsafe but not as bad because:
+      // 1. We're using Rc to ensure the root stays alive
+      // 2. NodeMatch is designed to work with this pattern
+      std::mem::transmute(node)
+    };
+
+    Ok(SgNode { root, inner: node })
+  }
+
+  #[wasm_bindgen]
+  pub fn source(&self) -> String {
+    self.inner.source().to_string()
+  }
+}
+
+fn convert_js_matcher(matcher: JsValue, lang: SupportLang) -> JsMatcher {
+  if matcher.is_string() {
+    JsMatcher::Pattern(matcher.as_string().unwrap())
+  } else if matcher.is_object() {
+    JsMatcher::Config(parse_config_from_js_value(lang, matcher).unwrap())
+  } else {
+    JsMatcher::Kind(matcher.as_f64().unwrap() as u16)
+  }
+}

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -1,0 +1,19 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(typescript_custom_section)]
+const NODE_RANGE: &'static str = include_str!("../types.d.ts");
+
+#[wasm_bindgen(typescript_custom_section)]
+const MATCH: &'static str = r#"
+type WasmNode<M> = {
+  text: string;
+  range: [number, number, number, number];
+}
+
+type SgMatch<M> = {
+  id: number;
+  node: WasmNode<M>;
+  env: Map<string, WasmNode<M>>;
+  message: string;
+}
+"#;

--- a/crates/wasm/src/utils.rs
+++ b/crates/wasm/src/utils.rs
@@ -1,0 +1,105 @@
+use ast_grep_config::{Fixer, RuleConfig};
+use ast_grep_core::{
+  meta_var::{MetaVarEnv, MetaVariable},
+  replacer::Replacer,
+  Node as SgNode, NodeMatch as SgNodeMatch, StrDoc,
+};
+use ast_grep_language::SupportLang;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+type WasmDoc = StrDoc<SupportLang>;
+type WasmLang = SupportLang;
+type Node<'a> = SgNode<'a, WasmDoc>;
+type NodeMatch<'a> = SgNodeMatch<'a, WasmDoc>;
+
+#[derive(Serialize, Deserialize)]
+pub struct WasmNode {
+  pub text: String,
+  pub range: (usize, usize, usize, usize),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WasmMatch {
+  pub id: usize,
+  pub node: WasmNode,
+  pub env: BTreeMap<String, WasmNode>,
+  pub message: String,
+}
+
+// TODO: move to ast-grep-core
+fn get_message(rule: &RuleConfig<WasmLang>, node: &NodeMatch) -> String {
+  let parsed = Fixer::from_str(&rule.message, &rule.language).expect("should work");
+  let bytes = parsed.generate_replacement(node);
+  String::from_utf8(bytes).expect("Invalid UTF-8 in message")
+}
+
+impl WasmMatch {
+  pub fn from_match(nm: NodeMatch, rule: &RuleConfig<WasmLang>) -> Self {
+    let node = nm.get_node().clone();
+    let id = node.node_id();
+    let node = WasmNode::from(node);
+    let env = nm.get_env().clone();
+    let env = env_to_map(env);
+    let message = get_message(rule, &nm);
+    Self {
+      node,
+      env,
+      message,
+      id,
+    }
+  }
+}
+
+fn env_to_map(env: MetaVarEnv<'_, WasmDoc>) -> BTreeMap<String, WasmNode> {
+  let mut map = BTreeMap::new();
+  for id in env.get_matched_variables() {
+    match id {
+      MetaVariable::Capture(name, _) => {
+        if let Some(node) = env.get_match(&name) {
+          map.insert(name, WasmNode::from(node.clone()));
+        } else if let Some(bytes) = env.get_transformed(&name) {
+          let node = WasmNode {
+            text: String::from_utf8(bytes.to_vec()).expect("Invalid UTF-8 in node text"),
+            range: (0, 0, 0, 0),
+          };
+          map.insert(name, WasmNode::from(node));
+        }
+      }
+      MetaVariable::MultiCapture(name) => {
+        let nodes = env.get_multiple_matches(&name);
+        let (Some(first), Some(last)) = (nodes.first(), nodes.last()) else {
+          continue;
+        };
+        let start = first.start_pos();
+        let end = last.end_pos();
+
+        let text = nodes.iter().map(|n| n.text()).collect();
+        let node = WasmNode {
+          text,
+          range: (
+            start.line(),
+            start.column(first),
+            end.line(),
+            end.column(last),
+          ),
+        };
+        map.insert(name, node);
+      }
+      // ignore anonymous
+      _ => continue,
+    }
+  }
+  map
+}
+
+impl From<Node<'_>> for WasmNode {
+  fn from(nm: Node) -> Self {
+    let start = nm.start_pos();
+    let end = nm.end_pos();
+    Self {
+      text: nm.text().to_string(),
+      range: (start.line(), start.column(&nm), end.line(), end.column(&nm)),
+    }
+  }
+}

--- a/crates/wasm/src/wasm_libc.rs
+++ b/crates/wasm/src/wasm_libc.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-use std::sync::{Mutex, OnceLock};
 use std::{
   alloc::{self, Layout},
   ffi::{c_char, c_int, c_void},
@@ -13,10 +11,6 @@ use wasm_bindgen::prelude::*;
 #[no_mangle]
 pub unsafe extern "C" fn abort() {
   panic!("Aborted from C");
-}
-
-macro_rules! console_log {
-    ($($t:tt)*) => (unsafe { log(&format_args!($($t)*).to_string()) })
 }
 
 #[wasm_bindgen]
@@ -201,8 +195,8 @@ pub unsafe extern "C" fn vsnprintf(
 }
 
 #[no_mangle]
-pub extern "C" fn clock_gettime(ptr: usize, new_size: usize) {
-  panic!("asdasd");
+pub extern "C" fn clock_gettime(_ptr: usize, _new_size: usize) {
+  panic!("clock_gettime is not supported");
 }
 
 // int snprintf( char* restrict buffer, size_t bufsz, const char* restrict format, ... );

--- a/crates/wasm/src/wasm_libc.rs
+++ b/crates/wasm/src/wasm_libc.rs
@@ -1,0 +1,217 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::{
+  alloc::{self, Layout},
+  ffi::{c_char, c_int, c_void},
+  mem::align_of,
+  ptr,
+};
+use wasm_bindgen::prelude::*;
+
+/* -------------------------------- stdlib.h -------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn abort() {
+  panic!("Aborted from C");
+}
+
+macro_rules! console_log {
+    ($($t:tt)*) => (unsafe { log(&format_args!($($t)*).to_string()) })
+}
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(js_namespace = console)]
+  fn log(a: &str);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
+  if size == 0 {
+    return ptr::null_mut();
+  }
+
+  let (layout, offset_to_data) = layout_for_size_prepended(size);
+  let buf = alloc::alloc(layout);
+  store_layout(buf, layout, offset_to_data)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn calloc(count: usize, size: usize) -> *mut c_void {
+  if count == 0 || size == 0 {
+    return ptr::null_mut();
+  }
+
+  let (layout, offset_to_data) = layout_for_size_prepended(size * count);
+  let buf = alloc::alloc_zeroed(layout);
+  store_layout(buf, layout, offset_to_data)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn realloc(buf: *mut c_void, new_size: usize) -> *mut c_void {
+  if buf.is_null() {
+    malloc(new_size)
+  } else if new_size == 0 {
+    free(buf);
+    ptr::null_mut()
+  } else {
+    let (old_buf, old_layout) = retrieve_layout(buf);
+    let (new_layout, offset_to_data) = layout_for_size_prepended(new_size);
+    let new_buf = alloc::realloc(old_buf, old_layout, new_layout.size());
+    store_layout(new_buf, new_layout, offset_to_data)
+  }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free(buf: *mut c_void) {
+  if buf.is_null() {
+    return;
+  }
+  let (buf, layout) = retrieve_layout(buf);
+  alloc::dealloc(buf, layout);
+}
+
+// In all these allocations, we store the layout before the data for later retrieval.
+// This is because we need to know the layout when deallocating the memory.
+// Here are some helper methods for that:
+
+/// Given a pointer to the data, retrieve the layout and the pointer to the layout.
+unsafe fn retrieve_layout(buf: *mut c_void) -> (*mut u8, Layout) {
+  let (_, layout_offset) = Layout::new::<Layout>()
+    .extend(Layout::from_size_align(0, align_of::<*const u8>() * 2).unwrap())
+    .unwrap();
+
+  let buf = (buf as *mut u8).offset(-(layout_offset as isize));
+  let layout = *(buf as *mut Layout);
+
+  (buf, layout)
+}
+
+/// Calculate a layout for a given size with space for storing a layout at the start.
+/// Returns the layout and the offset to the data.
+fn layout_for_size_prepended(size: usize) -> (Layout, usize) {
+  Layout::new::<Layout>()
+    .extend(Layout::from_size_align(size, align_of::<*const u8>() * 2).unwrap())
+    .unwrap()
+}
+
+/// Store a layout in the pointer, returning a pointer to where the data should be stored.
+unsafe fn store_layout(buf: *mut u8, layout: Layout, offset_to_data: usize) -> *mut c_void {
+  *(buf as *mut Layout) = layout;
+  (buf as *mut u8).offset(offset_to_data as isize) as *mut c_void
+}
+
+/* -------------------------------- string.h -------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn strncmp(ptr1: *const c_void, ptr2: *const c_void, n: usize) -> c_int {
+  let s1 = std::slice::from_raw_parts(ptr1 as *const u8, n);
+  let s2 = std::slice::from_raw_parts(ptr2 as *const u8, n);
+
+  for (a, b) in s1.iter().zip(s2.iter()) {
+    if *a != *b || *a == 0 {
+      return (*a as i32) - (*b as i32);
+    }
+  }
+
+  0
+}
+
+/* -------------------------------- wctype.h -------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn iswspace(c: c_int) -> bool {
+  char::from_u32(c as u32).map_or(false, |c| c.is_whitespace())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iswalnum(c: c_int) -> bool {
+  char::from_u32(c as u32).map_or(false, |c| c.is_alphanumeric())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iswdigit(c: c_int) -> bool {
+  char::from_u32(c as u32).map_or(false, |c| c.is_digit(10))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iswalpha(c: c_int) -> bool {
+  char::from_u32(c as u32).map_or(false, |c| c.is_alphabetic())
+}
+
+/* --------------------------------- time.h --------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn clock() -> u64 {
+  panic!("clock is not supported");
+}
+
+/* --------------------------------- ctype.h -------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn isprint(c: c_int) -> bool {
+  c >= 32 && c <= 126
+}
+
+/* --------------------------------- stdio.h -------------------------------- */
+
+#[no_mangle]
+pub unsafe extern "C" fn fprintf(_file: *mut c_void, _format: *const c_void, _args: ...) -> c_int {
+  panic!("fprintf is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fputs(_s: *const c_void, _file: *mut c_void) -> c_int {
+  panic!("fputs is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fputc(_c: c_int, _file: *mut c_void) -> c_int {
+  panic!("fputc is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fdopen(_fd: c_int, _mode: *const c_void) -> *mut c_void {
+  panic!("fdopen is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fclose(_file: *mut c_void) -> c_int {
+  panic!("fclose is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fwrite(
+  _ptr: *const c_void,
+  _size: usize,
+  _nmemb: usize,
+  _stream: *mut c_void,
+) -> usize {
+  panic!("fwrite is not supported");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vsnprintf(
+  _buf: *mut c_char,
+  _size: usize,
+  _format: *const c_char,
+  _args: ...
+) -> c_int {
+  panic!("vsnprintf is not supported");
+}
+
+#[no_mangle]
+pub extern "C" fn clock_gettime(ptr: usize, new_size: usize) {
+  panic!("asdasd");
+}
+
+// int snprintf( char* restrict buffer, size_t bufsz, const char* restrict format, ... );
+#[no_mangle]
+pub extern "C" fn snprintf() {
+  panic!("snprintf is not supported");
+}
+
+#[no_mangle]
+pub extern "C" fn __assert_fail(_: *const i32, _: *const i32, _: *const i32, _: *const i32) {
+  panic!("oh no");
+}

--- a/crates/wasm/types.d.ts
+++ b/crates/wasm/types.d.ts
@@ -1,0 +1,417 @@
+export type WasmLang = "typescript" | "tsx";
+
+export declare class SgNode<
+  M extends TypesMap = TypesMap,
+  out T extends Kinds<M> = Kinds<M>
+> {
+  /** Returns the node's id */
+  id(): number;
+  range(): Range;
+  isLeaf(): boolean;
+  isNamed(): boolean;
+  isNamedLeaf(): boolean;
+  text(): string;
+  matches(m: string | number | WasmConfig<M>): boolean;
+  inside(m: string | number | WasmConfig<M>): boolean;
+  has(m: string | number | WasmConfig<M>): boolean;
+  precedes(m: string | number | WasmConfig<M>): boolean;
+  follows(m: string | number | WasmConfig<M>): boolean;
+  /** Returns the string name of the node kind */
+  kind(): T;
+  readonly kindToRefine: T;
+  /** Check if the node is the same kind as the given `kind` string */
+  is<K extends T>(kind: K): this is SgNode<M, K>;
+  // we need this override to allow string literal union
+  is(kind: string): boolean;
+
+  getMatch: NodeMethod<M, [mv: string]>;
+  getMultipleMatches(m: string): Array<SgNode<M>>;
+  getTransformed(m: string): string | null;
+  /** Returns the node's SgRoot */
+  getRoot(): SgRoot<M>;
+  children(): Array<SgNode<M>>;
+  find: NodeMethod<M, [matcher: string | number | WasmConfig<M>]>;
+  findAll<K extends Kinds<M>>(
+    matcher: string | number | WasmConfig<M>
+  ): Array<RefineNode<M, K>>;
+  /** Finds the first child node in the `field` */
+  field<F extends FieldNames<M[T]>>(name: F): FieldNode<M, T, F>;
+  /** Finds all the children nodes in the `field` */
+  fieldChildren<F extends FieldNames<M[T]>>(
+    name: F
+  ): Exclude<FieldNode<M, T, F>, null>[];
+  parent: NodeMethod<M>;
+  child(nth: number): SgNode<M, ChildKinds<M, T>> | null;
+  child<K extends NamedChildKinds<M, T>>(nth: number): RefineNode<M, K> | null;
+  ancestors(): Array<SgNode<M>>;
+  next: NodeMethod<M>;
+  nextAll(): Array<SgNode<M>>;
+  prev: NodeMethod<M>;
+  prevAll(): Array<SgNode<M>>;
+  replace(text: string): Edit;
+  commitEdits(edits: Array<Edit>): string;
+}
+/** Represents the parsed tree of code. */
+export declare class SgRoot<M extends TypesMap = TypesMap> {
+  /** Returns the root SgNode of the ast-grep instance. */
+  root(): SgNode<M, RootKind<M>>;
+  /**
+   * Returns the path of the file if it is discovered by ast-grep's `findInFiles`.
+   * Returns `"anonymous"` if the instance is created by `lang.parse(source)`.
+   */
+  filename(): string;
+}
+
+interface NodeMethod<M extends TypesMap, Args extends unknown[] = []> {
+  (...args: Args): SgNode<M> | null;
+  <K extends NamedKinds<M>>(...args: Args): RefineNode<M, K> | null;
+}
+
+/**
+ * if K contains string, return general SgNode. Otherwise,
+ * if K is a literal union, return a union of SgNode of each kind.
+ */
+type RefineNode<M extends TypesMap, K> = string extends K
+  ? SgNode<M>
+  : K extends Kinds<M>
+  ? SgNode<M, K>
+  : never;
+
+/**
+ * return the SgNode of the field in the node.
+ */
+// F extends string is used to prevent noisy TS hover info
+type FieldNode<
+  M extends TypesMap,
+  K extends Kinds<M>,
+  F extends FieldNames<M[K]>
+> = F extends string ? FieldNodeImpl<M, ExtractField<M[K], F>> : never;
+
+type FieldNodeImpl<M extends TypesMap, I extends NodeFieldInfo> = I extends {
+  required: true;
+}
+  ? RefineNode<M, TypesInField<M, I>>
+  : RefineNode<M, TypesInField<M, I>> | null;
+
+/**
+ * Rule configuration similar to YAML
+ * See https://ast-grep.github.io/reference/yaml.html
+ */
+export interface WasmConfig<M extends TypesMap = TypesMap> {
+  /** The rule object, see https://ast-grep.github.io/reference/rule.html */
+  rule: Rule<M>;
+  /** See https://ast-grep.github.io/guide/rule-config.html#constraints */
+  constraints?: Record<string, Rule<M>>;
+  /** Builtin Language or custom language */
+  language?: WasmLang;
+  /**
+   * transform is NOT useful in JavaScript. You can use JS code to directly transform the result.
+   * https://ast-grep.github.io/reference/yaml.html#transform
+   */
+  transform?: unknown;
+  /** https://ast-grep.github.io/guide/rule-config/utility-rule.html */
+  utils?: Record<string, Rule<M>>;
+}
+
+export interface FileOption {
+  paths: Array<string>;
+  languageGlobs: Record<string, Array<string>>;
+}
+
+export interface FindConfig<M extends TypesMap = TypesMap> {
+  /** specify the file paths to recursively find files */
+  paths: Array<string>;
+  /** a Rule object to find what nodes will match */
+  matcher: WasmConfig<M>;
+  /**
+   * An list of pattern globs to treat of certain files in the specified language.
+   * eg. ['*.vue', '*.svelte'] for html.findFiles, or ['*.ts'] for tsx.findFiles.
+   * It is slightly different from https://ast-grep.github.io/reference/sgconfig.html#languageglobs
+   */
+  languageGlobs?: Array<string>;
+}
+
+export type Strictness = "cst" | "smart" | "ast" | "relaxed" | "signature";
+
+export interface PatternObject<M extends TypesMap = TypesMap> {
+  context: string;
+  selector?: NamedKinds<M>; // only named node types
+  strictness?: Strictness;
+}
+
+export type PatternStyle<M extends TypesMap = TypesMap> =
+  | string
+  | PatternObject<M>;
+
+export interface Relation<M extends TypesMap = TypesMap> extends Rule<M> {
+  /**
+   * Specify how relational rule will stop relative to the target node.
+   */
+  stopBy?: "neighbor" | "end" | Rule<M>;
+  /** Specify the tree-sitter field in parent node. Only available in has/inside rule. */
+  field?: string;
+}
+
+export interface NthChildObject<M extends TypesMap = TypesMap> {
+  /** The position in nodes' sibling list. It can be a number of An+B string */
+  position: string | number;
+  ofRule?: Rule<M>;
+  reverse?: boolean;
+}
+
+/**
+ * NthChild can have these types:
+ * * number: the position of the node in the sibling list.
+ * * string: An + B style string like CSS nth-child selector.
+ * * object: An object with `position` and `ofRule` fields.
+ */
+export type NthChild<M extends TypesMap = TypesMap> =
+  | number
+  | string
+  | NthChildObject<M>;
+
+export interface Rule<M extends TypesMap = TypesMap> {
+  /** A pattern string or a pattern object. */
+  pattern?: PatternStyle<M>;
+  /** The kind name of the node to match. You can look up code's kind names in playground. */
+  kind?: NamedKinds<M>;
+  /** The exact range of the node in the source code. */
+  range?: Range;
+  /** A Rust regular expression to match the node's text. https://docs.rs/regex/latest/regex/#syntax */
+  regex?: string;
+  /**
+   * `nthChild` accepts number, string or object.
+   * It specifies the position in nodes' sibling list. */
+  nthChild?: NthChild<M>;
+
+  // relational
+  /**
+   * `inside` accepts a relational rule object.
+   * the target node must appear inside of another node matching the `inside` sub-rule. */
+  inside?: Relation<M>;
+  /**
+   * `has` accepts a relational rule object.
+   * the target node must has a descendant node matching the `has` sub-rule. */
+  has?: Relation<M>;
+  /**
+   * `precedes` accepts a relational rule object.
+   * the target node must appear before another node matching the `precedes` sub-rule. */
+  precedes?: Relation<M>;
+  /**
+   * `follows` accepts a relational rule object.
+   * the target node must appear after another node matching the `follows` sub-rule. */
+  follows?: Relation<M>;
+  // composite
+  /**
+   * A list of sub rules and matches a node if all of sub rules match.
+   * The meta variables of the matched node contain all variables from the sub-rules. */
+  all?: Array<Rule<M>>;
+  /**
+   * A list of sub rules and matches a node if any of sub rules match.
+   * The meta variables of the matched node only contain those of the matched sub-rule. */
+  any?: Array<Rule<M>>;
+  /** A single sub-rule and matches a node if the sub rule does not match. */
+  not?: Rule<M>;
+  /** A utility rule id and matches a node if the utility rule matches. */
+  matches?: string;
+}
+
+type Separator =
+  | "caseChange"
+  | "dash"
+  | "dot"
+  | "slash"
+  | "space"
+  | "underscore";
+
+type StringCase =
+  | "lowerCase"
+  | "upperCase"
+  | "capitalize"
+  | "camelCase"
+  | "snakeCase"
+  | "kebabCase"
+  | "pascalCase";
+
+interface Substring {
+  endChar?: number | null;
+  source: string;
+  startChar?: number | null;
+}
+
+interface Replace {
+  by: string;
+  replace: string;
+  source: string;
+}
+
+type Transformation =
+  | { substring: Substring }
+  | { replace: Replace }
+  | { convert: Convert }
+  | { rewrite: Rewrite };
+
+interface Rewrite {
+  joinBy?: string | null;
+  rewriters: string[];
+  source: string;
+}
+
+interface SerializableFixConfig {
+  expandEnd?: Relation;
+  expandStart?: Relation;
+  template: string;
+}
+
+type SerializableFixer = string | SerializableFixConfig;
+
+export type Severity = "hint" | "info" | "warning" | "error" | "off";
+
+export interface CompleteRuleConfig<M extends TypesMap = TypesMap>
+  extends WasmConfig<M> {
+  id: string;
+  fix?: SerializableFixer;
+  transform?: Record<string, Transformation>;
+  severity?: Severity;
+  note?: string;
+  message?: string;
+  ignores?: string[];
+  url?: string;
+}
+
+// Definitions
+interface Convert {
+  separatedBy?: Separator[] | null;
+  source: string;
+  toCase: StringCase;
+}
+
+export interface Edit {
+  /** The start position of the edit */
+  startPos: number;
+  /** The end position of the edit */
+  endPos: number;
+  /** The text to be inserted */
+  insertedText: string;
+}
+export interface Position {
+  /** line number starting from 0 */
+  line: number;
+  /** column number starting from 0 */
+  column: number;
+  /** byte offset of the position */
+  index: number;
+}
+export interface Range {
+  /** starting position of the range */
+  start: Position;
+  /** ending position of the range */
+  end: Position;
+}
+
+/**
+ * Reference
+ * https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+ * Rust CLI Impl
+ * https://github.com/tree-sitter/tree-sitter/blob/f279d10aa2aca37c0004d84b2261685739f3cab8/cli/generate/src/node_types.rs#L35-L47
+ */
+
+export interface NodeBasicInfo {
+  type: string;
+  named: boolean;
+}
+
+export interface NodeFieldInfo {
+  multiple: boolean;
+  required: boolean;
+  types: NodeBasicInfo[];
+}
+
+export interface NodeType extends NodeBasicInfo {
+  root?: boolean;
+  fields?: {
+    [fieldName: string]: NodeFieldInfo;
+  };
+  children?: NodeFieldInfo;
+  subtypes?: NodeBasicInfo[];
+}
+
+/**
+ * A map of key to NodeType.
+ * Note, the key is not necessary node's kind.
+ * it can be a rule representing a category of syntax nodes
+ * (e.g. “expression”, “type”, “declaration”).
+ * See reference above for more details.
+ */
+export interface TypesMap {
+  [key: string]: NodeType;
+}
+
+export type FieldNames<N extends NodeType> = N extends { fields: infer F }
+  ? keyof F
+  : string;
+
+export type ExtractField<
+  N extends NodeType,
+  F extends FieldNames<N>
+> = N["fields"] extends Record<F, NodeFieldInfo>
+  ? N["fields"][F]
+  : NodeFieldInfo;
+
+// in case of empty types array, return string as fallback
+type NoNever<T, Fallback> = [T] extends [never] ? Fallback : T;
+
+export type TypesInField<M extends TypesMap, I extends NodeFieldInfo> = NoNever<
+  ResolveType<M, I["types"][number]["type"]>,
+  Kinds<M>
+>;
+
+export type NamedChildKinds<
+  M extends TypesMap,
+  T extends Kinds<M>
+> = M[T] extends { children: infer C extends NodeFieldInfo }
+  ? TypesInField<M, C>
+  : NamedKinds<M>;
+export type ChildKinds<M extends TypesMap, T extends Kinds<M>> =
+  | NamedChildKinds<M, T>
+  | LowPriorityKey;
+
+/**
+ * resolve subtypes alias. see tree-sitter's reference
+ * e.g. like `expression` => `binary_expression` | `unary_expression` | ...
+ */
+type ResolveType<M extends TypesMap, K> = K extends keyof M
+  ? M[K] extends { subtypes: infer S extends NodeBasicInfo[] }
+    ? ResolveType<M, S[number]["type"]>
+    : K
+  : K;
+
+/**
+ * All named nodes' kinds that are usable in ast-grep rule
+ * NOTE: SgNode can return kind not in this list
+ */
+export type NamedKinds<M extends TypesMap> = ResolveType<M, keyof M>;
+
+/**
+ * See open-ended unions / string literal completion in TypeScript
+ * https://github.com/microsoft/TypeScript/issues/26277
+ * https://github.com/microsoft/TypeScript/issues/33471
+ */
+type LowPriorityKey = string & {};
+
+/**
+ * A union of all named node kinds and a low priority key
+ * tree-sitter Kinds also include unnamed nodes which is not usable in rule
+ * NOTE: SgNode can return a string type if it is not a named node
+ */
+export type Kinds<M extends TypesMap = TypesMap> =
+  | NamedKinds<M>
+  | LowPriorityKey;
+
+/**
+ * The root node kind of the tree.
+ */
+export type RootKind<M extends TypesMap> = NoNever<
+  Extract<M[keyof M], { root: true }>["type"],
+  Kinds<M>
+>;

--- a/crates/wasm/wasm-sysroot/assert.h
+++ b/crates/wasm/wasm-sysroot/assert.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define assert(ignore) ((void)0)
+#define static_assert(cnd, msg) assert(cnd && msg)

--- a/crates/wasm/wasm-sysroot/ctype.h
+++ b/crates/wasm/wasm-sysroot/ctype.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int isprint(int c);

--- a/crates/wasm/wasm-sysroot/inttypes.h
+++ b/crates/wasm/wasm-sysroot/inttypes.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define PRId32 "d"

--- a/crates/wasm/wasm-sysroot/stdbool.h
+++ b/crates/wasm/wasm-sysroot/stdbool.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define bool _Bool
+#define true 1
+#define false 0

--- a/crates/wasm/wasm-sysroot/stdint.h
+++ b/crates/wasm/wasm-sysroot/stdint.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef signed char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef unsigned long size_t;
+
+typedef unsigned int uintptr_t;
+
+#define UINT8_MAX 0xff
+#define UINT16_MAX 0xffff
+#define UINT32_MAX 0xffffffff

--- a/crates/wasm/wasm-sysroot/stdio.h
+++ b/crates/wasm/wasm-sysroot/stdio.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// just some filler type
+#define FILE void
+
+#define stdin NULL
+#define stdout NULL
+#define stderr NULL
+
+int fprintf(FILE *__restrict__, const char *__restrict__, ...);
+int fputs(const char *__restrict, FILE *__restrict);
+int fputc(int, FILE *);
+FILE *fdopen(int, const char *);
+int fclose(FILE *);
+
+int vsnprintf(char *s, unsigned long n, const char *format, ...);
+
+#define sprintf(str, ...) 0
+#define snprintf(str, len, ...) 0

--- a/crates/wasm/wasm-sysroot/stdlib.h
+++ b/crates/wasm/wasm-sysroot/stdlib.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+#define NULL ((void*)0)
+
+void* malloc(size_t size);
+void* calloc(size_t nmemb, size_t size);
+void free(void* ptr);
+void* realloc(void* ptr, size_t size);
+
+void abort(void);

--- a/crates/wasm/wasm-sysroot/string.h
+++ b/crates/wasm/wasm-sysroot/string.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void *memcpy(void *dest, const void *src, unsigned long n);
+void *memmove(void *dest, const void *src, unsigned long n);
+void *memset(void *s, int c, unsigned long n);
+int memcmp(const void *ptr1, const void *ptr2, unsigned long n);
+int strncmp(const char *s1, const char *s2, unsigned long n);

--- a/crates/wasm/wasm-sysroot/time.h
+++ b/crates/wasm/wasm-sysroot/time.h
@@ -1,0 +1,5 @@
+#pragma once
+
+typedef unsigned long clock_t;
+#define CLOCKS_PER_SEC ((clock_t)1000000)
+clock_t clock(void);

--- a/crates/wasm/wasm-sysroot/unistd.h
+++ b/crates/wasm/wasm-sysroot/unistd.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int dup(int);

--- a/crates/wasm/wasm-sysroot/wctype.h
+++ b/crates/wasm/wasm-sysroot/wctype.h
@@ -1,0 +1,9 @@
+#pragma once
+
+typedef __WCHAR_TYPE__ wchar_t;
+typedef __WINT_TYPE__ wint_t;
+
+int iswspace(wchar_t ch);
+int iswalnum(wint_t _wc);
+int iswalpha(wint_t _wc);
+int iswdigit(wint_t _wc);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR adds a new package `crates/wasm` that porting the NAPI api to WASM. It also removes the need for the facade package, and allows ast-grep to continue using the native tree-sitter package. It was achieved by shimming the standard C libraries with custom implementations.

This WASM binary is being used live in [Codemod's studio here](https://app.codemod.com/private/studio-ast-grep)