### PR TITLE
chore: Unify tree-sitter dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
  "regex",
  "thiserror",
  "tree-sitter",
- "tree-sitter-typescript 0.21.2",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-swift",
- "tree-sitter-typescript 0.23.2",
+ "tree-sitter-typescript",
  "tree-sitter-yaml",
 ]
 
@@ -2135,16 +2135,6 @@ checksum = "bdc72ea9c62a6d188c9f7d64109a9b14b09231852b87229c68c44e8738b9e6b9"
 dependencies = [
  "cc",
  "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-typescript"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
-dependencies = [
- "cc",
- "tree-sitter",
 ]
 
 [[package]]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,4 +26,4 @@ thiserror.workspace = true
 schemars.workspace = true
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = "0.23.2"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
       Some(TypeScript::Tsx)
     }
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,4 +23,4 @@ tree-sitter.workspace = true
 default = ["regex"]
 
 [dev-dependencies]
-tree-sitter-typescript = "0.21.1"
+tree-sitter-typescript = "0.23.2"

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -86,7 +86,7 @@ mod test {
   pub struct Tsx;
   impl Language for Tsx {
     fn get_ts_language(&self) -> TSLanguage {
-      tree_sitter_typescript::language_tsx()
+      tree_sitter_typescript::LANGUAGE_TSX.into()
     }
   }
 }

--- a/crates/dynamic/Cargo.toml
+++ b/crates/dynamic/Cargo.toml
@@ -17,7 +17,7 @@ ignore.workspace = true
 libloading = "0.8.3"
 serde.workspace = true
 thiserror.workspace = true
-tree-sitter-native = { version = "0.24.4", package = "tree-sitter" }
+tree-sitter.workspace = true
 
 [dev-dependencies]
 serde_yaml.workspace = true

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -5,7 +5,7 @@ use ignore::types::{Types, TypesBuilder};
 use libloading::{Error as LibError, Library, Symbol};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tree_sitter_native::{Language as NativeTS, LANGUAGE_VERSION, MIN_COMPATIBLE_LANGUAGE_VERSION};
+use tree_sitter::{Language as NativeTS, LANGUAGE_VERSION, MIN_COMPATIBLE_LANGUAGE_VERSION};
 
 use std::borrow::Cow;
 use std::fs::canonicalize;


### PR DESCRIPTION
Remove tree-sitter-native from `crates/dynamic` and use the same `tree-sitter-typescript` version for tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated several dependency versions and streamlined dependency management for improved consistency.
  
- **Refactor**
  - Optimized the internal mechanism for TypeScript language processing without altering external functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->