### PR TITLE
feat: provide alias info in language schemas

### DIFF
--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -99,12 +99,16 @@ macro_rules! impl_lang_expando {
   };
 }
 
+pub trait Alias: Display {
+  const ALIAS: &'static [&'static str];
+}
+
 /// Implements the `ALIAS` associated constant for the given lang, which is
 /// then used to define the `alias` const fn and a `Deserialize` impl.
 macro_rules! impl_alias {
   ($lang:ident => $as:expr) => {
-    impl $lang {
-      pub const ALIAS: &'static [&'static str] = $as;
+    impl Alias for $lang {
+      const ALIAS: &'static [&'static str] = $as;
     }
 
     impl fmt::Display for $lang {

--- a/schemas/bash_rule.json
+++ b/schemas/bash_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "bash",
+        "Bash"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/c_rule.json
+++ b/schemas/c_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "c",
+        "C"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/cpp_rule.json
+++ b/schemas/cpp_rule.json
@@ -174,7 +174,14 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "cc",
+        "c++",
+        "cpp",
+        "cxx",
+        "Cpp"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/csharp_rule.json
+++ b/schemas/csharp_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "cs",
+        "csharp",
+        "CSharp"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/css_rule.json
+++ b/schemas/css_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "css",
+        "Css"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/elixir_rule.json
+++ b/schemas/elixir_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "ex",
+        "elixir",
+        "Elixir"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/go_rule.json
+++ b/schemas/go_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "go",
+        "golang",
+        "Go"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/haskell_rule.json
+++ b/schemas/haskell_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "hs",
+        "haskell",
+        "Haskell"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/html_rule.json
+++ b/schemas/html_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "html",
+        "Html"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/java_rule.json
+++ b/schemas/java_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "java",
+        "Java"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/javascript_rule.json
+++ b/schemas/javascript_rule.json
@@ -174,7 +174,13 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "javascript",
+        "js",
+        "jsx",
+        "JavaScript"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/json_rule.json
+++ b/schemas/json_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "json",
+        "Json"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/kotlin_rule.json
+++ b/schemas/kotlin_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "kotlin",
+        "kt",
+        "Kotlin"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/lua_rule.json
+++ b/schemas/lua_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "lua",
+        "Lua"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/php_rule.json
+++ b/schemas/php_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "php",
+        "Php"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/python_rule.json
+++ b/schemas/python_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "py",
+        "python",
+        "Python"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/ruby_rule.json
+++ b/schemas/ruby_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "rb",
+        "ruby",
+        "Ruby"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/rust_rule.json
+++ b/schemas/rust_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "rs",
+        "rust",
+        "Rust"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/scala_rule.json
+++ b/schemas/scala_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "scala",
+        "Scala"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/swift_rule.json
+++ b/schemas/swift_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "swift",
+        "Swift"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/tsx_rule.json
+++ b/schemas/tsx_rule.json
@@ -174,7 +174,11 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "tsx",
+        "Tsx"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/typescript_rule.json
+++ b/schemas/typescript_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "ts",
+        "typescript",
+        "TypeScript"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/schemas/yaml_rule.json
+++ b/schemas/yaml_rule.json
@@ -174,7 +174,12 @@
       }
     },
     "Language": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "yaml",
+        "yml",
+        "Yaml"
+      ]
     },
     "Maybe_Array_of_SerializableRule": {
       "type": "array",

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -2,8 +2,8 @@ use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
 use ast_grep_core::{language::TSLanguage, Language};
 use ast_grep_language::{
-  Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua, Php,
-  Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
+  Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
+  Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
 };
 use schemars::{
   gen::SchemaGenerator,
@@ -53,7 +53,7 @@ fn generate_lang_schemas() -> Result<()> {
   generate_lang_schema(Yaml, "yaml")
 }
 
-fn generate_lang_schema<T: Language>(lang: T, name: &str) -> Result<()> {
+fn generate_lang_schema<T: Language + Alias>(lang: T, name: &str) -> Result<()> {
   let mut schema = schema_for!(SerializableRuleConfig<PlaceholderLang>);
   tweak_schema(&mut schema)?;
   add_lang_info_to_schema(&mut schema, lang, name)?;
@@ -79,7 +79,7 @@ fn tweak_schema(schema: &mut RootSchema) -> Result<()> {
   Ok(())
 }
 
-fn add_lang_info_to_schema<T: Language>(
+fn add_lang_info_to_schema<T: Language + Alias>(
   schema: &mut RootSchema,
   lang: T,
   name: &str,
@@ -116,6 +116,21 @@ fn add_lang_info_to_schema<T: Language>(
     bail!("kind's type is not object!")
   };
   kind.enum_values = Some(named_nodes);
+  let Schema::Object(language) = definitions
+    .get_mut("Language")
+    .context("must have Language")?
+  else {
+    bail!("Language's type is not an object!")
+  };
+  language.enum_values = Some(
+    T::ALIAS
+      .iter()
+      .map(|alias| serde_json::Value::String(alias.to_string()))
+      .chain(std::iter::once(serde_json::Value::String(format!(
+        "{lang}"
+      ))))
+      .collect(),
+  );
   Ok(())
 }
 


### PR DESCRIPTION
Helpful for determining possible aliases, or catching typos like `language: Typescript` (should be `language: TypeScript`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Language schemas now strictly validate the "Language" property, accepting only a predefined set of case-sensitive aliases for each supported language.
- **Bug Fixes**
  - Improved schema validation to prevent invalid language identifiers.
- **Chores**
  - Enhanced internal schema generation to automatically include all language aliases as valid options in the schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->