### PR TITLE
feat: ast-grep Parser Abstratction (Part 1, Node)

### DIFF
--- a/benches/src/sg_benchmark.rs
+++ b/benches/src/sg_benchmark.rs
@@ -13,7 +13,7 @@ fn read_rule() -> RuleConfig<SupportLang> {
   rules.pop().unwrap()
 }
 
-fn find_pattern<M: Matcher<SupportLang>>(sg: &AstGrep<StrDoc<SupportLang>>, pattern: &M) {
+fn find_pattern<M: Matcher>(sg: &AstGrep<StrDoc<SupportLang>>, pattern: &M) {
   sg.root().find_all(pattern).for_each(drop);
 }
 

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -128,7 +128,7 @@ fn build_util_walker(base_dir: &Path, util_dirs: &Option<Vec<PathBuf>>) -> Optio
   Some(walker)
 }
 
-fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules<SgLang>> {
+fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
   let ProjectConfig {
     project_dir,
     util_dirs,
@@ -155,13 +155,13 @@ fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules<SgLang>> {
     utils.push(new_configs);
   }
 
-  let ret = DeserializeEnv::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
+  let ret = DeserializeEnv::<SgLang>::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
   Ok(ret)
 }
 
 fn read_directory_yaml(
   config: &ProjectConfig,
-  global_rules: GlobalRules<SgLang>,
+  global_rules: GlobalRules,
   rule_overwrite: RuleOverwrite,
 ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
   let mut configs = vec![];
@@ -219,7 +219,7 @@ pub fn with_rule_stats(
 
 pub fn read_rule_file(
   path: &Path,
-  global_rules: Option<&GlobalRules<SgLang>>,
+  global_rules: Option<&GlobalRules>,
 ) -> Result<Vec<RuleConfig<SgLang>>> {
   let yaml = read_to_string(path).with_context(|| EC::ReadRule(path.to_path_buf()))?;
   let parsed = if let Some(globals) = global_rules {

--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -34,7 +34,7 @@ pub struct SerializableInjection {
 
 struct Injection {
   host: SgLang,
-  rules: Vec<(RuleCore<SgLang>, Option<String>)>,
+  rules: Vec<(RuleCore, Option<String>)>,
   injectable: HashSet<String>,
 }
 

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -9,7 +9,7 @@ use ast_grep_core::{
   Doc, Node,
 };
 use ast_grep_dynamic::DynamicLang;
-use ast_grep_language::{Language, SupportLang};
+use ast_grep_language::{CoreLanguage, Language, SupportLang};
 use ignore::types::Types;
 use serde::{Deserialize, Serialize};
 
@@ -151,23 +151,7 @@ impl From<DynamicLang> for SgLang {
 }
 
 use SgLang::*;
-impl Language for SgLang {
-  fn get_ts_language(&self) -> TSLanguage {
-    match self {
-      Builtin(b) => b.get_ts_language(),
-      Custom(c) => c.get_ts_language(),
-    }
-  }
-
-  fn from_path<P: AsRef<Path>>(path: P) -> Option<Self> {
-    // respect user overriding like languageGlobs and custom lang
-    // TODO: test this preference
-    let path = path.as_ref();
-    lang_globs::from_path(path)
-      .or_else(|| DynamicLang::from_path(path).map(Custom))
-      .or_else(|| SupportLang::from_path(path).map(Builtin))
-  }
-
+impl CoreLanguage for SgLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -188,6 +172,23 @@ impl Language for SgLang {
     match self {
       Builtin(b) => b.expando_char(),
       Custom(c) => c.expando_char(),
+    }
+  }
+}
+impl Language for SgLang {
+  fn from_path<P: AsRef<Path>>(path: P) -> Option<Self> {
+    // respect user overriding like languageGlobs and custom lang
+    // TODO: test this preference
+    let path = path.as_ref();
+    lang_globs::from_path(path)
+      .or_else(|| DynamicLang::from_path(path).map(Custom))
+      .or_else(|| SupportLang::from_path(path).map(Builtin))
+  }
+
+  fn get_ts_language(&self) -> TSLanguage {
+    match self {
+      Builtin(b) => b.get_ts_language(),
+      Custom(c) => c.get_ts_language(),
     }
   }
 

--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -234,7 +234,7 @@ impl PrintProcessor<Buffer> for ColoredProcessor {
           "{}:{}:{}: ",
           path.display(),
           pos.line() + 1,
-          pos.column(&diff.node_match) + 1
+          pos.column(&*diff.node_match) + 1
         )?;
       }
       print_rule_title(rule, &diff.node_match, &self.styles.rule, writer)?;

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -366,11 +366,7 @@ language: TypeScript
     .unwrap()
   }
 
-  fn make_diffs(
-    grep: &AstGrep<StrDoc<SgLang>>,
-    matcher: impl Matcher<SgLang>,
-    fixer: &Fixer<SgLang>,
-  ) -> Diffs<()> {
+  fn make_diffs(grep: &AstGrep<StrDoc<SgLang>>, matcher: impl Matcher, fixer: &Fixer) -> Diffs<()> {
     let root = grep.root();
     let old_source = root.root().get_text().to_string();
     let contents = Visitor::new(&matcher)
@@ -418,7 +414,8 @@ fix: ($B, lifecycle.update(['$A']))",
     let diffs = make_diffs(
       &root,
       "Some($A)",
-      &Fixer::from_str("$A", &SupportLang::TypeScript.into()).expect("fixer must compile"),
+      &Fixer::from_str::<SgLang>("$A", &SupportLang::TypeScript.into())
+        .expect("fixer must compile"),
     );
     let ret = apply_rewrite(diffs);
     assert_eq!("Some(1)", ret);
@@ -431,7 +428,8 @@ fix: ($B, lifecycle.update(['$A']))",
     let diffs = make_diffs(
       &root,
       "Some($A)",
-      &Fixer::from_str("$A", &SupportLang::TypeScript.into()).expect("fixer must compile"),
+      &Fixer::from_str::<SgLang>("$A", &SupportLang::TypeScript.into())
+        .expect("fixer must compile"),
     );
     let ret = apply_rewrite(diffs);
     assert_eq!("\n\n\n1", ret);

--- a/crates/cli/src/print/mod.rs
+++ b/crates/cli/src/print/mod.rs
@@ -71,11 +71,7 @@ pub struct Diff<'n> {
 }
 
 impl<'n> Diff<'n> {
-  pub fn generate(
-    node_match: NodeMatch<'n>,
-    matcher: &impl Matcher<SgLang>,
-    rewrite: &Fixer<SgLang>,
-  ) -> Self {
+  pub fn generate(node_match: NodeMatch<'n>, matcher: &impl Matcher, rewrite: &Fixer) -> Self {
     let edit = node_match.make_edit(matcher, rewrite);
     let replacement = String::from_utf8(edit.inserted_text).unwrap();
     Self {

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -113,7 +113,7 @@ pub struct RunArg {
 }
 
 impl RunArg {
-  fn build_pattern(&self, lang: SgLang) -> Result<Pattern<SgLang>> {
+  fn build_pattern(&self, lang: SgLang) -> Result<Pattern> {
     let pattern = if let Some(sel) = &self.selector {
       Pattern::contextual(&self.pattern, sel, lang)
     } else {
@@ -128,7 +128,7 @@ impl RunArg {
   }
 
   // do not unwrap pattern here, we should allow non-pattern to be debugged as tree
-  fn debug_pattern_if_needed(&self, pattern_ret: &Result<Pattern<SgLang>>, lang: SgLang) {
+  fn debug_pattern_if_needed(&self, pattern_ret: &Result<Pattern>, lang: SgLang) {
     let Some(debug_query) = &self.debug_query else {
       return;
     };
@@ -244,8 +244,8 @@ impl PathWorker for RunWithInferredLang {
 
 struct RunWithSpecificLang {
   arg: RunArg,
-  pattern: Pattern<SgLang>,
-  rewrite: Option<Fixer<SgLang>>,
+  pattern: Pattern,
+  rewrite: Option<Fixer>,
   stats: RunTrace,
 }
 
@@ -349,8 +349,8 @@ impl StdInWorker for RunWithSpecificLang {
 }
 fn match_one_file<T, P: PrintProcessor<T>>(
   processor: &P,
-  match_unit: &MatchUnit<impl Matcher<SgLang>>,
-  rewrite: &Option<Fixer<SgLang>>,
+  match_unit: &MatchUnit<impl Matcher>,
+  rewrite: &Option<Fixer>,
 ) -> Result<Option<T>> {
   let MatchUnit {
     path,

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -17,7 +17,7 @@ pub enum DebugFormat {
   Sexp,
 }
 impl DebugFormat {
-  pub fn debug_pattern(&self, pattern: &Pattern<SgLang>, lang: SgLang, colored: bool) {
+  pub fn debug_pattern(&self, pattern: &Pattern, lang: SgLang, colored: bool) {
     match self {
       DebugFormat::Pattern => {
         let lang = lang.get_ts_language();

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -147,12 +147,12 @@ pub fn filter_file_rule(
 pub fn filter_file_pattern<'a>(
   path: &Path,
   lang: SgLang,
-  root_matcher: Option<&'a Pattern<SgLang>>,
-  sub_matchers: &'a [(SgLang, Pattern<SgLang>)],
-) -> Result<SmallVec<[MatchUnit<&'a Pattern<SgLang>>; 1]>> {
+  root_matcher: Option<&'a Pattern>,
+  sub_matchers: &'a [(SgLang, Pattern)],
+) -> Result<SmallVec<[MatchUnit<&'a Pattern>; 1]>> {
   let file_content = read_file(path)?;
   let grep = lang.ast_grep(&file_content);
-  let do_match = |ast_grep: AstGrep, matcher: &'a Pattern<SgLang>| {
+  let do_match = |ast_grep: AstGrep, matcher: &'a Pattern| {
     let fixed = matcher.fixed_string();
     if !fixed.is_empty() && !file_content.contains(&*fixed) {
       return None;
@@ -189,7 +189,7 @@ fn file_too_large(file_content: &str) -> bool {
 /// A single atomic unit where matches happen.
 /// It contains the file path, sg instance and matcher.
 /// An analogy to compilation unit in C programming language.
-pub struct MatchUnit<M: Matcher<SgLang>> {
+pub struct MatchUnit<M: Matcher> {
   pub path: PathBuf,
   pub grep: AstGrep,
   pub matcher: M,

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -2,7 +2,7 @@ use crate::{RuleConfig, SerializableRule, SerializableRuleConfig, SerializableRu
 
 use ast_grep_core::language::Language;
 use ast_grep_core::matcher::{Matcher, MatcherExt};
-use ast_grep_core::{AstGrep, Doc, Node, NodeMatch};
+use ast_grep_core::{AstGrep, Doc, NodeMatch, SgNode};
 
 use std::collections::{HashMap, HashSet};
 
@@ -52,7 +52,7 @@ impl<'t, D: Doc> ScanResultInner<'t, D> {
 
 struct Suppressions(HashMap<usize, Suppression>);
 impl Suppressions {
-  fn collect<D: Doc>(&mut self, node: &Node<D>) {
+  fn collect<'t, N: SgNode<'t>>(&mut self, node: &N) {
     if !node.kind().contains("comment") || !node.text().contains(IGNORE_TEXT) {
       return;
     }
@@ -76,7 +76,7 @@ impl Suppressions {
     self.0.values().map(|s| s.node_id).collect()
   }
 
-  fn check_suppression<D: Doc>(&mut self, node: &Node<D>) -> MaySuppressed {
+  fn check_suppression<'t, N: SgNode<'t>>(&mut self, node: &N) -> MaySuppressed {
     let line = node.start_pos().line();
     if let Some(sup) = self.0.get_mut(&line) {
       MaySuppressed::Yes(sup)

--- a/crates/config/src/fixer.rs
+++ b/crates/config/src/fixer.rs
@@ -3,7 +3,7 @@ use crate::rule::{Relation, Rule, RuleSerializeError, StopBy};
 use crate::transform::Transformation;
 use crate::DeserializeEnv;
 use ast_grep_core::replacer::{Content, Replacer, TemplateFix, TemplateFixError};
-use ast_grep_core::{Doc, Language, Matcher, NodeMatch};
+use ast_grep_core::{Doc, Language, Matcher, NodeMatch, SgNode, SgNodeMatch};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -131,7 +131,10 @@ where
   D: Doc<Source = C>,
   C: Content,
 {
-  fn generate_replacement(&self, nm: &ast_grep_core::NodeMatch<D>) -> Vec<C::Underlying> {
+  fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
+    &self,
+    nm: &SgNodeMatch<'t, N>,
+  ) -> Vec<C::Underlying> {
     // simple forwarding to template
     self.template.generate_replacement(nm)
   }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -43,6 +43,7 @@ pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
 mod test {
 
   use super::*;
+  use ast_grep_core::language::CoreLanguage;
   use ast_grep_core::language::TSLanguage;
   use std::path::Path;
 
@@ -50,6 +51,7 @@ mod test {
   pub enum TypeScript {
     Tsx,
   }
+  impl CoreLanguage for TypeScript {}
   impl Language for TypeScript {
     fn from_path<P: AsRef<Path>>(_path: P) -> Option<Self> {
       Some(TypeScript::Tsx)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -30,7 +30,7 @@ pub fn from_str<'de, T: Deserialize<'de>>(s: &'de str) -> Result<T, YamlError> {
 
 pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
   yamls: &'a str,
-  registration: &GlobalRules<L>,
+  registration: &GlobalRules,
 ) -> Result<Vec<RuleConfig<L>>, RuleConfigError> {
   let mut ret = vec![];
   for yaml in Deserializer::from_str(yamls) {

--- a/crates/config/src/rule/deserialize_env.rs
+++ b/crates/config/src/rule/deserialize_env.rs
@@ -37,7 +37,7 @@ type OrderResult<T> = Result<T, String>;
 #[derive(Clone)]
 pub struct DeserializeEnv<L: Language> {
   /// registration for global utility rules and local utility rules.
-  pub(crate) registration: RuleRegistration<L>,
+  pub(crate) registration: RuleRegistration,
   /// current rules' language
   pub(crate) lang: L,
 }
@@ -172,7 +172,7 @@ impl<L: Language> DeserializeEnv<L> {
   /// register global utils rule discovered in the config.
   pub fn parse_global_utils(
     utils: Vec<SerializableGlobalRule<L>>,
-  ) -> Result<GlobalRules<L>, RuleCoreError> {
+  ) -> Result<GlobalRules, RuleCoreError> {
     let registration = GlobalRules::default();
     let utils = into_map(utils);
     let order = TopologicalSort::get_order(&utils)
@@ -189,10 +189,7 @@ impl<L: Language> DeserializeEnv<L> {
     Ok(registration)
   }
 
-  pub fn deserialize_rule(
-    &self,
-    serialized: SerializableRule,
-  ) -> Result<Rule<L>, RuleSerializeError> {
+  pub fn deserialize_rule(&self, serialized: SerializableRule) -> Result<Rule, RuleSerializeError> {
     rule::deserialize_rule(serialized, self)
   }
 
@@ -203,7 +200,7 @@ impl<L: Language> DeserializeEnv<L> {
     TopologicalSort::get_order(trans)
   }
 
-  pub fn with_globals(self, globals: &GlobalRules<L>) -> Self {
+  pub fn with_globals(self, globals: &GlobalRules) -> Self {
     Self {
       registration: RuleRegistration::from_globals(globals),
       lang: self.lang,
@@ -219,7 +216,7 @@ mod test {
   use anyhow::Result;
   use ast_grep_core::Matcher;
 
-  fn get_dependent_utils() -> Result<(Rule<TypeScript>, DeserializeEnv<TypeScript>)> {
+  fn get_dependent_utils() -> Result<(Rule, DeserializeEnv<TypeScript>)> {
     let utils = from_str(
       "
 accessor-name:

--- a/crates/config/src/rule/mod.rs
+++ b/crates/config/src/rule/mod.rs
@@ -17,9 +17,9 @@ use relational_rule::{Follows, Has, Inside, Precedes};
 
 use ast_grep_core::language::Language;
 use ast_grep_core::matcher::{KindMatcher, KindMatcherError, RegexMatcher, RegexMatcherError};
-use ast_grep_core::meta_var::MetaVarEnv;
-use ast_grep_core::ops as o;
-use ast_grep_core::{Doc, MatchStrictness, Matcher, Node, Pattern, PatternError};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::{ops as o, SgNode};
+use ast_grep_core::{MatchStrictness, Matcher, Pattern, PatternError};
 
 use bit_set::BitSet;
 use schemars::JsonSchema;
@@ -277,11 +277,11 @@ impl Rule {
 }
 
 impl Matcher for Rule {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     use Rule::*;
     match self {
       // atomic
@@ -334,11 +334,11 @@ impl Default for Rule {
   }
 }
 
-fn match_and_add_label<'tree, D: Doc, M: Matcher>(
+fn match_and_add_label<'tree, N: SgNode<'tree>, M: Matcher>(
   inner: &M,
-  node: Node<'tree, D>,
-  env: &mut Cow<MetaVarEnv<'tree, D>>,
-) -> Option<Node<'tree, D>> {
+  node: N,
+  env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+) -> Option<N> {
   let matched = inner.match_node_with_env(node, env)?;
   env.to_mut().add_label("secondary", matched.clone());
   Some(matched)

--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -170,14 +170,14 @@ impl FunctionalPosition {
   }
 }
 
-pub struct NthChild<L: Language> {
+pub struct NthChild {
   position: FunctionalPosition,
-  of_rule: Option<Box<Rule<L>>>,
+  of_rule: Option<Box<Rule>>,
   reverse: bool,
 }
 
-impl<L: Language> NthChild<L> {
-  pub fn try_new(
+impl NthChild {
+  pub fn try_new<L: Language>(
     rule: SerializableNthChild,
     env: &DeserializeEnv<L>,
   ) -> Result<Self, NthChildError> {
@@ -203,7 +203,7 @@ impl<L: Language> NthChild<L> {
     }
   }
 
-  fn find_index<'t, D: Doc<Lang = L>>(
+  fn find_index<'t, D: Doc>(
     &self,
     node: &Node<'t, D>,
     env: &mut Cow<MetaVarEnv<'t, D>>,
@@ -245,8 +245,8 @@ impl<L: Language> NthChild<L> {
   }
 }
 
-impl<L: Language> Matcher<L> for NthChild<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for NthChild {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -291,7 +291,7 @@ mod test {
     assert!(position.is_matched(4));
   }
 
-  fn find_index(rule: Option<Rule<TS>>, reverse: bool) -> Option<usize> {
+  fn find_index(rule: Option<Rule>, reverse: bool) -> Option<usize> {
     let rule = NthChild {
       position: FunctionalPosition {
         step_size: 2,
@@ -386,7 +386,7 @@ mod test {
     parse_error("na", "character");
   }
 
-  fn deser(src: &str) -> Rule<TS> {
+  fn deser(src: &str) -> Rule {
     let rule: SerializableRule = from_str(src).expect("cannot parse rule");
     let env = DeserializeEnv::new(TS::Tsx);
     env.deserialize_rule(rule).expect("should deserialize")

--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -1,8 +1,8 @@
 use super::{DeserializeEnv, Rule, RuleSerializeError, SerializableRule};
 
 use ast_grep_core::language::Language;
-use ast_grep_core::meta_var::MetaVarEnv;
-use ast_grep_core::{Doc, Matcher, Node};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::{Matcher, SgNode};
 
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -203,10 +203,10 @@ impl NthChild {
     }
   }
 
-  fn find_index<'t, D: Doc>(
+  fn find_index<'t, N: SgNode<'t>>(
     &self,
-    node: &Node<'t, D>,
-    env: &mut Cow<MetaVarEnv<'t, D>>,
+    node: &N,
+    env: &mut Cow<SgMetaVarEnv<'t, N>>,
   ) -> Option<usize> {
     let parent = node.parent()?;
     //  only consider named children
@@ -246,11 +246,11 @@ impl NthChild {
 }
 
 impl Matcher for NthChild {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let index = self.find_index(&node, env)?;
     self.position.is_matched(index).then_some(node)
   }
@@ -266,6 +266,7 @@ mod test {
   use crate::from_str;
   use crate::test::TypeScript as TS;
   use ast_grep_core::matcher::RegexMatcher;
+  use ast_grep_core::meta_var::MetaVarEnv;
 
   #[test]
   fn test_positional() {
@@ -303,7 +304,7 @@ mod test {
     let mut env = Cow::Owned(MetaVarEnv::new());
     let grep = TS::Tsx.ast_grep("[1,2,3,4]");
     let node = grep.root().find("2").unwrap();
-    rule.find_index(&node, &mut env)
+    rule.find_index(&*node, &mut env)
   }
 
   #[test]

--- a/crates/config/src/rule/range.rs
+++ b/crates/config/src/rule/range.rs
@@ -1,4 +1,4 @@
-use ast_grep_core::{meta_var::MetaVarEnv, Doc, Node};
+use ast_grep_core::{meta_var::SgMetaVarEnv, SgNode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -66,11 +66,11 @@ impl RangeMatcher {
 }
 
 impl Matcher for RangeMatcher {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let node_start_pos = node.start_pos();
     let node_end_pos = node.end_pos();
 

--- a/crates/config/src/rule/referent_rule.rs
+++ b/crates/config/src/rule/referent_rule.rs
@@ -1,7 +1,7 @@
 use crate::{Rule, RuleCore};
 
-use ast_grep_core::meta_var::MetaVarEnv;
-use ast_grep_core::{Doc, Matcher, Node};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::{Matcher, SgNode};
 
 use bit_set::BitSet;
 use thiserror::Error;
@@ -191,11 +191,11 @@ impl ReferentRule {
 }
 
 impl Matcher for ReferentRule {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     self
       .eval_local(|r| r.match_node_with_env(node.clone(), env))
       .or_else(|| self.eval_global(|r| r.match_node_with_env(node, env)))

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -2,8 +2,8 @@ use super::deserialize_env::DeserializeEnv;
 use super::stop_by::{SerializableStopBy, StopBy};
 use crate::rule::{Rule, RuleSerializeError, SerializableRule};
 use ast_grep_core::language::Language;
-use ast_grep_core::meta_var::MetaVarEnv;
-use ast_grep_core::{Doc, Matcher, Node};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::{Matcher, SgNode};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -67,16 +67,16 @@ impl Inside {
 }
 
 impl Matcher for Inside {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let parent = || node.parent();
     let ancestors = || node.ancestors();
     if let Some(field) = self.field {
       let mut last_id = node.node_id();
-      let finder = move |nd: Node<'tree, D>| {
+      let finder = move |nd: N| {
         let expect_id = last_id;
         last_id = nd.node_id();
         let n = nd.child_by_field_id(field)?;
@@ -127,11 +127,11 @@ impl Has {
 }
 
 impl Matcher for Has {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     if let Some(field) = self.field {
       let nd = node.child_by_field_id(field)?;
       return match &self.stop_by {
@@ -209,11 +209,11 @@ impl Precedes {
   }
 }
 impl Matcher for Precedes {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let next = || node.next();
     let next_all = || node.next_all();
     let finder = |n| self.later.match_node_with_env(n, env);
@@ -253,11 +253,11 @@ impl Follows {
   }
 }
 impl Matcher for Follows {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let prev = || node.prev();
     let prev_all = || node.prev_all();
     let finder = |n| self.former.match_node_with_env(n, env);

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -34,13 +34,16 @@ fn field_name_to_id<L: Language>(
   }
 }
 
-pub struct Inside<L: Language> {
-  outer: Rule<L>,
+pub struct Inside {
+  outer: Rule,
   field: Option<u16>,
-  stop_by: StopBy<L>,
+  stop_by: StopBy,
 }
-impl<L: Language> Inside<L> {
-  pub fn try_new(relation: Relation, env: &DeserializeEnv<L>) -> Result<Self, RuleSerializeError> {
+impl Inside {
+  pub fn try_new<L: Language>(
+    relation: Relation,
+    env: &DeserializeEnv<L>,
+  ) -> Result<Self, RuleSerializeError> {
     Ok(Self {
       stop_by: StopBy::try_from(relation.stop_by, env)?,
       field: field_name_to_id(relation.field, env)?,
@@ -63,8 +66,8 @@ impl<L: Language> Inside<L> {
   }
 }
 
-impl<L: Language> Matcher<L> for Inside<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for Inside {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -91,13 +94,16 @@ impl<L: Language> Matcher<L> for Inside<L> {
   }
 }
 
-pub struct Has<L: Language> {
-  inner: Rule<L>,
-  stop_by: StopBy<L>,
+pub struct Has {
+  inner: Rule,
+  stop_by: StopBy,
   field: Option<u16>,
 }
-impl<L: Language> Has<L> {
-  pub fn try_new(relation: Relation, env: &DeserializeEnv<L>) -> Result<Self, RuleSerializeError> {
+impl Has {
+  pub fn try_new<L: Language>(
+    relation: Relation,
+    env: &DeserializeEnv<L>,
+  ) -> Result<Self, RuleSerializeError> {
     Ok(Self {
       stop_by: StopBy::try_from(relation.stop_by, env)?,
       inner: env.deserialize_rule(relation.rule)?,
@@ -120,8 +126,8 @@ impl<L: Language> Has<L> {
   }
 }
 
-impl<L: Language> Matcher<L> for Has<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for Has {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -170,12 +176,15 @@ impl<L: Language> Matcher<L> for Has<L> {
   }
 }
 
-pub struct Precedes<L: Language> {
-  later: Rule<L>,
-  stop_by: StopBy<L>,
+pub struct Precedes {
+  later: Rule,
+  stop_by: StopBy,
 }
-impl<L: Language> Precedes<L> {
-  pub fn try_new(relation: Relation, env: &DeserializeEnv<L>) -> Result<Self, RuleSerializeError> {
+impl Precedes {
+  pub fn try_new<L: Language>(
+    relation: Relation,
+    env: &DeserializeEnv<L>,
+  ) -> Result<Self, RuleSerializeError> {
     if relation.field.is_some() {
       return Err(RuleSerializeError::FieldNotSupported);
     }
@@ -199,8 +208,8 @@ impl<L: Language> Precedes<L> {
     self.stop_by.verify_util()
   }
 }
-impl<L: Language> Matcher<L> for Precedes<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for Precedes {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -212,12 +221,15 @@ impl<L: Language> Matcher<L> for Precedes<L> {
   }
 }
 
-pub struct Follows<L: Language> {
-  former: Rule<L>,
-  stop_by: StopBy<L>,
+pub struct Follows {
+  former: Rule,
+  stop_by: StopBy,
 }
-impl<L: Language> Follows<L> {
-  pub fn try_new(relation: Relation, env: &DeserializeEnv<L>) -> Result<Self, RuleSerializeError> {
+impl Follows {
+  pub fn try_new<L: Language>(
+    relation: Relation,
+    env: &DeserializeEnv<L>,
+  ) -> Result<Self, RuleSerializeError> {
     if relation.field.is_some() {
       return Err(RuleSerializeError::FieldNotSupported);
     }
@@ -240,8 +252,8 @@ impl<L: Language> Follows<L> {
     self.stop_by.verify_util()
   }
 }
-impl<L: Language> Matcher<L> for Follows<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for Follows {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -261,24 +273,24 @@ mod test {
   use ast_grep_core::ops as o;
   use ast_grep_core::Pattern;
 
-  fn find_rule<M: Matcher<TS>>(src: &str, matcher: M) -> Option<String> {
+  fn find_rule<M: Matcher>(src: &str, matcher: M) -> Option<String> {
     let grep = TS::Tsx.ast_grep(src);
     grep.root().find(matcher).map(|s| s.text().to_string())
   }
 
-  fn test_found<M: Matcher<TS>>(found_list: &[&str], matcher: M) {
+  fn test_found<M: Matcher>(found_list: &[&str], matcher: M) {
     for found in found_list {
       assert!(find_rule(found, &matcher).is_some());
     }
   }
 
-  fn test_not_found<M: Matcher<TS>>(not_found_list: &[&str], matcher: M) {
+  fn test_not_found<M: Matcher>(not_found_list: &[&str], matcher: M) {
     for found in not_found_list {
       assert!(find_rule(found, &matcher).is_none());
     }
   }
 
-  fn make_rule(target: &str, relation: Rule<TS>) -> impl Matcher<TS> {
+  fn make_rule(target: &str, relation: Rule) -> impl Matcher {
     o::All::new(vec![Rule::Pattern(Pattern::new(target, TS::Tsx)), relation])
   }
 

--- a/crates/config/src/rule/stop_by.rs
+++ b/crates/config/src/rule/stop_by.rs
@@ -82,14 +82,14 @@ impl Serialize for SerializableStopBy {
   }
 }
 
-pub enum StopBy<L: Language> {
+pub enum StopBy {
   Neighbor,
   End,
-  Rule(Rule<L>),
+  Rule(Rule),
 }
 
-impl<L: Language> StopBy<L> {
-  pub(crate) fn try_from(
+impl StopBy {
+  pub(crate) fn try_from<L: Language>(
     relation: SerializableStopBy,
     env: &DeserializeEnv<L>,
   ) -> Result<Self, RuleSerializeError> {
@@ -118,7 +118,7 @@ impl<L: Language> StopBy<L> {
   }
 }
 
-impl<L: Language> StopBy<L> {
+impl StopBy {
   // TODO: document this monster method
   pub(crate) fn find<'t, O, M, I, F, D>(
     &self,
@@ -127,7 +127,7 @@ impl<L: Language> StopBy<L> {
     mut finder: F,
   ) -> Option<Node<'t, D>>
   where
-    D: Doc<Lang = L> + 't,
+    D: Doc + 't,
     I: Iterator<Item = Node<'t, D>>,
     O: FnOnce() -> Option<Node<'t, D>>,
     M: FnOnce() -> I,
@@ -147,7 +147,7 @@ impl<L: Language> StopBy<L> {
   }
 }
 
-fn inclusive_until<D: Doc>(rule: &Rule<D::Lang>) -> impl FnMut(&Node<D>) -> bool + '_ {
+fn inclusive_until<D: Doc>(rule: &Rule) -> impl FnMut(&Node<D>) -> bool + '_ {
   let mut matched = false;
   move |n| {
     if matched {
@@ -209,7 +209,7 @@ inside:
     assert!(err.to_string().contains("variant"));
   }
 
-  fn parse_stop_by(src: &str) -> StopBy<TypeScript> {
+  fn parse_stop_by(src: &str) -> StopBy {
     let stop_by = to_stop_by(src).expect("cannot parse stopBy");
     StopBy::try_from(stop_by, &DeserializeEnv::new(TypeScript::Tsx)).expect("cannot convert")
   }

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -116,7 +116,7 @@ impl JsonSchema for Metadata {
 }
 
 impl<L: Language> SerializableRuleConfig<L> {
-  pub fn get_matcher(&self, globals: &GlobalRules<L>) -> Result<RuleCore<L>, RuleConfigError> {
+  pub fn get_matcher(&self, globals: &GlobalRules) -> Result<RuleCore, RuleConfigError> {
     // every RuleConfig has one rewriters, and the rewriter is shared between sub-rules
     // all RuleConfigs has one common globals
     // every sub-rule has one util
@@ -128,7 +128,7 @@ impl<L: Language> SerializableRuleConfig<L> {
 
   fn register_rewriters(
     &self,
-    rule: &RuleCore<L>,
+    rule: &RuleCore,
     env: DeserializeEnv<L>,
   ) -> Result<(), RuleConfigError> {
     let Some(ser) = &self.rewriters else {
@@ -166,13 +166,13 @@ impl<L: Language> DerefMut for SerializableRuleConfig<L> {
 
 pub struct RuleConfig<L: Language> {
   inner: SerializableRuleConfig<L>,
-  pub matcher: RuleCore<L>,
+  pub matcher: RuleCore,
 }
 
 impl<L: Language> RuleConfig<L> {
   pub fn try_from(
     inner: SerializableRuleConfig<L>,
-    globals: &GlobalRules<L>,
+    globals: &GlobalRules,
   ) -> Result<Self, RuleConfigError> {
     let matcher = inner.get_matcher(globals)?;
     if matcher.potential_kinds().is_none() {
@@ -183,7 +183,7 @@ impl<L: Language> RuleConfig<L> {
 
   pub fn deserialize<'de>(
     deserializer: Deserializer<'de>,
-    globals: &GlobalRules<L>,
+    globals: &GlobalRules,
   ) -> Result<Self, RuleConfigError>
   where
     L: Deserialize<'de>,
@@ -198,7 +198,7 @@ impl<L: Language> RuleConfig<L> {
     let bytes = parsed.generate_replacement(node);
     String::from_utf8(bytes).expect("replacement must be valid utf-8")
   }
-  pub fn get_fixer(&self) -> Result<Option<Fixer<L>>, RuleConfigError> {
+  pub fn get_fixer(&self) -> Result<Option<Fixer>, RuleConfigError> {
     if let Some(fix) = &self.fix {
       let env = self.matcher.get_env(self.language.clone());
       let parsed = Fixer::parse(fix, &env, &self.transform).map_err(RuleCoreError::Fixer)?;

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -228,12 +228,10 @@ impl RuleCore {
       let rewriters = self.registration.get_rewriters();
       let env = env.to_mut();
       if let Some(enclosing) = enclosing_env {
-        todo!()
-        // trans.apply_transform(env, rewriters, enclosing);
+        trans.apply_transform(env, rewriters, enclosing);
       } else {
         let enclosing = env.clone();
-        todo!()
-        // trans.apply_transform(env, rewriters, &enclosing);
+        trans.apply_transform(env, rewriters, &enclosing);
       };
     }
     Some(ret)

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -7,8 +7,8 @@ use crate::transform::{Transform, TransformError, Transformation};
 use crate::DeserializeEnv;
 
 use ast_grep_core::language::Language;
-use ast_grep_core::meta_var::MetaVarEnv;
-use ast_grep_core::{Doc, Matcher, Node};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::{Matcher, SgNode};
 use serde::{Deserialize, Serialize};
 use serde_yaml::Error as YamlError;
 
@@ -209,12 +209,12 @@ impl RuleCore {
     ret
   }
 
-  pub(crate) fn do_match<'tree, D: Doc>(
+  pub(crate) fn do_match<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-    enclosing_env: Option<&MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+    enclosing_env: Option<&SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     if let Some(kinds) = &self.kinds {
       if !kinds.contains(node.kind_id().into()) {
         return None;
@@ -228,10 +228,12 @@ impl RuleCore {
       let rewriters = self.registration.get_rewriters();
       let env = env.to_mut();
       if let Some(enclosing) = enclosing_env {
-        trans.apply_transform(env, rewriters, enclosing);
+        todo!()
+        // trans.apply_transform(env, rewriters, enclosing);
       } else {
         let enclosing = env.clone();
-        trans.apply_transform(env, rewriters, &enclosing);
+        todo!()
+        // trans.apply_transform(env, rewriters, &enclosing);
       };
     }
     Some(ret)
@@ -259,11 +261,11 @@ impl Default for RuleCore {
 }
 
 impl Matcher for RuleCore {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     self.do_match(node, env, None)
   }
 

--- a/crates/config/src/transform/mod.rs
+++ b/crates/config/src/transform/mod.rs
@@ -48,7 +48,7 @@ impl Transform {
   pub fn apply_transform<'c, D: Doc>(
     &self,
     env: &mut MetaVarEnv<'c, D>,
-    rewriters: &HashMap<String, RuleCore<D::Lang>>,
+    rewriters: &HashMap<String, RuleCore>,
     enclosing_env: &MetaVarEnv<'c, D>,
   ) {
     let mut ctx = Ctx {
@@ -72,7 +72,7 @@ impl Transform {
 
 // two lifetime to represent env root lifetime and lang/trans lifetime
 struct Ctx<'b, 'c, D: Doc> {
-  rewriters: &'b HashMap<String, RuleCore<D::Lang>>,
+  rewriters: &'b HashMap<String, RuleCore>,
   env: &'b mut MetaVarEnv<'c, D>,
   enclosing_env: &'b MetaVarEnv<'c, D>,
 }

--- a/crates/config/src/transform/mod.rs
+++ b/crates/config/src/transform/mod.rs
@@ -4,9 +4,10 @@ mod transformation;
 
 use crate::{DeserializeEnv, RuleCore};
 
-use ast_grep_core::meta_var::MetaVarEnv;
 use ast_grep_core::meta_var::MetaVariable;
-use ast_grep_core::{Doc, Language};
+use ast_grep_core::meta_var::SgMetaVarEnv;
+use ast_grep_core::Language;
+use ast_grep_core::SgNode;
 
 use std::collections::HashMap;
 use thiserror::Error;
@@ -45,11 +46,11 @@ impl Transform {
     })
   }
 
-  pub fn apply_transform<'c, D: Doc>(
+  pub fn apply_transform<'c, N: SgNode<'c>>(
     &self,
-    env: &mut MetaVarEnv<'c, D>,
+    env: &mut SgMetaVarEnv<'c, N>,
     rewriters: &HashMap<String, RuleCore>,
-    enclosing_env: &MetaVarEnv<'c, D>,
+    enclosing_env: &SgMetaVarEnv<'c, N>,
   ) {
     let mut ctx = Ctx {
       env,
@@ -71,10 +72,10 @@ impl Transform {
 }
 
 // two lifetime to represent env root lifetime and lang/trans lifetime
-struct Ctx<'b, 'c, D: Doc> {
+struct Ctx<'b, 'c, N: SgNode<'c>> {
   rewriters: &'b HashMap<String, RuleCore>,
-  env: &'b mut MetaVarEnv<'c, D>,
-  enclosing_env: &'b MetaVarEnv<'c, D>,
+  env: &'b mut SgMetaVarEnv<'c, N>,
+  enclosing_env: &'b SgMetaVarEnv<'c, N>,
 }
 
 #[cfg(test)]

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -89,7 +89,7 @@ impl Rewrite<MetaVariable> {
 type Bytes<D> = [<<D as Doc>::Source as Content>::Underlying];
 fn find_and_make_edits<'n, D: Doc>(
   nodes: Vec<Node<'n, D>>,
-  rules: &[&RuleCore<D::Lang>],
+  rules: &[&RuleCore],
   ctx: &Ctx<'_, 'n, D>,
 ) -> Vec<Edit<D::Source>> {
   nodes
@@ -100,7 +100,7 @@ fn find_and_make_edits<'n, D: Doc>(
 
 fn replace_one<'n, D: Doc>(
   node: Node<'n, D>,
-  rules: &[&RuleCore<D::Lang>],
+  rules: &[&RuleCore],
   ctx: &Ctx<'_, 'n, D>,
 ) -> Vec<Edit<D::Source>> {
   let mut edits = vec![];
@@ -161,7 +161,7 @@ mod test {
     rewrite: Rewrite<String>,
     src: &str,
     pat: &str,
-    rewriters: RuleRegistration<TypeScript>,
+    rewriters: RuleRegistration,
   ) -> String {
     compute_rewritten(src, pat, rewrite, rewriters).expect("should have transforms")
   }
@@ -170,14 +170,11 @@ mod test {
     ( $($a: expr),* ) => { vec![ $($a.to_string()),* ] };
   }
 
-  fn make_rewriters(pairs: &[(&str, &str)]) -> RuleRegistration<TypeScript> {
+  fn make_rewriters(pairs: &[(&str, &str)]) -> RuleRegistration {
     make_rewriter_reg(pairs, Default::default())
   }
 
-  fn make_rewriter_reg(
-    pairs: &[(&str, &str)],
-    vars: HashSet<&str>,
-  ) -> RuleRegistration<TypeScript> {
+  fn make_rewriter_reg(pairs: &[(&str, &str)], vars: HashSet<&str>) -> RuleRegistration {
     let env = DeserializeEnv::new(TypeScript::Tsx);
     for (key, ser) in pairs {
       let serialized: SerializableRuleCore = from_str(ser).unwrap();
@@ -343,7 +340,7 @@ fix: $D
     src: &str,
     pat: &str,
     rewrite: Rewrite<String>,
-    reg: RuleRegistration<TypeScript>,
+    reg: RuleRegistration,
   ) -> Option<String> {
     let grep = TypeScript::Tsx.ast_grep(src);
     let root = grep.root();

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -4,7 +4,7 @@ use crate::rule_core::RuleCore;
 
 use ast_grep_core::meta_var::MetaVariable;
 use ast_grep_core::source::{Content, Edit};
-use ast_grep_core::{Doc, Language, Node, NodeMatch};
+use ast_grep_core::{Doc, Language, SgNode, SgNodeMatch};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ pub struct Rewrite<T> {
   pub(super) join_by: Option<String>,
 }
 
-fn get_nodes_from_env<'b, D: Doc>(var: &MetaVariable, ctx: &Ctx<'_, 'b, D>) -> Vec<Node<'b, D>> {
+fn get_nodes_from_env<'b, N: SgNode<'b>>(var: &MetaVariable, ctx: &Ctx<'_, 'b, N>) -> Vec<N> {
   match var {
     MetaVariable::MultiCapture(n) => ctx.env.get_multiple_matches(n),
     MetaVariable::Capture(m, _) => {
@@ -43,7 +43,7 @@ impl Rewrite<String> {
 }
 
 impl Rewrite<MetaVariable> {
-  pub(super) fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
+  pub(super) fn compute<'r, N: SgNode<'r>>(&self, ctx: &mut Ctx<'_, 'r, N>) -> Option<String> {
     let var = &self.source;
     let nodes = get_nodes_from_env(var, ctx);
     if nodes.is_empty() {
@@ -64,7 +64,7 @@ impl Rewrite<MetaVariable> {
       if let Some(first) = edits.next() {
         let mut pos = first.position - start + first.deleted_length;
         ret.extend(first.inserted_text);
-        let joiner = D::Source::decode_str(joiner);
+        let joiner = <N::Doc as Doc>::Source::decode_str(joiner);
         for edit in edits {
           let p = edit.position - start;
           // skip overlapping edits
@@ -80,29 +80,29 @@ impl Rewrite<MetaVariable> {
         ret
       }
     } else {
-      make_edit::<D>(bytes, edits, start)
+      make_edit::<N::Doc>(bytes, edits, start)
     };
-    Some(D::Source::encode_bytes(&rewritten).to_string())
+    Some(<N::Doc as Doc>::Source::encode_bytes(&rewritten).to_string())
   }
 }
 
 type Bytes<D> = [<<D as Doc>::Source as Content>::Underlying];
-fn find_and_make_edits<'n, D: Doc>(
-  nodes: Vec<Node<'n, D>>,
+fn find_and_make_edits<'n, N: SgNode<'n>>(
+  nodes: Vec<N>,
   rules: &[&RuleCore],
-  ctx: &Ctx<'_, 'n, D>,
-) -> Vec<Edit<D::Source>> {
+  ctx: &Ctx<'_, 'n, N>,
+) -> Vec<Edit<<N::Doc as Doc>::Source>> {
   nodes
     .into_iter()
     .flat_map(|n| replace_one(n, rules, ctx))
     .collect()
 }
 
-fn replace_one<'n, D: Doc>(
-  node: Node<'n, D>,
+fn replace_one<'n, N: SgNode<'n>>(
+  node: N,
   rules: &[&RuleCore],
-  ctx: &Ctx<'_, 'n, D>,
-) -> Vec<Edit<D::Source>> {
+  ctx: &Ctx<'_, 'n, N>,
+) -> Vec<Edit<<N::Doc as Doc>::Source>> {
   let mut edits = vec![];
   for child in node.dfs() {
     for rule in rules {
@@ -114,7 +114,7 @@ fn replace_one<'n, D: Doc>(
       // this is to enable recursive rewriter to match sub nodes
       // in future, we can use the explict `expose` to control env inheritance
       if let Some(n) = rule.do_match(child.clone(), &mut env, Some(ctx.enclosing_env)) {
-        let nm = NodeMatch::new(n, env.into_owned());
+        let nm = SgNodeMatch::new(n, env.into_owned());
         edits.push(nm.make_edit(rule, rule.fixer.as_ref().expect("rewriter must have fix")));
         // stop at first fix, skip duplicate fix
         break;

--- a/crates/config/src/transform/transformation.rs
+++ b/crates/config/src/transform/transformation.rs
@@ -2,7 +2,7 @@ use super::rewrite::Rewrite;
 use super::{string_case, Ctx, TransformError};
 use ast_grep_core::meta_var::MetaVariable;
 use ast_grep_core::source::Content;
-use ast_grep_core::{Doc, Language};
+use ast_grep_core::{Doc, Language, SgNode};
 
 use regex::Regex;
 use schemars::JsonSchema;
@@ -10,10 +10,13 @@ use serde::{Deserialize, Serialize};
 
 use string_case::{Separator, StringCase};
 
-fn get_text_from_env<D: Doc>(var: &MetaVariable, ctx: &mut Ctx<D>) -> Option<String> {
+fn get_text_from_env<'r, N: SgNode<'r>>(
+  var: &MetaVariable,
+  ctx: &mut Ctx<'_, 'r, N>,
+) -> Option<String> {
   // TODO: check if topological sort has resolved transform dependency
   let bytes = ctx.env.get_var_bytes(var)?;
-  Some(<D::Source as Content>::encode_bytes(bytes).into_owned())
+  Some(<<N::Doc as Doc>::Source as Content>::encode_bytes(bytes).into_owned())
 }
 
 /// Extracts a substring from the meta variable's text content.
@@ -32,7 +35,7 @@ pub struct Substring<T> {
 }
 
 impl Substring<MetaVariable> {
-  fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
+  fn compute<'r, N: SgNode<'r>>(&self, ctx: &mut Ctx<'_, 'r, N>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;
     let chars: Vec<_> = text.chars().collect();
     let len = chars.len() as i32;
@@ -73,7 +76,7 @@ pub struct Replace<T> {
   by: String,
 }
 impl Replace<MetaVariable> {
-  fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
+  fn compute<'r, N: SgNode<'r>>(&self, ctx: &mut Ctx<'_, 'r, N>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;
     let re = Regex::new(&self.replace).unwrap();
     Some(re.replace_all(&text, &self.by).into_owned())
@@ -92,7 +95,7 @@ pub struct Convert<T> {
   separated_by: Option<Vec<Separator>>,
 }
 impl Convert<MetaVariable> {
-  fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
+  fn compute<'r, N: SgNode<'r>>(&self, ctx: &mut Ctx<'_, 'r, N>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;
     Some(self.to_case.apply(&text, self.separated_by.as_deref()))
   }
@@ -166,7 +169,7 @@ impl Transformation<String> {
   }
 }
 impl Transformation<MetaVariable> {
-  pub(super) fn insert<D: Doc>(&self, key: &str, ctx: &mut Ctx<D>) {
+  pub(super) fn insert<'r, N: SgNode<'r>>(&self, key: &str, ctx: &mut Ctx<'_, 'r, N>) {
     let src = self.source();
     // TODO: add this debug assertion back
     // debug_assert!(ctx.env.get_transformed(key).is_none());
@@ -174,13 +177,13 @@ impl Transformation<MetaVariable> {
     ctx.env.insert_transformation(src, key, vec![]);
     let opt = self.compute(ctx);
     let bytes = if let Some(s) = opt {
-      <D::Source as Content>::decode_str(&s).to_vec()
+      <<N::Doc as Doc>::Source as Content>::decode_str(&s).to_vec()
     } else {
       vec![]
     };
     ctx.env.insert_transformation(src, key, bytes);
   }
-  fn compute<D: Doc>(&self, ctx: &mut Ctx<D>) -> Option<String> {
+  fn compute<'r, N: SgNode<'r>>(&self, ctx: &mut Ctx<'_, 'r, N>) -> Option<String> {
     use Transformation as T;
     match self {
       T::Replace(r) => r.compute(ctx),

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -10,7 +10,7 @@ pub use tree_sitter::{Point as TSPoint, Range as TSRange};
 /// * which character is used for meta variable.
 /// * if we need to use other char in meta var for parser at runtime
 /// * pre process the Pattern code.
-pub trait CoreLanguage: Clone {
+pub trait CoreLanguage: Clone + 'static {
   /// ignore trivial tokens in language matching
   fn skippable_kind_ids(&self) -> &'static [u16] {
     &[]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,7 +22,7 @@ mod node;
 
 pub use language::Language;
 pub use match_tree::MatchStrictness;
-pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
+pub use matcher::{Matcher, NodeMatch, Pattern, PatternError, SgNodeMatch};
 pub use node::{Node, Position, SgNode};
 pub use source::{Doc, StrDoc};
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,7 +23,7 @@ mod node;
 pub use language::Language;
 pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
-pub use node::{Node, Position};
+pub use node::{Node, Position, SgNode};
 pub use source::{Doc, StrDoc};
 
 #[doc(hidden)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -49,7 +49,7 @@ impl<D: Doc> AstGrep<D> {
     Ok(self)
   }
 
-  pub fn replace<M: Matcher<D::Lang>, R: Replacer<D>>(
+  pub fn replace<M: Matcher, R: Replacer<D>>(
     &mut self,
     pattern: M,
     replacer: R,

--- a/crates/core/src/match_tree/match_node.rs
+++ b/crates/core/src/match_tree/match_node.rs
@@ -2,13 +2,13 @@ use super::strictness::{MatchOneNode, MatchStrictness};
 use super::Aggregator;
 use crate::matcher::{kind_utils, PatternNode};
 use crate::meta_var::MetaVariable;
-use crate::{Doc, Node};
+use crate::node::SgNode;
 use std::iter::Peekable;
 
-pub(super) fn match_node_impl<'tree, D: Doc>(
+pub(super) fn match_node_impl<'tree, N: SgNode<'tree>>(
   goal: &PatternNode,
-  candidate: &Node<'tree, D>,
-  agg: &mut impl Aggregator<'tree, D>,
+  candidate: &N,
+  agg: &mut impl Aggregator<'tree, N>,
   strictness: &MatchStrictness,
 ) -> MatchOneNode {
   use PatternNode as P;
@@ -45,10 +45,10 @@ pub(super) fn match_node_impl<'tree, D: Doc>(
   }
 }
 
-fn match_nodes_impl_recursive<'tree, D: Doc + 'tree>(
+fn match_nodes_impl_recursive<'tree, N: SgNode<'tree>>(
   goals: &[PatternNode],
-  candidates: impl Iterator<Item = Node<'tree, D>>,
-  agg: &mut impl Aggregator<'tree, D>,
+  candidates: impl Iterator<Item = N>,
+  agg: &mut impl Aggregator<'tree, N>,
   strictness: &MatchStrictness,
 ) -> Option<()> {
   let mut goal_children = goals.iter().peekable();
@@ -91,10 +91,10 @@ enum ControlFlow {
 }
 
 /// returns None means no match
-fn may_match_ellipsis_impl<'p, 't: 'p, D: Doc + 't>(
+fn may_match_ellipsis_impl<'p, 't: 'p, N: SgNode<'t>>(
   goal_children: &mut Peekable<impl Iterator<Item = &'p PatternNode>>,
-  cand_children: &mut Peekable<impl Iterator<Item = Node<'t, D>>>,
-  agg: &mut impl Aggregator<'t, D>,
+  cand_children: &mut Peekable<impl Iterator<Item = N>>,
+  agg: &mut impl Aggregator<'t, N>,
   strictness: &MatchStrictness,
 ) -> Option<ControlFlow> {
   let Some(curr_node) = goal_children.peek() else {
@@ -166,10 +166,10 @@ fn may_match_ellipsis_impl<'p, 't: 'p, D: Doc + 't>(
   }
 }
 
-fn match_single_node_while_skip_trivial<'p, 't: 'p, D: Doc + 't>(
+fn match_single_node_while_skip_trivial<'p, 't: 'p, N: SgNode<'t>>(
   goal_children: &mut Peekable<impl Iterator<Item = &'p PatternNode>>,
-  cand_children: &mut Peekable<impl Iterator<Item = Node<'t, D>>>,
-  agg: &mut impl Aggregator<'t, D>,
+  cand_children: &mut Peekable<impl Iterator<Item = N>>,
+  agg: &mut impl Aggregator<'t, N>,
   strictness: &MatchStrictness,
 ) -> Option<ControlFlow> {
   loop {
@@ -219,11 +219,11 @@ fn try_get_ellipsis_mode(node: &PatternNode) -> Result<Option<String>, ()> {
   }
 }
 
-fn match_ellipsis<'t, D: Doc>(
-  agg: &mut impl Aggregator<'t, D>,
+fn match_ellipsis<'t, N: SgNode<'t>>(
+  agg: &mut impl Aggregator<'t, N>,
   optional_name: &Option<String>,
-  mut matched: Vec<Node<'t, D>>,
-  cand_children: impl Iterator<Item = Node<'t, D>>,
+  mut matched: Vec<N>,
+  cand_children: impl Iterator<Item = N>,
   skipped_anonymous: usize,
 ) -> Option<()> {
   matched.extend(cand_children);
@@ -245,7 +245,7 @@ mod test {
     let n = Root::str(n, Tsx);
     let n = n.root().find(kind).expect("should find");
     let mut env = Cow::Owned(MetaVarEnv::new());
-    match_node_impl(&pattern.node, &n, &mut env, &strictness)
+    match_node_impl(&pattern.node, &*n, &mut env, &strictness)
   }
   fn matched(p: &str, n: &str, strictness: MatchStrictness) {
     let ret = match_tree(p, n, strictness);

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -44,10 +44,7 @@ impl<'t, D: Doc> Aggregator<'t, D> for ComputeEnd {
   }
 }
 
-pub fn match_end_non_recursive<D: Doc>(
-  goal: &Pattern<D::Lang>,
-  candidate: Node<D>,
-) -> Option<usize> {
+pub fn match_end_non_recursive<D: Doc>(goal: &Pattern, candidate: Node<D>) -> Option<usize> {
   let mut end = ComputeEnd(0);
   match match_node_impl(&goal.node, &candidate, &mut end, &goal.strictness) {
     MatchOneNode::MatchedBoth => Some(end.0),
@@ -113,7 +110,7 @@ impl<'t, D: Doc> Aggregator<'t, D> for Cow<'_, MetaVarEnv<'t, D>> {
 }
 
 pub fn match_node_non_recursive<'tree, D: Doc>(
-  goal: &Pattern<D::Lang>,
+  goal: &Pattern,
   candidate: Node<'tree, D>,
   env: &mut Cow<MetaVarEnv<'tree, D>>,
 ) -> Option<Node<'tree, D>> {
@@ -154,7 +151,7 @@ mod test {
   use std::collections::HashMap;
 
   fn find_node_recursive<'tree>(
-    goal: &Pattern<Tsx>,
+    goal: &Pattern,
     node: Node<'tree, StrDoc<Tsx>>,
     env: &mut Cow<MetaVarEnv<'tree, StrDoc<Tsx>>>,
   ) -> Option<Node<'tree, StrDoc<Tsx>>> {
@@ -300,7 +297,7 @@ mod test {
     test_non_match("class A { get b() {}}", "class A { b() {}}");
   }
 
-  fn find_end_recursive(goal: &Pattern<Tsx>, node: Node<StrDoc<Tsx>>) -> Option<usize> {
+  fn find_end_recursive(goal: &Pattern, node: Node<StrDoc<Tsx>>) -> Option<usize> {
     match_end_non_recursive(goal, node.clone()).or_else(|| {
       node
         .children()

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -6,6 +6,7 @@ use strictness::MatchOneNode;
 pub use strictness::MatchStrictness;
 
 use crate::meta_var::{MetaVarEnv, MetaVariable};
+use crate::node::SgNode;
 use crate::{Doc, Node, Pattern};
 
 use std::borrow::Cow;
@@ -120,7 +121,7 @@ pub fn match_node_non_recursive<'tree, D: Doc>(
   }
 }
 
-pub fn does_node_match_exactly<D: Doc>(goal: &Node<D>, candidate: &Node<D>) -> bool {
+pub fn does_node_match_exactly<'r, N: SgNode<'r>>(goal: &N, candidate: &N) -> bool {
   // return true if goal and candidate are the same node
   if goal.node_id() == candidate.node_id() {
     return true;

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -7,7 +7,7 @@ pub use strictness::MatchStrictness;
 
 use crate::meta_var::{MetaVariable, SgMetaVarEnv};
 use crate::node::SgNode;
-use crate::{Doc, Node, Pattern};
+use crate::Pattern;
 
 use std::borrow::Cow;
 
@@ -40,7 +40,7 @@ impl<'t, N: SgNode<'t>> Aggregator<'t, N> for ComputeEnd {
   }
 }
 
-pub fn match_end_non_recursive<D: Doc>(goal: &Pattern, candidate: Node<D>) -> Option<usize> {
+pub fn match_end_non_recursive<'t, N: SgNode<'t>>(goal: &Pattern, candidate: N) -> Option<usize> {
   let mut end = ComputeEnd(0);
   match match_node_impl(&goal.node, &candidate, &mut end, &goal.strictness) {
     MatchOneNode::MatchedBoth => Some(end.0),
@@ -144,6 +144,7 @@ mod test {
   use super::*;
   use crate::language::Tsx;
   use crate::meta_var::MetaVarEnv;
+  use crate::Node;
   use crate::{Root, StrDoc};
   use std::collections::HashMap;
 

--- a/crates/core/src/match_tree/strictness.rs
+++ b/crates/core/src/match_tree/strictness.rs
@@ -1,6 +1,6 @@
 use crate::matcher::{kind_utils, PatternNode};
 use crate::meta_var::MetaVariable;
-use crate::{Doc, Node};
+use crate::node::SgNode;
 use std::iter::Peekable;
 use std::str::FromStr;
 
@@ -21,7 +21,7 @@ pub(crate) enum MatchOneNode {
   NoMatch,
 }
 
-fn skip_comment_or_unnamed(n: &Node<impl Doc>) -> bool {
+fn skip_comment_or_unnamed<'r>(n: &impl SgNode<'r>) -> bool {
   if !n.is_named() {
     return true;
   }
@@ -30,12 +30,12 @@ fn skip_comment_or_unnamed(n: &Node<impl Doc>) -> bool {
 }
 
 impl MatchStrictness {
-  pub(crate) fn match_terminal<D: Doc>(
+  pub(crate) fn match_terminal<'r>(
     &self,
     is_named: bool,
     text: &str,
     goal_kind: u16,
-    candidate: &Node<D>,
+    candidate: &impl SgNode<'r>,
   ) -> MatchOneNode {
     use MatchStrictness as M;
     let cand_kind = candidate.kind_id();
@@ -67,7 +67,7 @@ impl MatchStrictness {
   }
 
   // TODO: this is a method for working around trailing nodes after pattern is matched
-  pub(crate) fn should_skip_trailing<D: Doc>(&self, candidate: &Node<D>) -> bool {
+  pub(crate) fn should_skip_trailing<'r, N: SgNode<'r>>(&self, candidate: &N) -> bool {
     use MatchStrictness as M;
     match self {
       M::Cst => false,

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -11,7 +11,8 @@ mod pattern;
 #[cfg(feature = "regex")]
 mod text;
 
-use crate::meta_var::MetaVarEnv;
+use crate::meta_var::{MetaVarEnv, SgMetaVarEnv};
+use crate::node::SgNode;
 use crate::traversal::Pre;
 use crate::{Doc, Node};
 
@@ -31,11 +32,11 @@ pub trait Matcher {
   /// Returns the node why the input is matched or None if not matched.
   /// The return value is usually input node itself, but it can be different node.
   /// For example `Has` matcher can return the child or descendant node.
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    _node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>>;
+    _node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N>;
 
   /// Returns a bitset for all possible target node kind ids.
   /// Returns None if the matcher needs to try against all node kind.
@@ -74,11 +75,11 @@ pub trait MatcherExt: Matcher {
 impl<T> MatcherExt for T where T: Matcher {}
 
 impl Matcher for str {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     let pattern = Pattern::str(self, node.lang().clone());
     pattern.match_node_with_env(node, env)
   }
@@ -93,11 +94,11 @@ impl<T> Matcher for &T
 where
   T: Matcher + ?Sized,
 {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     (**self).match_node_with_env(node, env)
   }
 
@@ -146,11 +147,11 @@ impl<'tree, D: Doc, M: Matcher> Iterator for FindAllNodes<'tree, D, M> {
 
 pub struct MatchAll;
 impl Matcher for MatchAll {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     Some(node)
   }
 
@@ -162,11 +163,11 @@ impl Matcher for MatchAll {
 
 pub struct MatchNone;
 impl Matcher for MatchNone {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    _node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    _node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     None
   }
 

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -46,7 +46,7 @@ pub trait Matcher {
 
   /// get_match_len will skip trailing anonymous child node to exclude punctuation.
   // This is not included in NodeMatch since it is only used in replace
-  fn get_match_len<D: Doc>(&self, _node: Node<D>) -> Option<usize> {
+  fn get_match_len<'tree, N: SgNode<'tree>>(&self, _node: N) -> Option<usize> {
     None
   }
 }
@@ -84,7 +84,7 @@ impl Matcher for str {
     pattern.match_node_with_env(node, env)
   }
 
-  fn get_match_len<D: Doc>(&self, node: Node<D>) -> Option<usize> {
+  fn get_match_len<'tree, N: SgNode<'tree>>(&self, node: N) -> Option<usize> {
     let pattern = Pattern::str(self, node.lang().clone());
     pattern.get_match_len(node)
   }
@@ -106,7 +106,7 @@ where
     (**self).potential_kinds()
   }
 
-  fn get_match_len<D: Doc>(&self, node: Node<D>) -> Option<usize> {
+  fn get_match_len<'tree, N: SgNode<'tree>>(&self, node: N) -> Option<usize> {
     (**self).get_match_len(node)
   }
 }

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -13,7 +13,7 @@ mod text;
 
 use crate::meta_var::MetaVarEnv;
 use crate::traversal::Pre;
-use crate::{Doc, Language, Node};
+use crate::{Doc, Node};
 
 use bit_set::BitSet;
 use std::borrow::Cow;
@@ -27,11 +27,11 @@ pub use text::{RegexMatcher, RegexMatcherError};
 /// `Matcher` defines whether a tree-sitter node matches certain pattern,
 /// and update the matched meta-variable values in `MetaVarEnv`.
 /// N.B. At least one positive term is required for matching
-pub trait Matcher<L: Language> {
+pub trait Matcher {
   /// Returns the node why the input is matched or None if not matched.
   /// The return value is usually input node itself, but it can be different node.
   /// For example `Has` matcher can return the child or descendant node.
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     _node: Node<'tree, D>,
     _env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -45,7 +45,7 @@ pub trait Matcher<L: Language> {
 
   /// get_match_len will skip trailing anonymous child node to exclude punctuation.
   // This is not included in NodeMatch since it is only used in replace
-  fn get_match_len<D: Doc<Lang = L>>(&self, _node: Node<D>) -> Option<usize> {
+  fn get_match_len<D: Doc>(&self, _node: Node<D>) -> Option<usize> {
     None
   }
 }
@@ -53,21 +53,15 @@ pub trait Matcher<L: Language> {
 /// MatcherExt provides additional utility methods for `Matcher`.
 /// It is implemented for all types that implement `Matcher`.
 /// N.B. This trait is not intended to be implemented by users.
-pub trait MatcherExt<L: Language>: Matcher<L> {
-  fn match_node<'tree, D: Doc<Lang = L>>(
-    &self,
-    node: Node<'tree, D>,
-  ) -> Option<NodeMatch<'tree, D>> {
+pub trait MatcherExt: Matcher {
+  fn match_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
     // in future we might need to customize initial MetaVarEnv
     let mut env = Cow::Owned(MetaVarEnv::new());
     let node = self.match_node_with_env(node, &mut env)?;
     Some(NodeMatch::new(node, env.into_owned()))
   }
 
-  fn find_node<'tree, D: Doc<Lang = L>>(
-    &self,
-    node: Node<'tree, D>,
-  ) -> Option<NodeMatch<'tree, D>> {
+  fn find_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
     for n in node.dfs() {
       if let Some(ret) = self.match_node(n.clone()) {
         return Some(ret);
@@ -77,15 +71,10 @@ pub trait MatcherExt<L: Language>: Matcher<L> {
   }
 }
 
-impl<L, T> MatcherExt<L> for T
-where
-  L: Language,
-  T: Matcher<L>,
-{
-}
+impl<T> MatcherExt for T where T: Matcher {}
 
-impl<L: Language> Matcher<L> for str {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for str {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -94,18 +83,17 @@ impl<L: Language> Matcher<L> for str {
     pattern.match_node_with_env(node, env)
   }
 
-  fn get_match_len<D: Doc<Lang = L>>(&self, node: Node<D>) -> Option<usize> {
+  fn get_match_len<D: Doc>(&self, node: Node<D>) -> Option<usize> {
     let pattern = Pattern::str(self, node.lang().clone());
     pattern.get_match_len(node)
   }
 }
 
-impl<L, T> Matcher<L> for &T
+impl<T> Matcher for &T
 where
-  L: Language,
-  T: Matcher<L> + ?Sized,
+  T: Matcher + ?Sized,
 {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -117,19 +105,19 @@ where
     (**self).potential_kinds()
   }
 
-  fn get_match_len<D: Doc<Lang = L>>(&self, node: Node<D>) -> Option<usize> {
+  fn get_match_len<D: Doc>(&self, node: Node<D>) -> Option<usize> {
     (**self).get_match_len(node)
   }
 }
 
-pub struct FindAllNodes<'tree, D: Doc, M: Matcher<D::Lang>> {
+pub struct FindAllNodes<'tree, D: Doc, M: Matcher> {
   // using dfs is not universally correct, say, when we want replace nested matches
   // e.g. for pattern Some($A) with replacement $A, Some(Some(1)) will cause panic
   dfs: Pre<'tree, D>,
   matcher: M,
 }
 
-impl<'tree, D: Doc, M: Matcher<D::Lang>> FindAllNodes<'tree, D, M> {
+impl<'tree, D: Doc, M: Matcher> FindAllNodes<'tree, D, M> {
   pub fn new(matcher: M, node: Node<'tree, D>) -> Self {
     Self {
       dfs: node.dfs(),
@@ -138,7 +126,7 @@ impl<'tree, D: Doc, M: Matcher<D::Lang>> FindAllNodes<'tree, D, M> {
   }
 }
 
-impl<'tree, D: Doc, M: Matcher<D::Lang>> Iterator for FindAllNodes<'tree, D, M> {
+impl<'tree, D: Doc, M: Matcher> Iterator for FindAllNodes<'tree, D, M> {
   type Item = NodeMatch<'tree, D>;
   fn next(&mut self) -> Option<Self::Item> {
     let kinds = self.matcher.potential_kinds();
@@ -157,8 +145,8 @@ impl<'tree, D: Doc, M: Matcher<D::Lang>> Iterator for FindAllNodes<'tree, D, M> 
 }
 
 pub struct MatchAll;
-impl<L: Language> Matcher<L> for MatchAll {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for MatchAll {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     _env: &mut Cow<MetaVarEnv<'tree, D>>,
@@ -173,8 +161,8 @@ impl<L: Language> Matcher<L> for MatchAll {
 }
 
 pub struct MatchNone;
-impl<L: Language> Matcher<L> for MatchNone {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for MatchNone {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     _node: Node<'tree, D>,
     _env: &mut Cow<MetaVarEnv<'tree, D>>,

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -20,7 +20,7 @@ use bit_set::BitSet;
 use std::borrow::Cow;
 
 pub use kind::{kind_utils, KindMatcher, KindMatcherError};
-pub use node_match::NodeMatch;
+pub use node_match::{NodeMatch, SgNodeMatch};
 pub use pattern::{Pattern, PatternError, PatternNode};
 #[cfg(feature = "regex")]
 pub use text::{RegexMatcher, RegexMatcherError};

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -11,7 +11,7 @@ mod pattern;
 #[cfg(feature = "regex")]
 mod text;
 
-use crate::meta_var::{MetaVarEnv, SgMetaVarEnv};
+use crate::meta_var::SgMetaVarEnv;
 use crate::node::SgNode;
 use crate::traversal::Pre;
 use crate::{Doc, Node};
@@ -55,14 +55,14 @@ pub trait Matcher {
 /// It is implemented for all types that implement `Matcher`.
 /// N.B. This trait is not intended to be implemented by users.
 pub trait MatcherExt: Matcher {
-  fn match_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+  fn match_node<'tree, N: SgNode<'tree>>(&self, node: N) -> Option<SgNodeMatch<'tree, N>> {
     // in future we might need to customize initial MetaVarEnv
-    let mut env = Cow::Owned(MetaVarEnv::new());
+    let mut env = Cow::Owned(SgMetaVarEnv::new());
     let node = self.match_node_with_env(node, &mut env)?;
-    Some(NodeMatch::new(node, env.into_owned()))
+    Some(SgNodeMatch::new(node, env.into_owned()))
   }
 
-  fn find_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+  fn find_node<'tree, N: SgNode<'tree>>(&self, node: N) -> Option<SgNodeMatch<'tree, N>> {
     for n in node.dfs() {
       if let Some(ret) = self.match_node(n.clone()) {
         return Some(ret);

--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -1,8 +1,8 @@
 use super::Matcher;
 
-use crate::meta_var::MetaVarEnv;
-use crate::node::KindId;
-use crate::{Doc, Language, Node};
+use crate::meta_var::SgMetaVarEnv;
+use crate::node::{KindId, SgNode};
+use crate::Language;
 
 use std::borrow::Cow;
 
@@ -76,11 +76,11 @@ pub mod kind_utils {
 }
 
 impl Matcher for KindMatcher {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     if node.kind_id() == self.kind {
       Some(node)
     } else {

--- a/crates/core/src/matcher/node_match.rs
+++ b/crates/core/src/matcher/node_match.rs
@@ -12,7 +12,11 @@ use std::ops::Deref;
 /// It derefs to the Node so you can use it as a Node.
 /// To access the underlying MetaVarEnv, call `get_env` method.
 #[derive(Clone)]
-pub struct SgNodeMatch<'t, N: SgNode<'t>, C>(N, SgMetaVarEnv<'t, N, C>);
+pub struct SgNodeMatch<
+  't,
+  N: SgNode<'t>,
+  C = Vec<<<<N as SgNode<'t>>::Doc as Doc>::Source as Content>::Underlying>,
+>(N, SgMetaVarEnv<'t, N, C>);
 pub type NodeMatch<'t, D> =
   SgNodeMatch<'t, Node<'t, D>, Vec<<<D as Doc>::Source as Content>::Underlying>>;
 

--- a/crates/core/src/matcher/node_match.rs
+++ b/crates/core/src/matcher/node_match.rs
@@ -43,8 +43,8 @@ impl<'tree, N: SgNode<'tree>, C> SgNodeMatch<'tree, N, C> {
   }
 }
 
-impl<D: Doc> NodeMatch<'_, D> {
-  pub fn replace_by<R: Replacer<D>>(&self, replacer: R) -> Edit<D::Source> {
+impl<'r, N: SgNode<'r>> SgNodeMatch<'r, N> {
+  pub fn replace_by<R: Replacer<N::Doc>>(&self, replacer: R) -> Edit<<N::Doc as Doc>::Source> {
     let range = self.range();
     let position = range.start;
     let deleted_length = range.len();
@@ -57,10 +57,10 @@ impl<D: Doc> NodeMatch<'_, D> {
   }
 
   #[doc(hidden)]
-  pub fn make_edit<M, R>(&self, matcher: &M, replacer: &R) -> Edit<D::Source>
+  pub fn make_edit<M, R>(&self, matcher: &M, replacer: &R) -> Edit<<N::Doc as Doc>::Source>
   where
     M: Matcher,
-    R: Replacer<D>,
+    R: Replacer<N::Doc>,
   {
     let range = replacer.get_replaced_range(self, matcher);
     let inserted_text = replacer.generate_replacement(self);

--- a/crates/core/src/matcher/node_match.rs
+++ b/crates/core/src/matcher/node_match.rs
@@ -52,7 +52,7 @@ impl<D: Doc> NodeMatch<'_, D> {
   #[doc(hidden)]
   pub fn make_edit<M, R>(&self, matcher: &M, replacer: &R) -> Edit<D::Source>
   where
-    M: Matcher<D::Lang>,
+    M: Matcher,
     R: Replacer<D>,
   {
     let range = replacer.get_replaced_range(self, matcher);

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -294,7 +294,7 @@ impl Matcher for Pattern {
     Some(kinds)
   }
 
-  fn get_match_len<D: Doc>(&self, node: Node<D>) -> Option<usize> {
+  fn get_match_len<'tree, N: SgNode<'tree>>(&self, node: N) -> Option<usize> {
     let start = node.range().start;
     let end = match_end_non_recursive(self, node)?;
     Some(end - start)

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -1,7 +1,7 @@
 use crate::language::{CoreLanguage, Language};
 use crate::match_tree::{match_end_non_recursive, match_node_non_recursive, MatchStrictness};
 use crate::matcher::{kind_utils, KindMatcher, KindMatcherError, Matcher};
-use crate::meta_var::{MetaVarEnv, MetaVariable};
+use crate::meta_var::{MetaVariable, SgMetaVarEnv};
 use crate::node::SgNode;
 use crate::source::TSParseError;
 use crate::{Doc, Node, Root, StrDoc};
@@ -256,11 +256,11 @@ impl Pattern {
 }
 
 impl Matcher for Pattern {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     if let Some(k) = self.root_kind {
       if node.kind_id() != k {
         return None;
@@ -321,6 +321,7 @@ mod test {
   use super::*;
   use crate::language::Tsx;
   use crate::matcher::MatcherExt;
+  use crate::meta_var::MetaVarEnv;
   use std::collections::HashMap;
 
   fn pattern_node(s: &str) -> Root<StrDoc<Tsx>> {

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -1,4 +1,4 @@
-use crate::language::Language;
+use crate::language::{CoreLanguage, Language};
 use crate::match_tree::{match_end_non_recursive, match_node_non_recursive, MatchStrictness};
 use crate::matcher::{kind_utils, KindMatcher, KindMatcherError, Matcher};
 use crate::meta_var::{MetaVarEnv, MetaVariable};

--- a/crates/core/src/matcher/text.rs
+++ b/crates/core/src/matcher/text.rs
@@ -1,13 +1,12 @@
 use super::Matcher;
 use crate::meta_var::MetaVarEnv;
-use crate::{Doc, Language, Node};
+use crate::{Doc, Node};
 
 use bit_set::BitSet;
 use regex::{Error as RegexError, Regex};
 use thiserror::Error;
 
 use std::borrow::Cow;
-use std::marker::PhantomData;
 
 #[derive(Debug, Error)]
 pub enum RegexMatcherError {
@@ -16,22 +15,20 @@ pub enum RegexMatcherError {
 }
 
 #[derive(Clone)]
-pub struct RegexMatcher<L: Language> {
+pub struct RegexMatcher {
   regex: Regex,
-  lang: PhantomData<L>,
 }
 
-impl<L: Language> RegexMatcher<L> {
+impl RegexMatcher {
   pub fn try_new(text: &str) -> Result<Self, RegexMatcherError> {
     Ok(RegexMatcher {
       regex: Regex::new(text)?,
-      lang: PhantomData,
     })
   }
 }
 
-impl<L: Language> Matcher<L> for RegexMatcher<L> {
-  fn match_node_with_env<'tree, D: Doc<Lang = L>>(
+impl Matcher for RegexMatcher {
+  fn match_node_with_env<'tree, D: Doc>(
     &self,
     node: Node<'tree, D>,
     _env: &mut Cow<MetaVarEnv<'tree, D>>,

--- a/crates/core/src/matcher/text.rs
+++ b/crates/core/src/matcher/text.rs
@@ -1,6 +1,6 @@
 use super::Matcher;
-use crate::meta_var::MetaVarEnv;
-use crate::{Doc, Node};
+use crate::meta_var::SgMetaVarEnv;
+use crate::node::SgNode;
 
 use bit_set::BitSet;
 use regex::{Error as RegexError, Regex};
@@ -28,11 +28,11 @@ impl RegexMatcher {
 }
 
 impl Matcher for RegexMatcher {
-  fn match_node_with_env<'tree, D: Doc>(
+  fn match_node_with_env<'tree, N: SgNode<'tree>>(
     &self,
-    node: Node<'tree, D>,
-    _env: &mut Cow<MetaVarEnv<'tree, D>>,
-  ) -> Option<Node<'tree, D>> {
+    node: N,
+    _env: &mut Cow<SgMetaVarEnv<'tree, N>>,
+  ) -> Option<N> {
     self.regex.is_match(&node.text()).then_some(node)
   }
 

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -163,7 +163,7 @@ impl<'t, N: SgNode<'t>> SgMetaVarEnv<'t, N> {
   pub fn get_transformed(&self, var: &str) -> Option<&Underlying<N::Doc>> {
     self.transformed_var.get(var)
   }
-  pub fn get_var_bytes<'s: 't>(
+  pub fn get_var_bytes<'s>(
     &'s self,
     var: &MetaVariable,
   ) -> Option<&'s [<<N::Doc as Doc>::Source as Content>::Underlying]> {
@@ -189,10 +189,10 @@ impl<D: Doc> MetaVarEnv<'_, D> {
   }
 }
 
-fn get_var_bytes_impl<'t, C, D, N>(
-  env: &'t SgMetaVarEnv<'t, N>,
+fn get_var_bytes_impl<'e, 't, C, D, N>(
+  env: &'e SgMetaVarEnv<'t, N>,
   var: &MetaVariable,
-) -> Option<&'t [C::Underlying]>
+) -> Option<&'e [C::Underlying]>
 where
   N: SgNode<'t, Doc = D>,
   D: Doc<Source = C> + 't,

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -17,7 +17,7 @@ pub type Underlying<D> = Vec<<<D as Doc>::Source as Content>::Underlying>;
 /// a dictionary that stores metavariable instantiation
 /// const a = 123 matched with const a = $A will produce env: $A => 123
 #[derive(Clone)]
-pub struct SgMetaVarEnv<'tree, N: SgNode<'tree>, C> {
+pub struct SgMetaVarEnv<'tree, N: SgNode<'tree>, C = Underlying<<N as SgNode<'tree>>::Doc>> {
   single_matched: HashMap<MetaVariableID, N>,
   multi_matched: HashMap<MetaVariableID, Vec<N>>,
   transformed_var: HashMap<MetaVariableID, C>,

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -11,7 +11,7 @@ use crate::replacer::formatted_slice;
 pub type MetaVariableID = String;
 
 pub type MetaVarEnv<'t, D> = SgMetaVarEnv<'t, Node<'t, D>, Underlying<D>>;
-type Underlying<D> = Vec<<<D as Doc>::Source as Content>::Underlying>;
+pub type Underlying<D> = Vec<<<D as Doc>::Source as Content>::Underlying>;
 
 // why we need one more content? https://github.com/ast-grep/ast-grep/issues/1951
 /// a dictionary that stores metavariable instantiation

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -109,7 +109,7 @@ impl<'tree, D: Doc> MetaVarEnv<'tree, D> {
     single.chain(multi).chain(transformed)
   }
 
-  pub fn match_constraints<M: Matcher<D::Lang>>(
+  pub fn match_constraints<M: Matcher>(
     &mut self,
     var_matchers: &HashMap<MetaVariableID, M>,
   ) -> bool {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -146,6 +146,7 @@ impl<D: Doc> Root<D> {
 }
 
 pub trait SgNode<'r>: Clone {
+  type Doc: Doc;
   fn children(&self) -> impl ExactSizeIterator<Item = Self>;
   fn is_named(&self) -> bool;
   /// N.B. it is different from is_named && is_leaf
@@ -158,6 +159,7 @@ pub trait SgNode<'r>: Clone {
 }
 
 impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
+  type Doc = D;
   fn node_id(&self) -> usize {
     self.node_id()
   }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -147,7 +147,7 @@ impl<D: Doc> Root<D> {
 
 pub trait SgNode<'r>: Clone {
   type Doc: Doc;
-  fn get_doc(&self) -> &Self::Doc;
+  fn get_doc(&self) -> &'r Self::Doc;
   fn parent(&self) -> Option<Self>;
   fn ancestors(&self) -> impl Iterator<Item = Self>;
   fn dfs(&self) -> impl Iterator<Item = Self>;
@@ -179,7 +179,7 @@ pub trait SgNode<'r>: Clone {
 
 impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
   type Doc = D;
-  fn get_doc(&self) -> &Self::Doc {
+  fn get_doc(&self) -> &'r Self::Doc {
     &self.root.doc
   }
   fn node_id(&self) -> usize {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -152,10 +152,16 @@ pub trait SgNode<'r>: Clone {
   /// N.B. it is different from is_named && is_leaf
   /// if a node has no named children.
   fn is_named_leaf(&self) -> bool;
+  fn is_leaf(&self) -> bool;
   fn kind(&self) -> Cow<str>;
   fn kind_id(&self) -> KindId;
   fn node_id(&self) -> usize;
   fn text(&self) -> Cow<'r, str>;
+  fn lang(&self) -> &<Self::Doc as Doc>::Lang;
+  // missing node is a tree-sitter specific concept
+  fn is_missing_node(&self) -> bool {
+    false
+  }
 }
 
 impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
@@ -169,6 +175,9 @@ impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
   fn is_named_leaf(&self) -> bool {
     self.is_named_leaf()
   }
+  fn is_leaf(&self) -> bool {
+    self.is_leaf()
+  }
   fn text(&self) -> Cow<'r, str> {
     self.text()
   }
@@ -180,6 +189,12 @@ impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
   }
   fn children(&self) -> impl ExactSizeIterator<Item = Self> {
     self.children()
+  }
+  fn lang(&self) -> &<Self::Doc as Doc>::Lang {
+    self.lang()
+  }
+  fn is_missing_node(&self) -> bool {
+    self.get_ts_node().is_missing()
   }
 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -303,23 +303,23 @@ impl<'r, L: Language> Node<'r, StrDoc<L>> {
  * Corresponds to inside/has/precedes/follows
  */
 impl<D: Doc> Node<'_, D> {
-  pub fn matches<M: Matcher<D::Lang>>(&self, m: M) -> bool {
+  pub fn matches<M: Matcher>(&self, m: M) -> bool {
     m.match_node(self.clone()).is_some()
   }
 
-  pub fn inside<M: Matcher<D::Lang>>(&self, m: M) -> bool {
+  pub fn inside<M: Matcher>(&self, m: M) -> bool {
     self.ancestors().find_map(|n| m.match_node(n)).is_some()
   }
 
-  pub fn has<M: Matcher<D::Lang>>(&self, m: M) -> bool {
+  pub fn has<M: Matcher>(&self, m: M) -> bool {
     self.dfs().skip(1).find_map(|n| m.match_node(n)).is_some()
   }
 
-  pub fn precedes<M: Matcher<D::Lang>>(&self, m: M) -> bool {
+  pub fn precedes<M: Matcher>(&self, m: M) -> bool {
     self.next_all().find_map(|n| m.match_node(n)).is_some()
   }
 
-  pub fn follows<M: Matcher<D::Lang>>(&self, m: M) -> bool {
+  pub fn follows<M: Matcher>(&self, m: M) -> bool {
     self.prev_all().find_map(|n| m.match_node(n)).is_some()
   }
 }
@@ -509,32 +509,24 @@ impl<'r, D: Doc> Node<'r, D> {
   }
 
   #[must_use]
-  pub fn find<M: Matcher<D::Lang>>(&self, pat: M) -> Option<NodeMatch<'r, D>> {
+  pub fn find<M: Matcher>(&self, pat: M) -> Option<NodeMatch<'r, D>> {
     pat.find_node(self.clone())
   }
 
-  pub fn find_all<M: Matcher<D::Lang>>(&self, pat: M) -> impl Iterator<Item = NodeMatch<'r, D>> {
+  pub fn find_all<M: Matcher>(&self, pat: M) -> impl Iterator<Item = NodeMatch<'r, D>> {
     FindAllNodes::new(pat, self.clone())
   }
 }
 
 /// Tree manipulation API
 impl<D: Doc> Node<'_, D> {
-  pub fn replace<M: Matcher<D::Lang>, R: Replacer<D>>(
-    &self,
-    matcher: M,
-    replacer: R,
-  ) -> Option<Edit<D>> {
+  pub fn replace<M: Matcher, R: Replacer<D>>(&self, matcher: M, replacer: R) -> Option<Edit<D>> {
     let matched = matcher.find_node(self.clone())?;
     let edit = matched.make_edit(&matcher, &replacer);
     Some(edit)
   }
 
-  pub fn replace_all<M: Matcher<D::Lang>, R: Replacer<D>>(
-    &self,
-    matcher: M,
-    replacer: R,
-  ) -> Vec<Edit<D>> {
+  pub fn replace_all<M: Matcher, R: Replacer<D>>(&self, matcher: M, replacer: R) -> Vec<Edit<D>> {
     // TODO: support nested matches like Some(Some(1)) with pattern Some($A)
     Visitor::new(&matcher)
       .reentrant(false)

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -145,6 +145,42 @@ impl<D: Doc> Root<D> {
   }
 }
 
+pub trait SgNode<'r> {
+  fn children(&self) -> impl ExactSizeIterator<Item = Self>;
+  fn is_named(&self) -> bool;
+  /// N.B. it is different from is_named && is_leaf
+  /// if a node has no named children.
+  fn is_named_leaf(&self) -> bool;
+  fn kind(&self) -> Cow<str>;
+  fn kind_id(&self) -> KindId;
+  fn node_id(&self) -> usize;
+  fn text(&self) -> Cow<'r, str>;
+}
+
+impl<'r, D: Doc> SgNode<'r> for Node<'r, D> {
+  fn node_id(&self) -> usize {
+    self.node_id()
+  }
+  fn is_named(&self) -> bool {
+    self.is_named()
+  }
+  fn is_named_leaf(&self) -> bool {
+    self.is_named_leaf()
+  }
+  fn text(&self) -> Cow<'r, str> {
+    self.text()
+  }
+  fn kind(&self) -> Cow<str> {
+    self.kind()
+  }
+  fn kind_id(&self) -> KindId {
+    self.kind_id()
+  }
+  fn children(&self) -> impl ExactSizeIterator<Item = Self> {
+    self.children()
+  }
+}
+
 /// 'r represents root lifetime
 #[derive(Clone)]
 pub struct Node<'r, D: Doc> {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -145,7 +145,7 @@ impl<D: Doc> Root<D> {
   }
 }
 
-pub trait SgNode<'r> {
+pub trait SgNode<'r>: Clone {
   fn children(&self) -> impl ExactSizeIterator<Item = Self>;
   fn is_named(&self) -> bool;
   /// N.B. it is different from is_named && is_leaf

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -19,7 +19,7 @@ pub use template::{TemplateFix, TemplateFixError};
 /// Replace meta variable in the replacer string
 pub trait Replacer<D: Doc> {
   fn generate_replacement(&self, nm: &NodeMatch<D>) -> Underlying<D::Source>;
-  fn get_replaced_range(&self, nm: &NodeMatch<D>, matcher: impl Matcher<D::Lang>) -> Range<usize> {
+  fn get_replaced_range(&self, nm: &NodeMatch<D>, matcher: impl Matcher) -> Range<usize> {
     let range = nm.range();
     if let Some(len) = matcher.get_match_len(nm.get_node().clone()) {
       range.start..range.start + len

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,5 +1,5 @@
 use crate::matcher::Matcher;
-use crate::meta_var::{is_valid_meta_var_char, MetaVariableID};
+use crate::meta_var::{is_valid_meta_var_char, MetaVariableID, Underlying};
 use crate::{Doc, Node, SgNode, SgNodeMatch};
 use std::ops::Range;
 
@@ -7,7 +7,6 @@ pub(crate) use indent::formatted_slice;
 
 // use crate::source::Edit as E;
 // type Edit<D> = E<<D as Doc>::Source>;
-type Underlying<S> = Vec<<S as Content>::Underlying>;
 
 mod indent;
 mod structural;
@@ -21,7 +20,7 @@ pub trait Replacer<D: Doc> {
   fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
     &self,
     nm: &SgNodeMatch<'t, N>,
-  ) -> Underlying<D::Source>;
+  ) -> Underlying<D>;
   fn get_replaced_range<'t, N: SgNode<'t, Doc = D>>(
     &self,
     nm: &SgNodeMatch<'t, N>,
@@ -40,7 +39,7 @@ impl<D: Doc> Replacer<D> for str {
   fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
     &self,
     nm: &SgNodeMatch<'t, N>,
-  ) -> Underlying<D::Source> {
+  ) -> Underlying<D> {
     template::gen_replacement(self, nm)
   }
 }
@@ -59,7 +58,7 @@ where
   fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
     &self,
     nm: &SgNodeMatch<'t, N>,
-  ) -> Underlying<D::Source> {
+  ) -> Underlying<D> {
     (**self).generate_replacement(nm)
   }
 }
@@ -68,7 +67,7 @@ impl<D: Doc> Replacer<D> for Node<'_, D> {
   fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
     &self,
     _nm: &SgNodeMatch<'t, N>,
-  ) -> Underlying<D::Source> {
+  ) -> Underlying<D> {
     let range = self.range();
     self.root.doc.get_source().get_range(range).to_vec()
   }

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,4 +1,4 @@
-use crate::matcher::{Matcher, NodeMatch};
+use crate::matcher::Matcher;
 use crate::meta_var::{is_valid_meta_var_char, MetaVariableID};
 use crate::{Doc, Node, SgNode, SgNodeMatch};
 use std::ops::Range;
@@ -22,7 +22,11 @@ pub trait Replacer<D: Doc> {
     &self,
     nm: &SgNodeMatch<'t, N>,
   ) -> Underlying<D::Source>;
-  fn get_replaced_range(&self, nm: &NodeMatch<D>, matcher: impl Matcher) -> Range<usize> {
+  fn get_replaced_range<'t, N: SgNode<'t, Doc = D>>(
+    &self,
+    nm: &SgNodeMatch<'t, N>,
+    matcher: impl Matcher,
+  ) -> Range<usize> {
     let range = nm.range();
     if let Some(len) = matcher.get_match_len(nm.get_node().clone()) {
       range.start..range.start + len

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -1,220 +1,215 @@
-use super::{Edit, Underlying};
-use crate::language::CoreLanguage;
-use crate::matcher::NodeMatch;
-use crate::meta_var::MetaVarEnv;
-use crate::source::Content;
-use crate::{Doc, Node, Root};
+// use super::{Edit, Underlying};
+// use crate::language::CoreLanguage;
+// use crate::matcher::NodeMatch;
+// use crate::meta_var::MetaVarEnv;
+// use crate::source::Content;
+// use crate::{Doc, Node, Root};
 
-pub fn gen_replacement<D: Doc>(root: &Root<D>, nm: &NodeMatch<D>) -> Underlying<D::Source> {
-  let edits = collect_edits(root, nm.get_env(), nm.lang());
-  merge_edits_to_vec(edits, root)
-}
+// fn collect_edits<D: Doc>(root: &Root<D>, env: &MetaVarEnv<D>, lang: &D::Lang) -> Vec<Edit<D>> {
+//   let mut node = root.root();
+//   let root_id = node.inner.id();
+//   let mut edits = vec![];
 
-fn collect_edits<D: Doc>(root: &Root<D>, env: &MetaVarEnv<D>, lang: &D::Lang) -> Vec<Edit<D>> {
-  let mut node = root.root();
-  let root_id = node.inner.id();
-  let mut edits = vec![];
+//   // this is a post-order DFS that stops traversal when the node matches
+//   'outer: loop {
+//     if let Some(text) = get_meta_var_replacement(&node, env, lang.clone()) {
+//       let position = node.inner.start_byte();
+//       let length = node.inner.end_byte() - position;
+//       edits.push(Edit::<D> {
+//         position: position as usize,
+//         deleted_length: length as usize,
+//         inserted_text: text,
+//       });
+//     } else if let Some(first_child) = node.child(0) {
+//       // traverse down to child
+//       node = first_child;
+//       continue;
+//     } else if node.inner.is_missing() {
+//       // TODO: better handling missing node
+//       if let Some(sibling) = node.next() {
+//         node = sibling;
+//         continue;
+//       } else {
+//         break;
+//       }
+//     }
+//     // traverse up to parent until getting to root
+//     loop {
+//       // come back to the root node, terminating dfs
+//       if node.inner.id() == root_id {
+//         break 'outer;
+//       }
+//       if let Some(sibling) = node.next() {
+//         node = sibling;
+//         break;
+//       }
+//       node = node.parent().unwrap();
+//     }
+//   }
+//   // add the missing one
+//   edits.push(Edit::<D> {
+//     position: root.root().range().end,
+//     deleted_length: 0,
+//     inserted_text: vec![],
+//   });
+//   edits
+// }
 
-  // this is a post-order DFS that stops traversal when the node matches
-  'outer: loop {
-    if let Some(text) = get_meta_var_replacement(&node, env, lang.clone()) {
-      let position = node.inner.start_byte();
-      let length = node.inner.end_byte() - position;
-      edits.push(Edit::<D> {
-        position: position as usize,
-        deleted_length: length as usize,
-        inserted_text: text,
-      });
-    } else if let Some(first_child) = node.child(0) {
-      // traverse down to child
-      node = first_child;
-      continue;
-    } else if node.inner.is_missing() {
-      // TODO: better handling missing node
-      if let Some(sibling) = node.next() {
-        node = sibling;
-        continue;
-      } else {
-        break;
-      }
-    }
-    // traverse up to parent until getting to root
-    loop {
-      // come back to the root node, terminating dfs
-      if node.inner.id() == root_id {
-        break 'outer;
-      }
-      if let Some(sibling) = node.next() {
-        node = sibling;
-        break;
-      }
-      node = node.parent().unwrap();
-    }
-  }
-  // add the missing one
-  edits.push(Edit::<D> {
-    position: root.root().range().end,
-    deleted_length: 0,
-    inserted_text: vec![],
-  });
-  edits
-}
+// fn merge_edits_to_vec<D: Doc>(edits: Vec<Edit<D>>, root: &Root<D>) -> Underlying<D::Source> {
+//   let mut ret = vec![];
+//   let mut start = 0;
+//   for edit in edits {
+//     debug_assert!(start <= edit.position, "Edit must be ordered!");
+//     ret.extend(
+//       root
+//         .doc
+//         .get_source()
+//         .get_range(start..edit.position)
+//         .iter()
+//         .cloned(),
+//     );
+//     ret.extend(edit.inserted_text.iter().cloned());
+//     start = edit.position + edit.deleted_length;
+//   }
+//   ret
+// }
 
-fn merge_edits_to_vec<D: Doc>(edits: Vec<Edit<D>>, root: &Root<D>) -> Underlying<D::Source> {
-  let mut ret = vec![];
-  let mut start = 0;
-  for edit in edits {
-    debug_assert!(start <= edit.position, "Edit must be ordered!");
-    ret.extend(
-      root
-        .doc
-        .get_source()
-        .get_range(start..edit.position)
-        .iter()
-        .cloned(),
-    );
-    ret.extend(edit.inserted_text.iter().cloned());
-    start = edit.position + edit.deleted_length;
-  }
-  ret
-}
+// fn get_meta_var_replacement<D: Doc>(
+//   node: &Node<D>,
+//   env: &MetaVarEnv<D>,
+//   lang: D::Lang,
+// ) -> Option<Underlying<D::Source>> {
+//   if !node.is_named_leaf() {
+//     return None;
+//   }
+//   let meta_var = lang.extract_meta_var(&node.text())?;
+//   let replaced = env.get_var_bytes(&meta_var)?;
+//   Some(replaced.to_vec())
+// }
 
-fn get_meta_var_replacement<D: Doc>(
-  node: &Node<D>,
-  env: &MetaVarEnv<D>,
-  lang: D::Lang,
-) -> Option<Underlying<D::Source>> {
-  if !node.is_named_leaf() {
-    return None;
-  }
-  let meta_var = lang.extract_meta_var(&node.text())?;
-  let replaced = env.get_var_bytes(&meta_var)?;
-  Some(replaced.to_vec())
-}
+// #[cfg(test)]
+// mod test {
+//   use super::*;
+//   use crate::language::{Language, Tsx};
+//   use crate::meta_var::MetaVarEnv;
+//   use crate::{replacer::Replacer, Root};
+//   use std::collections::HashMap;
 
-#[cfg(test)]
-mod test {
-  use super::*;
-  use crate::language::{Language, Tsx};
-  use crate::meta_var::MetaVarEnv;
-  use crate::{replacer::Replacer, Root};
-  use std::collections::HashMap;
+//   fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
+//     let mut env = MetaVarEnv::new();
+//     let roots: Vec<_> = vars
+//       .iter()
+//       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
+//       .collect();
+//     for (var, root) in &roots {
+//       env.insert(var, root.root());
+//     }
+//     let dummy = Tsx.ast_grep("dummy");
+//     let node_match = NodeMatch::new(dummy.root(), env.clone());
+//     let replacer = Root::new(replacer, Tsx);
+//     let replaced = replacer.generate_replacement(&node_match);
+//     let replaced = String::from_utf8_lossy(&replaced);
+//     assert_eq!(
+//       replaced,
+//       expected,
+//       "wrong replacement {replaced} {expected} {:?}",
+//       HashMap::from(env)
+//     );
+//   }
 
-  fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
-    let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
-    for (var, root) in &roots {
-      env.insert(var, root.root());
-    }
-    let dummy = Tsx.ast_grep("dummy");
-    let node_match = NodeMatch::new(dummy.root(), env.clone());
-    let replacer = Root::new(replacer, Tsx);
-    let replaced = replacer.generate_replacement(&node_match);
-    let replaced = String::from_utf8_lossy(&replaced);
-    assert_eq!(
-      replaced,
-      expected,
-      "wrong replacement {replaced} {expected} {:?}",
-      HashMap::from(env)
-    );
-  }
+//   #[test]
+//   fn test_no_env() {
+//     test_pattern_replace("let a = 123", &[], "let a = 123");
+//     test_pattern_replace(
+//       "console.log('hello world'); let b = 123;",
+//       &[],
+//       "console.log('hello world'); let b = 123;",
+//     );
+//   }
 
-  #[test]
-  fn test_no_env() {
-    test_pattern_replace("let a = 123", &[], "let a = 123");
-    test_pattern_replace(
-      "console.log('hello world'); let b = 123;",
-      &[],
-      "console.log('hello world'); let b = 123;",
-    );
-  }
+//   #[test]
+//   fn test_single_env() {
+//     test_pattern_replace("let a = $A", &[("A", "123")], "let a = 123");
+//     test_pattern_replace(
+//       "console.log($HW); let b = 123;",
+//       &[("HW", "'hello world'")],
+//       "console.log('hello world'); let b = 123;",
+//     );
+//   }
 
-  #[test]
-  fn test_single_env() {
-    test_pattern_replace("let a = $A", &[("A", "123")], "let a = 123");
-    test_pattern_replace(
-      "console.log($HW); let b = 123;",
-      &[("HW", "'hello world'")],
-      "console.log('hello world'); let b = 123;",
-    );
-  }
+//   #[test]
+//   fn test_multiple_env() {
+//     test_pattern_replace("let $V = $A", &[("A", "123"), ("V", "a")], "let a = 123");
+//     test_pattern_replace(
+//       "console.log($HW); let $B = 123;",
+//       &[("HW", "'hello world'"), ("B", "b")],
+//       "console.log('hello world'); let b = 123;",
+//     );
+//   }
 
-  #[test]
-  fn test_multiple_env() {
-    test_pattern_replace("let $V = $A", &[("A", "123"), ("V", "a")], "let a = 123");
-    test_pattern_replace(
-      "console.log($HW); let $B = 123;",
-      &[("HW", "'hello world'"), ("B", "b")],
-      "console.log('hello world'); let b = 123;",
-    );
-  }
+//   #[test]
+//   fn test_multiple_occurrences() {
+//     test_pattern_replace("let $A = $A", &[("A", "a")], "let a = a");
+//     test_pattern_replace("var $A = () => $A", &[("A", "a")], "var a = () => a");
+//     test_pattern_replace(
+//       "const $A = () => { console.log($B); $A(); };",
+//       &[("B", "'hello world'"), ("A", "a")],
+//       "const a = () => { console.log('hello world'); a(); };",
+//     );
+//   }
 
-  #[test]
-  fn test_multiple_occurrences() {
-    test_pattern_replace("let $A = $A", &[("A", "a")], "let a = a");
-    test_pattern_replace("var $A = () => $A", &[("A", "a")], "var a = () => a");
-    test_pattern_replace(
-      "const $A = () => { console.log($B); $A(); };",
-      &[("B", "'hello world'"), ("A", "a")],
-      "const a = () => { console.log('hello world'); a(); };",
-    );
-  }
+//   fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
+//     let mut env = MetaVarEnv::new();
+//     let roots: Vec<_> = vars
+//       .iter()
+//       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
+//       .collect();
+//     for (var, root) in &roots {
+//       env.insert_multi(var, root.root().children().collect());
+//     }
+//     let dummy = Tsx.ast_grep("dummy");
+//     let node_match = NodeMatch::new(dummy.root(), env.clone());
+//     let replacer = Root::new(replacer, Tsx);
+//     let replaced = replacer.generate_replacement(&node_match);
+//     let replaced = String::from_utf8_lossy(&replaced);
+//     assert_eq!(
+//       replaced,
+//       expected,
+//       "wrong replacement {replaced} {expected} {:?}",
+//       HashMap::from(env)
+//     );
+//   }
 
-  fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
-    let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
-    for (var, root) in &roots {
-      env.insert_multi(var, root.root().children().collect());
-    }
-    let dummy = Tsx.ast_grep("dummy");
-    let node_match = NodeMatch::new(dummy.root(), env.clone());
-    let replacer = Root::new(replacer, Tsx);
-    let replaced = replacer.generate_replacement(&node_match);
-    let replaced = String::from_utf8_lossy(&replaced);
-    assert_eq!(
-      replaced,
-      expected,
-      "wrong replacement {replaced} {expected} {:?}",
-      HashMap::from(env)
-    );
-  }
+//   #[test]
+//   fn test_ellipsis_meta_var() {
+//     test_ellipsis_replace(
+//       "let a = () => { $$$B }",
+//       &[("B", "alert('works!')")],
+//       "let a = () => { alert('works!') }",
+//     );
+//     test_ellipsis_replace(
+//       "let a = () => { $$$B }",
+//       &[("B", "alert('works!');console.log(123)")],
+//       "let a = () => { alert('works!');console.log(123) }",
+//     );
+//   }
 
-  #[test]
-  fn test_ellipsis_meta_var() {
-    test_ellipsis_replace(
-      "let a = () => { $$$B }",
-      &[("B", "alert('works!')")],
-      "let a = () => { alert('works!') }",
-    );
-    test_ellipsis_replace(
-      "let a = () => { $$$B }",
-      &[("B", "alert('works!');console.log(123)")],
-      "let a = () => { alert('works!');console.log(123) }",
-    );
-  }
+//   #[test]
+//   fn test_multi_ellipsis() {
+//     test_ellipsis_replace(
+//       "import {$$$A, B, $$$C} from 'a'",
+//       &[("A", "A"), ("C", "C")],
+//       "import {A, B, C} from 'a'",
+//     );
+//   }
 
-  #[test]
-  fn test_multi_ellipsis() {
-    test_ellipsis_replace(
-      "import {$$$A, B, $$$C} from 'a'",
-      &[("A", "A"), ("C", "C")],
-      "import {A, B, C} from 'a'",
-    );
-  }
+//   #[test]
+//   fn test_replace_in_string() {
+//     test_pattern_replace("'$A'", &[("A", "123")], "'123'");
+//   }
 
-  #[test]
-  fn test_replace_in_string() {
-    test_pattern_replace("'$A'", &[("A", "123")], "'123'");
-  }
-
-  #[test]
-  fn test_nested_matching_replace() {
-    // TODO
-  }
-}
+//   #[test]
+//   fn test_nested_matching_replace() {
+//     // TODO
+//   }
+// }

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -1,5 +1,5 @@
 use super::{Edit, Underlying};
-use crate::language::Language;
+use crate::language::CoreLanguage;
 use crate::matcher::NodeMatch;
 use crate::meta_var::MetaVarEnv;
 use crate::source::Content;

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -1,6 +1,6 @@
 use super::indent::{extract_with_deindent, get_indent_at_offset, indent_lines, DeindentedExtract};
 use super::{split_first_meta_var, MetaVarExtract, Replacer, Underlying};
-use crate::language::Language;
+use crate::language::CoreLanguage;
 use crate::matcher::NodeMatch;
 use crate::meta_var::MetaVarEnv;
 use crate::source::{Content, Doc};
@@ -20,11 +20,11 @@ pub enum TemplateFix {
 pub enum TemplateFixError {}
 
 impl TemplateFix {
-  pub fn try_new<L: Language>(template: &str, lang: &L) -> Result<Self, TemplateFixError> {
+  pub fn try_new<L: CoreLanguage>(template: &str, lang: &L) -> Result<Self, TemplateFixError> {
     Ok(create_template(template, lang.meta_var_char(), &[]))
   }
 
-  pub fn with_transform<L: Language>(tpl: &str, lang: &L, trans: &[String]) -> Self {
+  pub fn with_transform<L: CoreLanguage>(tpl: &str, lang: &L, trans: &[String]) -> Self {
     create_template(tpl, lang.meta_var_char(), trans)
   }
 

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -1,7 +1,7 @@
 use super::indent::{extract_with_deindent, get_indent_at_offset, indent_lines, DeindentedExtract};
-use super::{split_first_meta_var, MetaVarExtract, Replacer, Underlying};
+use super::{split_first_meta_var, MetaVarExtract, Replacer};
 use crate::language::CoreLanguage;
-use crate::meta_var::SgMetaVarEnv;
+use crate::meta_var::{SgMetaVarEnv, Underlying};
 use crate::source::{Content, Doc};
 use crate::{SgNode, SgNodeMatch};
 
@@ -41,7 +41,7 @@ impl<D: Doc> Replacer<D> for TemplateFix {
   fn generate_replacement<'t, N: SgNode<'t, Doc = D>>(
     &self,
     nm: &SgNodeMatch<'t, N>,
-  ) -> Underlying<D::Source> {
+  ) -> Underlying<D> {
     let leading = nm.get_doc().get_source().get_range(0..nm.range().start);
     let indent = get_indent_at_offset::<D::Source>(leading);
     let bytes = replace_fixer(self, nm.get_env());
@@ -91,7 +91,7 @@ fn create_template(tmpl: &str, mv_char: char, transforms: &[String]) -> Template
 fn replace_fixer<'t, N: SgNode<'t>>(
   fixer: &TemplateFix,
   env: &SgMetaVarEnv<'t, N>,
-) -> Vec<<<N::Doc as Doc>::Source as Content>::Underlying> {
+) -> Underlying<N::Doc> {
   let template = match fixer {
     TemplateFix::Textual(n) => return <N::Doc as Doc>::Source::decode_str(n).to_vec(),
     TemplateFix::WithMetaVar(t) => t,
@@ -158,7 +158,7 @@ where
 pub fn gen_replacement<'t, N: SgNode<'t>>(
   template: &str,
   nm: &SgNodeMatch<'t, N>,
-) -> Underlying<<N::Doc as Doc>::Source> {
+) -> Underlying<N::Doc> {
   let fixer = create_template(template, nm.lang().meta_var_char(), &[]);
   fixer.generate_replacement(nm)
 }

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -77,7 +77,7 @@ pub enum TSParseError {
   TreeUnavailable,
 }
 
-pub trait Doc: Clone {
+pub trait Doc: Clone + 'static {
   type Source: Content;
   type Lang: Language;
   fn get_lang(&self) -> &Self::Lang;

--- a/crates/core/src/traversal.rs
+++ b/crates/core/src/traversal.rs
@@ -74,7 +74,7 @@ where
 {
   pub fn visit<D: Doc>(self, node: Node<D>) -> Visit<'_, D, A::Traversal<'_, D>, M>
   where
-    M: Matcher<D::Lang>,
+    M: Matcher,
   {
     let traversal = A::traverse(node);
     Visit {
@@ -98,7 +98,7 @@ impl<'t, D, T, M> Visit<'t, D, T, M>
 where
   D: Doc + 't,
   T: Traversal<'t, D>,
-  M: Matcher<D::Lang>,
+  M: Matcher,
 {
   #[inline]
   fn mark_match(&mut self, depth: Option<usize>) {
@@ -112,7 +112,7 @@ impl<'t, D, T, M> Iterator for Visit<'t, D, T, M>
 where
   D: Doc + 't,
   T: Traversal<'t, D>,
-  M: Matcher<D::Lang>,
+  M: Matcher,
 {
   type Item = NodeMatch<'t, D>;
   fn next(&mut self) -> Option<Self::Item> {

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,5 +1,5 @@
 use super::pre_process_pattern;
-use ast_grep_core::language::TSRange;
+use ast_grep_core::language::{CoreLanguage, TSRange};
 use ast_grep_core::Language;
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
 use std::collections::HashMap;
@@ -8,15 +8,17 @@ use std::collections::HashMap;
 // https://github.com/tree-sitter/tree-sitter-html/blob/b5d9758e22b4d3d25704b72526670759a9e4d195/src/scanner.c#L194
 #[derive(Clone, Copy, Debug)]
 pub struct Html;
-impl Language for Html {
-  fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {
-    crate::parsers::language_html()
-  }
+impl CoreLanguage for Html {
   fn expando_char(&self) -> char {
     'z'
   }
   fn pre_process_pattern<'q>(&self, query: &'q str) -> std::borrow::Cow<'q, str> {
     pre_process_pattern(self.expando_char(), query)
+  }
+}
+impl Language for Html {
+  fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {
+    crate::parsers::language_html()
   }
   fn injectable_languages(&self) -> Option<&'static [&'static str]> {
     Some(&["css", "js", "ts", "tsx", "scss", "less", "stylus", "coffee"])

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -518,9 +518,6 @@ mod test {
     lang: impl Language,
   ) -> Result<String, TSParseError> {
     let mut source = lang.ast_grep(src);
-    // TODO: we should have still have pattern as replacer
-    let replacer = lang.pre_process_pattern(replacer);
-    let replacer = lang.ast_grep(replacer).inner;
     assert!(source.replace(pattern, replacer)?);
     Ok(source.generate())
   }

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -29,7 +29,7 @@ pub struct NapiConfig {
 }
 
 impl NapiConfig {
-  pub fn parse_with(self, lang: NapiLang) -> NapiResult<RuleCore<NapiLang>> {
+  pub fn parse_with(self, lang: NapiLang) -> NapiResult<RuleCore> {
     let rule = SerializableRuleCore {
       rule: serde_json::from_value(self.rule)?,
       constraints: self.constraints.map(serde_json::from_value).transpose()?,

--- a/crates/napi/src/find_files.rs
+++ b/crates/napi/src/find_files.rs
@@ -140,7 +140,7 @@ fn get_root(entry: ignore::DirEntry, lang_option: &LangOption) -> Ret<(AstGrep<J
 
 pub type FindInFiles = IterateFiles<(
   ThreadsafeFunction<PinnedNodes, ErrorStrategy::CalleeHandled>,
-  RuleCore<NapiLang>,
+  RuleCore,
 )>;
 
 pub struct PinnedNodes(
@@ -208,7 +208,7 @@ fn from_pinned_data(pinned: PinnedNodes, env: napi::Env) -> Result<Vec<Vec<SgNod
 fn call_sg_node(
   (tsfn, rule): &(
     ThreadsafeFunction<PinnedNodes, ErrorStrategy::CalleeHandled>,
-    RuleCore<NapiLang>,
+    RuleCore,
   ),
   entry: std::result::Result<ignore::DirEntry, ignore::Error>,
   lang_option: &LangOption,

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -1,7 +1,7 @@
 use ast_grep_core::language::TSLanguage;
 use ast_grep_core::Language;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
-use ast_grep_language::SupportLang;
+use ast_grep_language::{CoreLanguage, SupportLang};
 use ignore::types::{Types, TypesBuilder};
 use ignore::{WalkBuilder, WalkParallel};
 use napi::anyhow::anyhow;
@@ -112,14 +112,7 @@ impl From<SupportLang> for NapiLang {
 }
 
 use NapiLang::*;
-impl Language for NapiLang {
-  fn get_ts_language(&self) -> TSLanguage {
-    match self {
-      Builtin(b) => b.get_ts_language(),
-      Custom(c) => c.get_ts_language(),
-    }
-  }
-
+impl CoreLanguage for NapiLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -140,6 +133,14 @@ impl Language for NapiLang {
     match self {
       Builtin(b) => b.expando_char(),
       Custom(c) => c.expando_char(),
+    }
+  }
+}
+impl Language for NapiLang {
+  fn get_ts_language(&self) -> TSLanguage {
+    match self {
+      Builtin(b) => b.get_ts_language(),
+      Custom(c) => c.get_ts_language(),
     }
   }
 }

--- a/crates/napi/src/sg_node.rs
+++ b/crates/napi/src/sg_node.rs
@@ -43,7 +43,7 @@ impl SgNode {
   fn to_pos(&self, pos: Position, offset: usize) -> Pos {
     Pos {
       line: pos.line() as u32,
-      column: pos.column(&self.inner) as u32,
+      column: pos.column(self.inner.get_node()) as u32,
       index: offset as u32 / 2,
     }
   }

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use ast_grep_core::language::TSLanguage;
+use ast_grep_core::language::{CoreLanguage, TSLanguage};
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};
 use serde::{Deserialize, Serialize};
@@ -87,14 +87,7 @@ impl FromStr for PyLang {
 }
 
 use PyLang::*;
-impl Language for PyLang {
-  fn get_ts_language(&self) -> TSLanguage {
-    match self {
-      Builtin(b) => b.get_ts_language(),
-      Custom(c) => c.get_ts_language(),
-    }
-  }
-
+impl CoreLanguage for PyLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -115,6 +108,14 @@ impl Language for PyLang {
     match self {
       Builtin(b) => b.expando_char(),
       Custom(c) => c.expando_char(),
+    }
+  }
+}
+impl Language for PyLang {
+  fn get_ts_language(&self) -> TSLanguage {
+    match self {
+      Builtin(b) => b.get_ts_language(),
+      Custom(c) => c.get_ts_language(),
     }
   }
 }

--- a/crates/pyo3/src/py_node.rs
+++ b/crates/pyo3/src/py_node.rs
@@ -339,7 +339,7 @@ impl SgNode {
     &self,
     config: Option<Bound<PyDict>>,
     kwargs: Option<Bound<PyDict>>,
-  ) -> PyResult<RuleCore<PyLang>> {
+  ) -> PyResult<RuleCore> {
     let lang = self.inner.lang();
     let config = if let Some(config) = config {
       config_from_dict(config)?
@@ -369,7 +369,7 @@ fn config_from_rule(dict: Bound<PyDict>) -> PyResult<SerializableRuleCore> {
   })
 }
 
-fn get_matcher_from_rule(lang: &PyLang, dict: Option<Bound<PyDict>>) -> PyResult<RuleCore<PyLang>> {
+fn get_matcher_from_rule(lang: &PyLang, dict: Option<Bound<PyDict>>) -> PyResult<RuleCore> {
   let rule = dict.ok_or_else(|| PyErr::new::<PyValueError, _>("rule must not be empty"))?;
   let env = DeserializeEnv::new(*lang);
   let config = config_from_rule(rule)?;

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
-use ast_grep_core::{language::TSLanguage, Language};
+use ast_grep_core::language::{CoreLanguage, TSLanguage};
+use ast_grep_core::Language;
 use ast_grep_language::{
   Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua, Php,
   Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
@@ -209,6 +210,7 @@ impl JsonSchema for PlaceholderLang {
   }
 }
 
+impl CoreLanguage for PlaceholderLang {}
 impl Language for PlaceholderLang {
   fn get_ts_language(&self) -> TSLanguage {
     unreachable!("PlaceholderLang is only for json schema")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed explicit language-type parameters from matcher, rule, fixer, and pattern types across public APIs and internal implementations.
  - Split language trait into core language and extended language traits to separate foundational parsing logic from language-specific features.
  - Simplified trait bounds and type signatures in pattern matching, rule configuration, transformation, and replacement modules.
  - Reorganized trait implementations for language structs to improve modularity and clarity.
  - Introduced a new syntax tree node trait to generalize node handling across modules.
  - Generalized matcher traits and implementations by eliminating language-specific generics.
  - Updated node match and metavariable environment abstractions to support generic syntax tree nodes.
  - Refined replacer and transformation logic to use generalized node and environment types.
- **Bug Fixes**
  - Enhanced consistency and robustness of rule matching and pattern processing across languages.
- **Chores**
  - Updated internal APIs, macros, and tests to conform with the new non-generic interfaces and trait structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->