### PR TITLE
feat(KindMatcher): Support super types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,9 +386,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -1920,13 +1920,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "b9ac5ea5e7f2f1700842ec071401010b9c59bf735295f6e9fa079c3dc035b167"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
-tree-sitter = { version = "0.24.4" }
+tree-sitter = { version = "0.25.3" }
 thiserror = "2.0.0"
 schemars = "0.8.17"
 anyhow = "1.0.82"

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -126,7 +126,7 @@ unsafe fn load_ts_language(
     .get(name.as_bytes())
     .map_err(DynamicLangError::ReadSymbol)?;
   let lang = func();
-  let version = lang.version();
+  let version = lang.abi_version();
   if !(MIN_COMPATIBLE_LANGUAGE_VERSION..=LANGUAGE_VERSION).contains(&version) {
     Err(DynamicLangError::IncompatibleVersion(version))
   } else {

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -56,7 +56,7 @@ pub struct Wrapper {
 impl Content for Wrapper {
   type Underlying = u16;
   fn parse_tree_sitter(&self, parser: &mut Parser, tree: Option<&Tree>) -> Option<Tree> {
-    parser.parse_utf16(self.inner.as_slice(), tree)
+    parser.parse_utf16_le(self.inner.as_slice(), tree)
   }
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
     // the range is in byte offset, but our underlying is u16


### PR DESCRIPTION
As mentioned in https://github.com/ast-grep/ast-grep/pull/1784, `ast-grep` currently accepts supertypes like "declaration" and "expression" as valid types but doesn't actually match anything.  

Ideally, it should either return an `InvalidKindName` error or match all subtypes instead of doing nothing.  

Tree-sitter recently introduced support for exposing supertype data. While the tree-sitter crate already includes the necessary API changes, the parser dependencies haven't been updated in the last four months. As a result, this PR won't have any effect until the tree-sitter team updates those crates using the new `tree-sitter-cli`. We can disable the test and merge, or just wait until the `tree-sitter-typescript` crate is updated.

To make the test pass, you can replace the tree-sitter-typescript dependency in `core/Cargo.toml` with the following:

```
tree-sitter-typescript = { package = "tree-sitter-typescript-codemod", version = "0.25.0-codemod.1" }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the `tree-sitter` library dependency to version `0.25.3`, enhancing underlying performance and stability.
- **Refactor**
  - Revamped matching functionality to support multiple subtypes more effectively, with added test coverage for supertype matching.
  - Improved language compatibility checks by switching to ABI version retrieval for better validation.
  - Standardized UTF‑16 parsing to consistently use little‑endian encoding for reliable text processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->