### PR TITLE
chore: Remove tree-sitter facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "tokio",
- "tree-sitter-facade-sg",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "bit-set",
  "regex",
  "thiserror",
- "tree-sitter-facade-sg",
+ "tree-sitter",
  "tree-sitter-typescript 0.21.2",
 ]
 
@@ -241,7 +241,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "serde_json",
- "tree-sitter-facade-sg",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -610,9 +610,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",
@@ -991,7 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.4"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67baf55e7e1b6806063b1e51041069c90afff16afcbbccd278d899f9d84bca4"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
 dependencies = [
  "cc",
  "regex",
@@ -1989,20 +1989,6 @@ checksum = "e45d444647b4fd53d8fd32474c1b8bedc1baa22669ce3a78d083e365fa9a2d3f"
 dependencies = [
  "cc",
  "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-facade-sg"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195ab85ddd7df7ddac5b2e397ec6264816ae640346013002ceccf0f9b3578f1"
-dependencies = [
- "js-sys",
- "tree-sitter",
- "tree-sitter-language",
- "wasm-bindgen",
- "web-sys",
- "web-tree-sitter-sg",
 ]
 
 [[package]]
@@ -2304,18 +2290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,17 +2326,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web-tree-sitter-sg"
-version = "0.24.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cf7d34b16550f076d75b4a5d4673f1a9692f79787d040e3ac7ddb04e5c48a0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
-tree-sitter = { version = "0.24.5", package = "tree-sitter-facade-sg" }
+tree-sitter = { version = "0.24.4" }
 thiserror = "2.0.0"
 schemars = "0.8.17"
 anyhow = "1.0.82"

--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -168,7 +168,12 @@ fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let sp = start.ts_point();
   let end = node.end_pos();
   let ep = end.ts_point();
-  TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
+  TSRange {
+    start_byte: r.start,
+    end_byte: r.end,
+    start_point: sp,
+    end_point: ep,
+  }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -83,7 +83,7 @@ fn dump_pattern(
       let lang = lang.get_ts_language();
       if *is_named {
         let kind = lang.node_kind_for_id(*kind_id).unwrap();
-        let kind = style.kind_style.paint(format!("{kind}"));
+        let kind = style.kind_style.paint(kind.to_string());
         writeln!(ret, "{kind} {text}")?;
       } else {
         writeln!(ret, "{text}")?;
@@ -189,8 +189,8 @@ impl From<ts::Point> for Pos {
   #[inline]
   fn from(pt: ts::Point) -> Self {
     Pos {
-      row: pt.row(),
-      column: pt.column(),
+      row: pt.row as u32,
+      column: pt.column as u32,
     }
   }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
       Some(TypeScript::Tsx)
     }
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::language_tsx()
     }
   }
 

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -29,7 +29,7 @@ fn field_name_to_id<L: Language>(
   };
   let ts_lang = env.lang.get_ts_language();
   match ts_lang.field_id_for_name(&field) {
-    Some(id) => Ok(Some(id)),
+    Some(id) => Ok(Some(id.into())),
     None => Err(RuleSerializeError::InvalidField(field)),
   }
 }
@@ -621,7 +621,10 @@ mod test {
     let inside = Inside {
       stop_by: StopBy::End,
       outer: Rule::Kind(KindMatcher::new("for_statement", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx
+        .get_ts_language()
+        .field_id_for_name("condition")
+        .map(|id| id.into()),
     };
     let rule = make_rule("a = 1", Rule::Inside(Box::new(inside)));
     test_found(&["for (;a = 1;) {}"], &rule);
@@ -633,7 +636,10 @@ mod test {
     let has = Has {
       stop_by: StopBy::End,
       inner: Rule::Pattern(Pattern::new("a = 1", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx
+        .get_ts_language()
+        .field_id_for_name("condition")
+        .map(|id| id.into()),
     };
     let rule = o::All::new(vec![
       Rule::Kind(KindMatcher::new("for_statement", TS::Tsx)),
@@ -674,13 +680,19 @@ mod test {
     let inside = Inside {
       stop_by: StopBy::Rule(Rule::Pattern(Pattern::new("var $C", TS::Tsx))),
       outer: Rule::Pattern(Pattern::new("var a = $A", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx
+        .get_ts_language()
+        .field_id_for_name("condition")
+        .map(|id| id.into()),
     };
     assert_eq!(inside.defined_vars(), ["A", "C"].into_iter().collect());
     let has = Has {
       stop_by: StopBy::Rule(Rule::Kind(KindMatcher::new("for_statement", TS::Tsx))),
       inner: Rule::Pattern(Pattern::new("var a = $A", TS::Tsx)),
-      field: TS::Tsx.get_ts_language().field_id_for_name("condition"),
+      field: TS::Tsx
+        .get_ts_language()
+        .field_id_for_name("condition")
+        .map(|id| id.into()),
     };
     assert_eq!(has.defined_vars(), ["A"].into_iter().collect());
   }

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -86,7 +86,7 @@ mod test {
   pub struct Tsx;
   impl Language for Tsx {
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx().into()
+      tree_sitter_typescript::language_tsx()
     }
   }
 }

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -202,8 +202,8 @@ where
         // NOTE: start_byte is not always index range of source's slice.
         // e.g. start_byte is still byte_offset in utf_16 (napi). start_byte
         // so we need to call source's get_range method
-        let start = nodes[0].inner.start_byte() as usize;
-        let end = nodes[nodes.len() - 1].inner.end_byte() as usize;
+        let start = nodes[0].inner.start_byte();
+        let end = nodes[nodes.len() - 1].inner.end_byte();
         Some(nodes[0].root.doc.get_source().get_range(start..end))
       }
     }

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -21,8 +21,8 @@ fn collect_edits<D: Doc>(root: &Root<D>, env: &MetaVarEnv<D>, lang: &D::Lang) ->
       let position = node.inner.start_byte();
       let length = node.inner.end_byte() - position;
       edits.push(Edit::<D> {
-        position: position as usize,
-        deleted_length: length as usize,
+        position,
+        deleted_length: length,
         inserted_text: text,
       });
     } else if let Some(first_child) = node.child(0) {

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -136,8 +136,8 @@ where
       // NOTE: start_byte is not always index range of source's slice.
       // e.g. start_byte is still byte_offset in utf_16 (napi). start_byte
       // so we need to call source's get_range method
-      let start = nodes[0].inner.start_byte() as usize;
-      let end = nodes[nodes.len() - 1].inner.end_byte() as usize;
+      let start = nodes[0].inner.start_byte();
+      let end = nodes[nodes.len() - 1].inner.end_byte();
       let source = nodes[0].root.doc.get_source();
       (source, start..end)
     }

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -15,18 +15,18 @@ use crate::language::Language;
 use std::borrow::Cow;
 use std::ops::Range;
 use thiserror::Error;
-use tree_sitter::{
-  InputEdit, Language as TsLang, LanguageError, Node, Parser, ParserError, Point, Tree,
-};
+use tree_sitter::{InputEdit, Language as TsLang, LanguageError, Node, Parser, Point, Tree};
 
 #[inline]
 fn parse_lang(
-  parse_fn: impl Fn(&mut Parser) -> Result<Option<Tree>, ParserError>,
+  parse_fn: impl Fn(&mut Parser) -> Option<Tree>,
   ts_lang: TsLang,
 ) -> Result<Tree, TSParseError> {
-  let mut parser = Parser::new()?;
-  parser.set_language(&ts_lang)?;
-  if let Some(tree) = parse_fn(&mut parser)? {
+  let mut parser = Parser::new();
+  parser
+    .set_language(&ts_lang)
+    .map_err(TSParseError::Language)?;
+  if let Some(tree) = parse_fn(&mut parser) {
     Ok(tree)
   } else {
     Err(TSParseError::TreeUnavailable)
@@ -64,8 +64,6 @@ pub fn perform_edit<S: Content>(tree: &mut Tree, input: &mut S, edit: &Edit<S>) 
 /// Represents tree-sitter related error
 #[derive(Debug, Error)]
 pub enum TSParseError {
-  #[error("web-tree-sitter parser is not available")]
-  Parse(#[from] ParserError),
   #[error("incompatible `Language` is assigned to a `Parser`.")]
   Language(#[from] LanguageError),
   /// A general error when tree sitter fails to parse in time. It can be caused by
@@ -132,11 +130,7 @@ impl<L: Language> Doc for StrDoc<L> {
 
 pub trait Content: Sized {
   type Underlying: Clone + PartialEq;
-  fn parse_tree_sitter(
-    &self,
-    parser: &mut Parser,
-    tree: Option<&Tree>,
-  ) -> Result<Option<Tree>, ParserError>;
+  fn parse_tree_sitter(&self, parser: &mut Parser, tree: Option<&Tree>) -> Option<Tree>;
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying];
   fn accept_edit(&mut self, edit: &Edit<Self>) -> InputEdit;
   fn get_text<'a>(&'a self, node: &Node) -> Cow<'a, str>;
@@ -152,20 +146,18 @@ pub trait Content: Sized {
 
 impl Content for String {
   type Underlying = u8;
-  fn parse_tree_sitter(
-    &self,
-    parser: &mut Parser,
-    tree: Option<&Tree>,
-  ) -> Result<Option<Tree>, ParserError> {
+  fn parse_tree_sitter(&self, parser: &mut Parser, tree: Option<&Tree>) -> Option<Tree> {
     parser.parse(self.as_bytes(), tree)
   }
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
     &self.as_bytes()[range]
   }
   fn get_text<'a>(&'a self, node: &Node) -> Cow<'a, str> {
-    node
-      .utf8_text(self.as_bytes())
-      .expect("invalid source text encoding")
+    Cow::Borrowed(
+      node
+        .utf8_text(self.as_bytes())
+        .expect("invalid source text encoding"),
+    )
   }
   fn accept_edit(&mut self, edit: &Edit<Self>) -> InputEdit {
     let start_byte = edit.position;
@@ -176,14 +168,14 @@ impl Content for String {
     let old_end_position = position_for_offset(input, old_end_byte);
     input.splice(start_byte..old_end_byte, edit.inserted_text.clone());
     let new_end_position = position_for_offset(input, new_end_byte);
-    InputEdit::new(
-      start_byte as u32,
-      old_end_byte as u32,
-      new_end_byte as u32,
-      &start_position,
-      &old_end_position,
-      &new_end_position,
-    )
+    InputEdit {
+      start_byte,
+      old_end_byte,
+      new_end_byte,
+      start_position,
+      old_end_position,
+      new_end_position,
+    }
   }
   fn decode_str(src: &str) -> Cow<[Self::Underlying]> {
     Cow::Borrowed(src.as_bytes())
@@ -218,7 +210,7 @@ mod test {
   use crate::language::{Language, Tsx};
 
   fn parse(src: &str) -> Result<Tree, TSParseError> {
-    parse_lang(|p| p.parse(src, None), Tsx.get_ts_language())
+    parse_lang(|p| p.parse(src.as_bytes(), None), Tsx.get_ts_language())
   }
 
   #[test]
@@ -226,8 +218,10 @@ mod test {
     let tree = parse("var a = 1234")?;
     let root_node = tree.root_node();
     assert_eq!(root_node.kind(), "program");
-    assert_eq!(root_node.start_position().column(), 0);
-    assert_eq!(root_node.end_position().column(), 12);
+    assert_eq!(root_node.start_position().row, 0);
+    assert_eq!(root_node.start_position().column, 0);
+    assert_eq!(root_node.end_position().row, 0);
+    assert_eq!(root_node.end_position().column, 12);
     assert_eq!(
       root_node.to_sexp(),
       "(program (variable_declaration (variable_declarator name: (identifier) value: (number))))"
@@ -259,9 +253,11 @@ mod test {
   fn test_row_col() -> Result<(), TSParseError> {
     let tree = parse("😄")?;
     let root = tree.root_node();
-    assert_eq!(root.start_position(), Point::new(0, 0));
+    assert_eq!(root.start_position().row, 0);
+    assert_eq!(root.start_position().column, 0);
     // NOTE: Point in tree-sitter is counted in bytes instead of char
-    assert_eq!(root.end_position(), Point::new(0, 4));
+    assert_eq!(root.end_position().row, 0);
+    assert_eq!(root.end_position().column, 4);
     Ok(())
   }
 
@@ -278,7 +274,10 @@ mod test {
         inserted_text: " * b".into(),
       },
     );
-    let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), Tsx.get_ts_language())?;
+    let tree2 = parse_lang(
+      |p| p.parse(src.as_bytes(), Some(&tree)),
+      Tsx.get_ts_language(),
+    )?;
     assert_eq!(
       tree.root_node().to_sexp(),
       "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"

--- a/crates/core/src/traversal.rs
+++ b/crates/core/src/traversal.rs
@@ -366,7 +366,7 @@ pub struct Level<'tree, D: Doc> {
 impl<'tree, D: Doc> Level<'tree, D> {
   pub fn new(node: &Node<'tree, D>) -> Self {
     let mut deque = VecDeque::new();
-    deque.push_back(node.inner.clone());
+    deque.push_back(node.inner);
     let cursor = node.inner.walk();
     Self {
       deque,

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -132,7 +132,7 @@ unsafe fn load_ts_language(
   } else {
     // ATTENTION: dragon ahead
     // must hold valid reference to NativeTS
-    Ok((lib, lang.into()))
+    Ok((lib, lang))
   }
 }
 

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -71,7 +71,12 @@ fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
   let sp = start.ts_point();
   let end = node.end_pos();
   let ep = end.ts_point();
-  TSRange::new(r.start as u32, r.end as u32, &sp, &ep)
+  TSRange {
+    start_byte: r.start,
+    end_byte: r.end,
+    start_point: sp,
+    end_point: ep,
+  }
 }
 
 #[cfg(test)]

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -19,7 +19,7 @@ ast-grep-language = { path = "../language", features = ["napi-lang"], default-fe
 ast-grep-dynamic.workspace = true
 
 napi = { version = "2.16.4", features = ["serde-json", "napi4", "error_anyhow"] }
-napi-derive = "2.16.3"
+napi-derive = "2.16.4"
 
 ignore.workspace = true
 tree-sitter.workspace = true

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -6,7 +6,7 @@ use ast_grep_core::Language;
 use napi::anyhow::Error;
 use napi::bindgen_prelude::Result as NapiResult;
 use napi_derive::napi;
-use tree_sitter::{InputEdit, Node, Parser, ParserError, Point, Tree};
+use tree_sitter::{InputEdit, Node, Parser, Point, Tree};
 
 use std::borrow::Cow;
 use std::ops::Range;
@@ -55,11 +55,7 @@ pub struct Wrapper {
 
 impl Content for Wrapper {
   type Underlying = u16;
-  fn parse_tree_sitter(
-    &self,
-    parser: &mut Parser,
-    tree: Option<&Tree>,
-  ) -> std::result::Result<Option<Tree>, ParserError> {
+  fn parse_tree_sitter(&self, parser: &mut Parser, tree: Option<&Tree>) -> Option<Tree> {
     parser.parse_utf16(self.inner.as_slice(), tree)
   }
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
@@ -77,14 +73,14 @@ impl Content for Wrapper {
     let old_end_position = pos_for_byte_offset(input, old_end_byte);
     input.splice(start_byte / 2..old_end_byte / 2, edit.inserted_text.clone());
     let new_end_position = pos_for_byte_offset(input, new_end_byte);
-    InputEdit::new(
-      start_byte as u32,
-      old_end_byte as u32,
-      new_end_byte as u32,
-      &start_position,
-      &old_end_position,
-      &new_end_position,
-    )
+    InputEdit {
+      start_byte,
+      old_end_byte,
+      new_end_byte,
+      start_position,
+      old_end_position,
+      new_end_position,
+    }
   }
   fn get_text<'a>(&'a self, node: &Node) -> Cow<'a, str> {
     let slice = self.inner.as_slice();
@@ -142,14 +138,13 @@ impl Doc for JsDoc {
   type Lang = NapiLang;
   type Source = Wrapper;
   fn parse(&self, old_tree: Option<&Tree>) -> std::result::Result<Tree, TSParseError> {
-    let mut parser = Parser::new()?;
+    let mut parser = Parser::new();
     let ts_lang = self.lang.get_ts_language();
     parser.set_language(&ts_lang)?;
-    if let Some(tree) = self.source.parse_tree_sitter(&mut parser, old_tree)? {
-      Ok(tree)
-    } else {
-      Err(TSParseError::TreeUnavailable)
-    }
+    self
+      .source
+      .parse_tree_sitter(&mut parser, old_tree)
+      .ok_or(TSParseError::TreeUnavailable)
   }
   fn get_lang(&self) -> &Self::Lang {
     &self.lang


### PR DESCRIPTION
As proposed in https://github.com/ast-grep/ast-grep/pull/1869, we can now build ast-grep with wasm32-unknown-unknown target without the need for the tree-sitter-web-sys hack so we can replace the tree-sitter facade with native tree-sitter.

This PR just replaces `tree-sitter-facade-sg` with `tree-sitter` and since the facade had diverged from the main tree-sitter repo, a few things had to be tweaked on top of swapping the dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated external dependency versions for `tree-sitter` (from `0.24.5` to `0.24.4`) and `napi-derive` (from `2.16.3` to `2.16.4`) to ensure consistent builds.

- **Refactor**
  - Streamlined error handling and parsing mechanisms for greater robustness.
  - Enhanced initialization and type conversion processes for improved efficiency.
  - Refined API interactions to boost overall performance and reliability.
  - Simplified value retrieval and object instantiation methods across various components.
  - Improved memory management by reducing unnecessary cloning in data structures.
  - Simplified handling of byte offsets and type conversions in multiple functions for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->