### PR TITLE
fix: fix incorrect musl detection in postinstall script

### DIFF
--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -3,8 +3,8 @@ let path = require('path');
 
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
-  if (family === MUSL) {
+  const {MUSL, familySync} = require('detect-libc');
+  if (familySync() === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');


### PR DESCRIPTION
Require and call the `familySync` method from `detect-libc` instead of comparing the _function_ `family` with the constant `MUSL`

Closes https://github.com/ast-grep/ast-grep/issues/1941