### PR TITLE
Parser Abstraction Part 3 Language

### DIFF
--- a/benches/src/sg_benchmark.rs
+++ b/benches/src/sg_benchmark.rs
@@ -1,5 +1,5 @@
 use ast_grep_config::{from_yaml_string, RuleConfig};
-use ast_grep_core::{AstGrep, Language, Matcher, Pattern, StrDoc};
+use ast_grep_core::{AstGrep, LanguageExt, Matcher, Pattern, StrDoc};
 use ast_grep_language::SupportLang;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::env::current_dir;

--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -1,7 +1,7 @@
 use super::SgLang;
 use crate::utils::ErrorContext as EC;
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::{language::TSRange, Doc, Language, Node, StrDoc};
+use ast_grep_core::{language::TSRange, Doc, LanguageExt, Node, StrDoc};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -123,7 +123,7 @@ pub fn injectable_languages(lang: SgLang) -> Option<&'static [&'static str]> {
   Some(&injection.1)
 }
 
-pub fn extract_injections<L: Language>(root: Node<StrDoc<L>>) -> HashMap<String, Vec<TSRange>> {
+pub fn extract_injections<L: LanguageExt>(root: Node<StrDoc<L>>) -> HashMap<String, Vec<TSRange>> {
   // NB Only works in the CLI crate because we only has Node<SgLang>
   let root: Node<StrDoc<SgLang>> = unsafe { std::mem::transmute(root) };
   let mut ret = match root.lang() {

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -4,6 +4,7 @@ mod lang_globs;
 use crate::utils::ErrorContext as EC;
 
 use anyhow::{Context, Result};
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::{
   language::{TSLanguage, TSRange},
   Node, StrDoc,
@@ -194,6 +195,9 @@ impl CoreLanguage for SgLang {
     lang_globs::from_path(path)
       .or_else(|| DynamicLang::from_path(path).map(Custom))
       .or_else(|| SupportLang::from_path(path).map(Builtin))
+  }
+  fn build_pattern(&self, builder: &PatternBuilder) -> std::result::Result<Pattern, PatternError> {
+    builder.build(|src| StrDoc::try_new(src, *self))
   }
 }
 

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -10,7 +10,7 @@ use ast_grep_core::{
   Node, StrDoc,
 };
 use ast_grep_dynamic::DynamicLang;
-use ast_grep_language::{CoreLanguage, Language, SupportLang};
+use ast_grep_language::{Language, LanguageExt, SupportLang};
 use ignore::types::Types;
 use serde::{Deserialize, Serialize};
 
@@ -152,7 +152,7 @@ impl From<DynamicLang> for SgLang {
 }
 
 use SgLang::*;
-impl CoreLanguage for SgLang {
+impl Language for SgLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -201,7 +201,7 @@ impl CoreLanguage for SgLang {
   }
 }
 
-impl Language for SgLang {
+impl LanguageExt for SgLang {
   fn get_ts_language(&self) -> TSLanguage {
     match self {
       Builtin(b) => b.get_ts_language(),
@@ -213,7 +213,7 @@ impl Language for SgLang {
     injection::injectable_languages(*self)
   }
 
-  fn extract_injections<L: Language>(
+  fn extract_injections<L: LanguageExt>(
     &self,
     root: Node<StrDoc<L>>,
   ) -> HashMap<String, Vec<TSRange>> {

--- a/crates/cli/src/print/cloud_print.rs
+++ b/crates/cli/src/print/cloud_print.rs
@@ -112,7 +112,7 @@ fn print_rule<W: Write>(
 mod test {
   use super::*;
   use ast_grep_config::{from_yaml_string, GlobalRules};
-  use ast_grep_language::{Language, SupportLang};
+  use ast_grep_language::{LanguageExt, SupportLang};
   use codespan_reporting::term::termcolor::Buffer;
 
   fn make_test_printer() -> CloudPrinter<Buffer> {

--- a/crates/cli/src/print/colored_print/test.rs
+++ b/crates/cli/src/print/colored_print/test.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use ast_grep_config::{from_yaml_string, Fixer, GlobalRules};
-use ast_grep_language::{Language, SupportLang};
+use ast_grep_language::{LanguageExt, SupportLang};
 use codespan_reporting::term::termcolor::Buffer;
 
 use std::fmt::Write;

--- a/crates/cli/src/print/json_print.rs
+++ b/crates/cli/src/print/json_print.rs
@@ -416,7 +416,7 @@ impl PrintProcessor<Buffer> for JSONProcessor {
 mod test {
   use super::*;
   use ast_grep_config::{from_yaml_string, Fixer, GlobalRules};
-  use ast_grep_language::{Language, SupportLang};
+  use ast_grep_language::{LanguageExt, SupportLang};
 
   struct Test(String);
   impl Write for Test {

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use ast_grep_config::Fixer;
 use ast_grep_core::{MatchStrictness, Matcher, Pattern};
-use ast_grep_language::{CoreLanguage, Language};
+use ast_grep_language::{Language, LanguageExt};
 use clap::{builder::PossibleValue, Parser, ValueEnum};
 use ignore::WalkParallel;
 

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -269,7 +269,7 @@ impl StdInWorker for ScanStdin {
     src: String,
     processor: &P::Processor,
   ) -> Result<Vec<P::Processed>> {
-    use ast_grep_core::Language;
+    use ast_grep_core::LanguageExt;
     let lang = self.rules[0].language;
     let combined = CombinedScan::new(self.rules.iter().collect());
     let grep = lang.ast_grep(src);

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -1,7 +1,7 @@
 use crate::lang::SgLang;
 use ansi_term::Style;
 use ast_grep_core::{language::TSLanguage, matcher::PatternNode, meta_var::MetaVariable, Pattern};
-use ast_grep_language::Language;
+use ast_grep_language::LanguageExt;
 use clap::ValueEnum;
 use tree_sitter as ts;
 

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -80,7 +80,6 @@ fn dump_pattern(
       kind_id,
       is_named,
     } => {
-      let lang = lang.get_ts_language();
       if *is_named {
         let kind = lang.node_kind_for_id(*kind_id).unwrap();
         let kind = style.kind_style.paint(format!("{kind}"));

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -42,14 +42,14 @@ impl DebugFormat {
         debug_assert!(false, "debug_tree cannot be called with Pattern")
       }
       DebugFormat::Sexp => {
-        eprintln!("Debug Sexp:\n{}", root.root().to_sexp());
+        eprintln!("Debug Sexp:\n{}", root.root().get_inner_node().to_sexp());
       }
       DebugFormat::Ast => {
-        let dumped = dump_node(root.root().get_ts_node());
+        let dumped = dump_node(root.root().get_inner_node());
         eprintln!("Debug AST:\n{}", dumped.ast(colored));
       }
       DebugFormat::Cst => {
-        let dumped = dump_node(root.root().get_ts_node());
+        let dumped = dump_node(root.root().get_inner_node());
         eprintln!("Debug CST:\n{}", dumped.cst(colored));
       }
     }
@@ -249,7 +249,7 @@ program (0,0)-(0,11)
   fn test_dump_node() {
     let lang = SgLang::Builtin(TypeScript.into());
     let root = lang.ast_grep("var a = 123");
-    let dumped = dump_node(root.root().get_ts_node());
+    let dumped = dump_node(root.root().get_inner_node());
     assert_eq!(DUMPED.trim(), dumped.ast(false).trim());
   }
 
@@ -266,7 +266,7 @@ translation_unit (0,0)-(0,9)
   fn test_missing_node() {
     let lang = SgLang::Builtin(C.into());
     let root = lang.ast_grep("int a = 1");
-    let dumped = dump_node(root.root().get_ts_node());
+    let dumped = dump_node(root.root().get_inner_node());
     assert_eq!(MISSING.trim(), dumped.cst(false).trim());
   }
 }

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -29,7 +29,7 @@ use smallvec::{smallvec, SmallVec};
 use ast_grep_config::RuleCollection;
 use ast_grep_core::Pattern;
 use ast_grep_core::{Matcher, StrDoc};
-use ast_grep_language::{CoreLanguage, Language};
+use ast_grep_language::{Language, LanguageExt};
 
 use std::fs::read_to_string;
 use std::io::stdout;

--- a/crates/cli/src/verify/case_result.rs
+++ b/crates/cli/src/verify/case_result.rs
@@ -7,7 +7,7 @@ for general review.
 */
 use super::{snapshot::TestSnapshot, SgLang, TestSnapshots};
 use ast_grep_config::RuleConfig;
-use ast_grep_language::Language;
+use ast_grep_language::LanguageExt;
 
 /// [CaseStatus] categorize whether and how ast-grep
 /// reports error for either valid or invalid code.

--- a/crates/cli/src/verify/snapshot.rs
+++ b/crates/cli/src/verify/snapshot.rs
@@ -1,7 +1,7 @@
 use crate::lang::SgLang;
 use anyhow::{anyhow, Result};
 use ast_grep_config::RuleConfig;
-use ast_grep_core::{Language, NodeMatch, StrDoc};
+use ast_grep_core::{LanguageExt, NodeMatch, StrDoc};
 
 use super::{CaseResult, Node};
 use serde::{Deserialize, Serialize, Serializer};

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -266,7 +266,7 @@ mod test {
   use crate::from_str;
   use crate::test::TypeScript;
   use crate::SerializableRuleConfig;
-  use ast_grep_core::language::LanguageExt;
+  use ast_grep_core::LanguageExt;
 
   fn create_rule() -> RuleConfig<TypeScript> {
     let rule: SerializableRuleConfig<TypeScript> = from_str(

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -266,6 +266,7 @@ mod test {
   use crate::from_str;
   use crate::test::TypeScript;
   use crate::SerializableRuleConfig;
+  use ast_grep_core::language::LanguageExt;
 
   fn create_rule() -> RuleConfig<TypeScript> {
     let rule: SerializableRuleConfig<TypeScript> = from_str(

--- a/crates/config/src/fixer.rs
+++ b/crates/config/src/fixer.rs
@@ -188,6 +188,7 @@ mod test {
   use crate::from_str;
   use crate::maybe::Maybe;
   use crate::test::TypeScript;
+  use ast_grep_core::LanguageExt;
 
   #[test]
   fn test_parse() {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -42,17 +42,17 @@ pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
 #[cfg(test)]
 mod test {
   use super::*;
-  use ast_grep_core::language::CoreLanguage;
   use ast_grep_core::language::TSLanguage;
   use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
   use ast_grep_core::StrDoc;
+  use ast_grep_core::{Language, LanguageExt};
   use std::path::Path;
 
   #[derive(Clone, Deserialize, PartialEq, Eq)]
   pub enum TypeScript {
     Tsx,
   }
-  impl CoreLanguage for TypeScript {
+  impl Language for TypeScript {
     fn kind_to_id(&self, kind: &str) -> u16 {
       TSLanguage::from(tree_sitter_typescript::LANGUAGE_TSX).id_for_node_kind(kind, true)
     }
@@ -66,7 +66,7 @@ mod test {
       builder.build(|src| StrDoc::try_new(src, self.clone()))
     }
   }
-  impl Language for TypeScript {
+  impl LanguageExt for TypeScript {
     fn get_ts_language(&self) -> TSLanguage {
       tree_sitter_typescript::LANGUAGE_TSX.into()
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -41,10 +41,11 @@ pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
 }
 #[cfg(test)]
 mod test {
-
   use super::*;
   use ast_grep_core::language::CoreLanguage;
   use ast_grep_core::language::TSLanguage;
+  use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+  use ast_grep_core::StrDoc;
   use std::path::Path;
 
   #[derive(Clone, Deserialize, PartialEq, Eq)]
@@ -60,6 +61,9 @@ mod test {
     }
     fn from_path<P: AsRef<Path>>(_path: P) -> Option<Self> {
       Some(TypeScript::Tsx)
+    }
+    fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+      builder.build(|src| StrDoc::try_new(src, self.clone()))
     }
   }
   impl Language for TypeScript {

--- a/crates/config/src/rule/deserialize_env.rs
+++ b/crates/config/src/rule/deserialize_env.rs
@@ -214,6 +214,7 @@ mod test {
   use crate::test::TypeScript;
   use crate::{from_str, Rule};
   use anyhow::Result;
+  use ast_grep_core::LanguageExt;
   use ast_grep_core::Matcher;
 
   fn get_dependent_utils() -> Result<(Rule, DeserializeEnv<TypeScript>)> {

--- a/crates/config/src/rule/mod.rs
+++ b/crates/config/src/rule/mod.rs
@@ -489,6 +489,7 @@ mod test {
   use super::*;
   use crate::from_str;
   use crate::test::TypeScript;
+  use ast_grep_core::LanguageExt;
   use PatternStyle::*;
 
   #[test]

--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -267,6 +267,7 @@ mod test {
   use crate::test::TypeScript as TS;
   use ast_grep_core::matcher::RegexMatcher;
   use ast_grep_core::meta_var::MetaVarEnv;
+  use ast_grep_core::LanguageExt;
 
   #[test]
   fn test_positional() {

--- a/crates/config/src/rule/range.rs
+++ b/crates/config/src/rule/range.rs
@@ -97,7 +97,7 @@ mod test {
   use super::*;
   use crate::test::TypeScript as TS;
   use ast_grep_core::matcher::MatcherExt;
-  use ast_grep_core::Language;
+  use ast_grep_core::LanguageExt;
 
   #[test]
   fn test_invalid_range() {

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -268,10 +268,10 @@ impl Matcher for Follows {
 mod test {
   use super::*;
   use crate::test::TypeScript as TS;
-  use ast_grep_core::language::CoreLanguage;
   use ast_grep_core::matcher::KindMatcher;
   use ast_grep_core::ops as o;
   use ast_grep_core::Pattern;
+  use ast_grep_core::{Language, LanguageExt};
 
   fn find_rule<M: Matcher>(src: &str, matcher: M) -> Option<String> {
     let grep = TS::Tsx.ast_grep(src);

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -7,7 +7,7 @@ use crate::rule_core::{RuleCore, RuleCoreError, SerializableRuleCore};
 
 use ast_grep_core::language::Language;
 use ast_grep_core::replacer::Replacer;
-use ast_grep_core::{Matcher, NodeMatch, StrDoc};
+use ast_grep_core::{LanguageExt, Matcher, NodeMatch, StrDoc};
 
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -192,7 +192,10 @@ impl<L: Language> RuleConfig<L> {
     Self::try_from(inner, globals)
   }
 
-  pub fn get_message(&self, node: &NodeMatch<StrDoc<L>>) -> String {
+  pub fn get_message(&self, node: &NodeMatch<StrDoc<L>>) -> String
+  where
+    L: LanguageExt,
+  {
     let env = self.matcher.get_env(self.language.clone());
     let parsed = Fixer::with_transform(&self.message, &env, &self.transform).expect("should work");
     let bytes = parsed.generate_replacement(node);

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -279,6 +279,7 @@ mod test {
   use crate::rule::referent_rule::{ReferentRule, ReferentRuleError};
   use crate::test::TypeScript;
   use ast_grep_core::matcher::{Pattern, RegexMatcher};
+  use ast_grep_core::LanguageExt;
 
   fn get_matcher(src: &str) -> RResult<RuleCore> {
     let env = DeserializeEnv::new(TypeScript::Tsx);

--- a/crates/config/src/transform/mod.rs
+++ b/crates/config/src/transform/mod.rs
@@ -83,6 +83,7 @@ mod test {
   use super::*;
   use crate::from_str;
   use crate::test::TypeScript;
+  use ast_grep_core::LanguageExt;
 
   #[test]
   fn test_single_cyclic_transform() {

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -342,6 +342,7 @@ fix: $D
     rewrite: Rewrite<String>,
     reg: RuleRegistration,
   ) -> Option<String> {
+    use ast_grep_core::language::LanguageExt;
     let grep = TypeScript::Tsx.ast_grep(src);
     let root = grep.root();
     let mut nm = root.find(pat).expect("should find");

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -342,7 +342,7 @@ fix: $D
     rewrite: Rewrite<String>,
     reg: RuleRegistration,
   ) -> Option<String> {
-    use ast_grep_core::language::LanguageExt;
+    use ast_grep_core::LanguageExt;
     let grep = TypeScript::Tsx.ast_grep(src);
     let root = grep.root();
     let mut nm = root.find(pat).expect("should find");

--- a/crates/config/src/transform/transformation.rs
+++ b/crates/config/src/transform/transformation.rs
@@ -207,7 +207,7 @@ mod test {
   use super::*;
   use crate::test::TypeScript;
   use crate::DeserializeEnv;
-  use ast_grep_core::language::LanguageExt;
+  use ast_grep_core::LanguageExt;
   use serde_yaml::with::singleton_map_recursive;
   use std::collections::HashMap;
 

--- a/crates/config/src/transform/transformation.rs
+++ b/crates/config/src/transform/transformation.rs
@@ -207,6 +207,7 @@ mod test {
   use super::*;
   use crate::test::TypeScript;
   use crate::DeserializeEnv;
+  use ast_grep_core::language::LanguageExt;
   use serde_yaml::with::singleton_map_recursive;
   use std::collections::HashMap;
 

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -1,5 +1,6 @@
+use crate::matcher::PatternBuilder;
 use crate::meta_var::{extract_meta_var, MetaVariable};
-use crate::{AstGrep, Node, StrDoc};
+use crate::{AstGrep, Node, Pattern, PatternError, StrDoc};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
@@ -45,6 +46,7 @@ pub trait CoreLanguage: Clone + 'static {
 
   fn kind_to_id(&self, kind: &str) -> u16;
   fn field_to_id(&self, field: &str) -> Option<u16>;
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError>;
 }
 
 /// tree-sitter specific language trait
@@ -81,6 +83,9 @@ impl CoreLanguage for TSLanguage {
   fn field_to_id(&self, field: &str) -> Option<u16> {
     self.field_id_for_name(field)
   }
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+    builder.build(|src| StrDoc::try_new(src, self.clone()))
+  }
 }
 impl Language for TSLanguage {
   fn get_ts_language(&self) -> TSLanguage {
@@ -103,6 +108,9 @@ mod test {
     }
     fn field_to_id(&self, field: &str) -> Option<u16> {
       self.get_ts_language().field_id_for_name(field)
+    }
+    fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+      builder.build(|src| StrDoc::try_new(src, self.clone()))
     }
   }
   impl Language for Tsx {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,15 +16,17 @@ pub mod traversal;
 
 #[doc(hidden)]
 pub mod pinned;
+pub mod tree_sitter;
 
 mod match_tree;
 mod node;
 
-pub use language::{Language, LanguageExt};
+pub use language::Language;
 pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
 pub use node::{Node, Position};
-pub use source::{Doc, StrDoc};
+pub use source::Doc;
+pub use tree_sitter::{LanguageExt, StrDoc};
 
 #[doc(hidden)]
 pub use node::DisplayContext;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod pinned;
 mod match_tree;
 mod node;
 
-pub use language::Language;
+pub use language::{Language, LanguageExt};
 pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
 pub use node::{Node, Position};
@@ -77,7 +77,7 @@ impl<D: Doc> AstGrep<D> {
   }
 }
 
-impl<L: Language> AstGrep<StrDoc<L>> {
+impl<L: LanguageExt> AstGrep<StrDoc<L>> {
   pub fn new<S: AsRef<str>>(src: S, lang: L) -> Self {
     Self {
       inner: Root::str(src.as_ref(), lang),

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -173,7 +173,7 @@ mod test {
     assert!(
       ret.is_some(),
       "goal: {goal:?}, candidate: {}",
-      cand.to_sexp(),
+      cand.get_inner_node().to_sexp(),
     );
     HashMap::from(env.into_owned())
   }

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 
 pub use kind::{kind_utils, KindMatcher, KindMatcherError};
 pub use node_match::NodeMatch;
-pub use pattern::{Pattern, PatternError, PatternNode};
+pub use pattern::{Pattern, PatternBuilder, PatternError, PatternNode};
 #[cfg(feature = "regex")]
 pub use text::{RegexMatcher, RegexMatcherError};
 

--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -1,6 +1,6 @@
 use super::Matcher;
 
-use crate::language::CoreLanguage;
+use crate::language::Language;
 use crate::meta_var::MetaVarEnv;
 use crate::node::KindId;
 use crate::{Doc, Node};
@@ -28,13 +28,13 @@ pub struct KindMatcher {
 }
 
 impl KindMatcher {
-  pub fn new<L: CoreLanguage>(node_kind: &str, lang: L) -> Self {
+  pub fn new<L: Language>(node_kind: &str, lang: L) -> Self {
     Self {
       kind: lang.kind_to_id(node_kind),
     }
   }
 
-  pub fn try_new<L: CoreLanguage>(node_kind: &str, lang: L) -> Result<Self, KindMatcherError> {
+  pub fn try_new<L: Language>(node_kind: &str, lang: L) -> Result<Self, KindMatcherError> {
     let s = Self::new(node_kind, lang);
     if s.is_invalid() {
       Err(KindMatcherError::InvalidKindName(node_kind.into()))

--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -114,7 +114,7 @@ mod test {
       pattern.find_node(cand.clone()).is_some(),
       "goal: {}, candidate: {}",
       kind,
-      cand.to_sexp(),
+      cand.get_inner_node().to_sexp(),
     );
   }
 
@@ -128,7 +128,7 @@ mod test {
       pattern.find_node(cand.clone()).is_none(),
       "goal: {}, candidate: {}",
       kind,
-      cand.to_sexp(),
+      cand.get_inner_node().to_sexp(),
     );
   }
 

--- a/crates/core/src/matcher/node_match.rs
+++ b/crates/core/src/matcher/node_match.rs
@@ -99,9 +99,9 @@ impl<'tree, D: Doc> Borrow<Node<'tree, D>> for NodeMatch<'tree, D> {
 mod test {
   use super::*;
   use crate::language::Tsx;
-  use crate::{Language, StrDoc};
+  use crate::{LanguageExt, StrDoc};
 
-  fn use_node<L: Language>(n: &Node<StrDoc<L>>) -> String {
+  fn use_node<L: LanguageExt>(n: &Node<StrDoc<L>>) -> String {
     n.text().to_string()
   }
 

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -362,7 +362,7 @@ mod test {
       pattern.find_node(cand.clone()).is_some(),
       "goal: {:?}, candidate: {}",
       pattern,
-      cand.to_sexp(),
+      cand.get_inner_node().to_sexp(),
     );
   }
   fn test_non_match(s1: &str, s2: &str) {
@@ -373,7 +373,7 @@ mod test {
       pattern.find_node(cand.clone()).is_none(),
       "goal: {:?}, candidate: {}",
       pattern,
-      cand.to_sexp(),
+      cand.get_inner_node().to_sexp(),
     );
   }
 

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -2,7 +2,7 @@ use crate::language::Language;
 use crate::match_tree::{match_end_non_recursive, match_node_non_recursive, MatchStrictness};
 use crate::matcher::{kind_utils, KindMatcher, KindMatcherError, Matcher};
 use crate::meta_var::{MetaVarEnv, MetaVariable};
-use crate::source::{Content, SgNode};
+use crate::source::SgNode;
 use crate::{Doc, Node, Root};
 
 use bit_set::BitSet;
@@ -40,14 +40,10 @@ impl PatternBuilder<'_> {
   fn single<D: Doc>(&self, root: &Root<D>) -> Result<Pattern, PatternError> {
     let goal = root.root();
     if goal.children().len() == 0 {
-      return Err(PatternError::NoContent(
-        root.doc.get_source().get_full_string(),
-      ));
+      return Err(PatternError::NoContent(self.src.to_string()));
     }
     if !is_single_node(&goal.inner) {
-      return Err(PatternError::MultipleNode(
-        root.doc.get_source().get_full_string(),
-      ));
+      return Err(PatternError::MultipleNode(self.src.to_string()));
     }
     let node = Pattern::single_matcher(root);
     Ok(Pattern::from(node))

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -3,7 +3,7 @@ use crate::match_tree::{match_end_non_recursive, match_node_non_recursive, Match
 use crate::matcher::{kind_utils, KindMatcher, KindMatcherError, Matcher};
 use crate::meta_var::{MetaVarEnv, MetaVariable};
 use crate::source::{Content, SgNode};
-use crate::{Doc, Node, Root, StrDoc};
+use crate::{Doc, Node, Root};
 
 use bit_set::BitSet;
 use thiserror::Error;
@@ -249,7 +249,7 @@ impl Pattern {
       selector: None,
       src: processed,
     };
-    builder.build(|src| StrDoc::try_new(src, lang).map_err(|e| e.to_string()))
+    lang.build_pattern(&builder)
   }
 
   pub fn new<L: Language>(src: &str, lang: L) -> Self {
@@ -271,7 +271,7 @@ impl Pattern {
       selector: Some(selector),
       src: processed,
     };
-    builder.build(|src| StrDoc::try_new(src, lang).map_err(|e| e.to_string()))
+    lang.build_pattern(&builder)
   }
   fn single_matcher<D: Doc>(root: &Root<D>) -> Node<D> {
     // debug_assert!(matches!(self.style, PatternStyle::Single));
@@ -351,6 +351,7 @@ mod test {
   use crate::language::Tsx;
   use crate::matcher::MatcherExt;
   use crate::meta_var::MetaVarEnv;
+  use crate::StrDoc;
   use std::collections::HashMap;
 
   fn pattern_node(s: &str) -> Root<StrDoc<Tsx>> {

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -1,4 +1,4 @@
-use crate::language::{CoreLanguage, Language};
+use crate::language::Language;
 use crate::match_tree::{match_end_non_recursive, match_node_non_recursive, MatchStrictness};
 use crate::matcher::{kind_utils, KindMatcher, KindMatcherError, Matcher};
 use crate::meta_var::{MetaVarEnv, MetaVariable};

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -301,7 +301,8 @@ impl<'tree, D: Doc> From<MetaVarEnv<'tree, D>> for HashMap<String, String> {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::language::{LanguageExt, Tsx};
+  use crate::language::Tsx;
+  use crate::LanguageExt;
   use crate::Pattern;
 
   fn extract_var(s: &str) -> Option<MetaVariable> {

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -1,7 +1,7 @@
 use crate::match_tree::does_node_match_exactly;
 use crate::matcher::Matcher;
 use crate::source::Content;
-use crate::{Doc, LanguageExt, Node, StrDoc};
+use crate::{Doc, Node};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -280,17 +280,14 @@ pub(crate) fn is_valid_meta_var_char(c: char) -> bool {
   is_valid_first_char(c) || c.is_ascii_digit()
 }
 
-impl<'tree, L: LanguageExt> From<MetaVarEnv<'tree, StrDoc<L>>> for HashMap<String, String> {
-  fn from(env: MetaVarEnv<'tree, StrDoc<L>>) -> Self {
+impl<'tree, D: Doc> From<MetaVarEnv<'tree, D>> for HashMap<String, String> {
+  fn from(env: MetaVarEnv<'tree, D>) -> Self {
     let mut ret = HashMap::new();
     for (id, node) in env.single_matched {
       ret.insert(id, node.text().into());
     }
     for (id, bytes) in env.transformed_var {
-      ret.insert(
-        id,
-        String::from_utf8(bytes).expect("invalid transform variable"),
-      );
+      ret.insert(id, <D::Source as Content>::encode_bytes(&bytes).to_string());
     }
     for (id, nodes) in env.multi_matched {
       let s: Vec<_> = nodes.iter().map(|n| n.text()).collect();

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -1,7 +1,7 @@
 use crate::match_tree::does_node_match_exactly;
 use crate::matcher::Matcher;
 use crate::source::Content;
-use crate::{Doc, Language, Node, StrDoc};
+use crate::{Doc, LanguageExt, Node, StrDoc};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -280,7 +280,7 @@ pub(crate) fn is_valid_meta_var_char(c: char) -> bool {
   is_valid_first_char(c) || c.is_ascii_digit()
 }
 
-impl<'tree, L: Language> From<MetaVarEnv<'tree, StrDoc<L>>> for HashMap<String, String> {
+impl<'tree, L: LanguageExt> From<MetaVarEnv<'tree, StrDoc<L>>> for HashMap<String, String> {
   fn from(env: MetaVarEnv<'tree, StrDoc<L>>) -> Self {
     let mut ret = HashMap::new();
     for (id, node) in env.single_matched {
@@ -304,7 +304,7 @@ impl<'tree, L: Language> From<MetaVarEnv<'tree, StrDoc<L>>> for HashMap<String, 
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::language::{Language, Tsx};
+  use crate::language::{LanguageExt, Tsx};
   use crate::Pattern;
 
   fn extract_var(s: &str) -> Option<MetaVariable> {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -198,6 +198,15 @@ impl<'r, D: Doc> Node<'r, D> {
   pub fn lang(&self) -> &'r D::Lang {
     self.root.lang()
   }
+
+  /// the underlying tree-sitter Node
+  pub fn get_inner_node(&self) -> D::Node<'r> {
+    self.inner.clone()
+  }
+
+  pub fn root(&self) -> &'r Root<D> {
+    self.root
+  }
 }
 
 /// these methods are only for `StrDoc`
@@ -244,20 +253,6 @@ impl<'r, L: LanguageExt> Node<'r, StrDoc<L>> {
       trailing: &source[end..trailing],
       start_line: self.start_pos().line() - offset,
     }
-  }
-
-  pub fn root(&self) -> &'r Root<StrDoc<L>> {
-    self.root
-  }
-
-  /// the underlying tree-sitter Node
-  pub fn get_ts_node(&self) -> tree_sitter::Node<'r> {
-    self.inner.clone()
-  }
-
-  /// Node's tree structure dumped in Lisp like S-expression
-  pub fn to_sexp(&self) -> Cow<'_, str> {
-    self.inner.to_sexp()
   }
 
   pub fn replace_all<M: Matcher, R: Replacer<StrDoc<L>>>(

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1,4 +1,4 @@
-use crate::language::{CoreLanguage, Language};
+use crate::language::{Language, LanguageExt};
 use crate::matcher::{Matcher, MatcherExt, NodeMatch};
 use crate::replacer::Replacer;
 use crate::source::{Content, Edit as E, SgNode};
@@ -51,7 +51,7 @@ pub struct Root<D: Doc> {
   pub(crate) doc: D,
 }
 
-impl<L: Language> Root<StrDoc<L>> {
+impl<L: LanguageExt> Root<StrDoc<L>> {
   pub fn str(src: &str, lang: L) -> Self {
     Self::try_new(src, lang).expect("should parse")
   }
@@ -201,7 +201,7 @@ impl<'r, D: Doc> Node<'r, D> {
 }
 
 /// these methods are only for `StrDoc`
-impl<'r, L: Language> Node<'r, StrDoc<L>> {
+impl<'r, L: LanguageExt> Node<'r, StrDoc<L>> {
   #[doc(hidden)]
   pub fn display_context(&self, before: usize, after: usize) -> DisplayContext<'r> {
     let source = self.root.doc.get_source().as_str();
@@ -480,7 +480,7 @@ impl<D: Doc> Node<'_, D> {
 
 #[cfg(test)]
 mod test {
-  use crate::language::{CoreLanguage, Language, Tsx};
+  use crate::language::{Language, LanguageExt, Tsx};
   #[test]
   fn test_is_leaf() {
     let root = Tsx.ast_grep("let a = 123");

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1,9 +1,9 @@
-use crate::language::{Language, LanguageExt};
 use crate::matcher::{Matcher, MatcherExt, NodeMatch};
 use crate::replacer::Replacer;
 use crate::source::{Content, Edit as E, SgNode};
 use crate::traversal::Visitor;
 use crate::{Doc, StrDoc};
+use crate::{Language, LanguageExt};
 
 type Edit<D> = E<<D as Doc>::Source>;
 
@@ -480,7 +480,8 @@ impl<D: Doc> Node<'_, D> {
 
 #[cfg(test)]
 mod test {
-  use crate::language::{Language, LanguageExt, Tsx};
+  use crate::language::Tsx;
+  use crate::{Language, LanguageExt};
   #[test]
   fn test_is_leaf() {
     let root = Tsx.ast_grep("let a = 123");

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1,7 +1,7 @@
 use crate::language::{CoreLanguage, Language};
 use crate::matcher::{Matcher, MatcherExt, NodeMatch};
 use crate::replacer::Replacer;
-use crate::source::{Content, Edit as E, SgNode, TSParseError};
+use crate::source::{Content, Edit as E, SgNode};
 use crate::traversal::Visitor;
 use crate::{Doc, StrDoc};
 
@@ -55,7 +55,7 @@ impl<L: Language> Root<StrDoc<L>> {
   pub fn str(src: &str, lang: L) -> Self {
     Self::try_new(src, lang).expect("should parse")
   }
-  pub fn try_new(src: &str, lang: L) -> Result<Self, TSParseError> {
+  pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
     let doc = StrDoc::try_new(src, lang)?;
     Ok(Self { doc })
   }

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -157,9 +157,10 @@ pub fn gen_replacement<D: Doc>(template: &str, nm: &NodeMatch<'_, D>) -> Underly
 mod test {
 
   use super::*;
-  use crate::language::{LanguageExt, Tsx};
+  use crate::language::Tsx;
   use crate::matcher::NodeMatch;
   use crate::meta_var::{MetaVarEnv, MetaVariable};
+  use crate::LanguageExt;
   use crate::Pattern;
   use std::collections::HashMap;
 

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -1,6 +1,6 @@
 use super::indent::{extract_with_deindent, get_indent_at_offset, indent_lines, DeindentedExtract};
 use super::{split_first_meta_var, MetaVarExtract, Replacer};
-use crate::language::CoreLanguage;
+use crate::language::Language;
 use crate::meta_var::{MetaVarEnv, Underlying};
 use crate::source::{Content, Doc};
 use crate::NodeMatch;
@@ -20,11 +20,11 @@ pub enum TemplateFix {
 pub enum TemplateFixError {}
 
 impl TemplateFix {
-  pub fn try_new<L: CoreLanguage>(template: &str, lang: &L) -> Result<Self, TemplateFixError> {
+  pub fn try_new<L: Language>(template: &str, lang: &L) -> Result<Self, TemplateFixError> {
     Ok(create_template(template, lang.meta_var_char(), &[]))
   }
 
-  pub fn with_transform<L: CoreLanguage>(tpl: &str, lang: &L, trans: &[String]) -> Self {
+  pub fn with_transform<L: Language>(tpl: &str, lang: &L, trans: &[String]) -> Self {
     create_template(tpl, lang.meta_var_char(), trans)
   }
 
@@ -157,7 +157,7 @@ pub fn gen_replacement<D: Doc>(template: &str, nm: &NodeMatch<'_, D>) -> Underly
 mod test {
 
   use super::*;
-  use crate::language::{Language, Tsx};
+  use crate::language::{LanguageExt, Tsx};
   use crate::matcher::NodeMatch;
   use crate::meta_var::{MetaVarEnv, MetaVariable};
   use crate::Pattern;

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -11,6 +11,7 @@
 //! It has a `Source` associated type bounded by `Content` that represents the source code of the document,
 //! and a `Lang` associated type that represents the language of the document.
 
+use crate::language::LanguageExt;
 use crate::traversal::TsPre;
 use crate::{language::Language, node::KindId, Position};
 use std::borrow::Cow;
@@ -284,13 +285,13 @@ pub trait Doc: Clone + 'static {
 }
 
 #[derive(Clone)]
-pub struct StrDoc<L: Language> {
+pub struct StrDoc<L: LanguageExt> {
   pub src: String,
   pub lang: L,
   pub tree: Tree,
 }
 
-impl<L: Language> StrDoc<L> {
+impl<L: LanguageExt> StrDoc<L> {
   pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
     let src = src.to_string();
     let ts_lang = lang.get_ts_language();
@@ -308,7 +309,7 @@ impl<L: Language> StrDoc<L> {
   }
 }
 
-impl<L: Language> Doc for StrDoc<L> {
+impl<L: LanguageExt> Doc for StrDoc<L> {
   type Source = String;
   type Lang = L;
   type Node<'r> = Node<'r>;
@@ -418,7 +419,7 @@ impl Content for String {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::language::{Language, Tsx};
+  use crate::language::Tsx;
 
   fn parse(src: &str) -> Result<Tree, TSParseError> {
     parse_lang(|p| p.parse(src, None), Tsx.get_ts_language())

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -349,6 +349,8 @@ pub trait Content: Sized {
   fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<str>;
   /// Get the character column at the given position
   fn get_char_column(&self, column: usize, offset: usize) -> usize;
+  /// get full string
+  fn get_full_string(&self) -> String;
 }
 
 impl Content for String {
@@ -405,6 +407,9 @@ impl Content for String {
       }
     }
     col
+  }
+  fn get_full_string(&self) -> String {
+    self.clone()
   }
 }
 

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -11,29 +11,10 @@
 //! It has a `Source` associated type bounded by `Content` that represents the source code of the document,
 //! and a `Lang` associated type that represents the language of the document.
 
-use crate::language::LanguageExt;
-use crate::traversal::TsPre;
 use crate::{language::Language, node::KindId, Position};
 use std::borrow::Cow;
 use std::ops::Range;
-use thiserror::Error;
-use tree_sitter::{
-  InputEdit, Language as TsLang, LanguageError, Node, Parser, ParserError, Point, Tree,
-};
-
-#[inline]
-fn parse_lang(
-  parse_fn: impl Fn(&mut Parser) -> Result<Option<Tree>, ParserError>,
-  ts_lang: TsLang,
-) -> Result<Tree, TSParseError> {
-  let mut parser = Parser::new()?;
-  parser.set_language(&ts_lang)?;
-  if let Some(tree) = parse_fn(&mut parser)? {
-    Ok(tree)
-  } else {
-    Err(TSParseError::TreeUnavailable)
-  }
-}
+use tree_sitter::{InputEdit, Parser, ParserError, Point, Tree};
 
 // https://github.com/tree-sitter/tree-sitter/blob/e4e5ffe517ca2c668689b24cb17c51b8c6db0790/cli/src/parse.rs
 #[derive(Debug)]
@@ -55,28 +36,6 @@ fn position_for_offset(input: &[u8], offset: usize) -> Point {
     }
   }
   Point::new(row, col)
-}
-
-pub fn perform_edit<S: Content>(tree: &mut Tree, input: &mut S, edit: &Edit<S>) -> InputEdit {
-  let edit = input.accept_edit(edit);
-  tree.edit(&edit);
-  edit
-}
-
-/// Represents tree-sitter related error
-#[derive(Debug, Error)]
-pub enum TSParseError {
-  #[error("web-tree-sitter parser is not available")]
-  Parse(#[from] ParserError),
-  #[error("incompatible `Language` is assigned to a `Parser`.")]
-  Language(#[from] LanguageError),
-  /// A general error when tree sitter fails to parse in time. It can be caused by
-  /// the following reasons but tree-sitter does not provide error detail.
-  /// * The timeout set with [Parser::set_timeout_micros] expired
-  /// * The cancellation flag set with [Parser::set_cancellation_flag] was flipped
-  /// * The parser has not yet had a language assigned with [Parser::set_language]
-  #[error("general error when tree-sitter fails to parse.")]
-  TreeUnavailable,
 }
 
 /// NOTE: Some method names are the same as tree-sitter's methods.
@@ -111,168 +70,6 @@ pub trait SgNode<'r>: Clone {
   fn field_children(&self, field_id: Option<u16>) -> impl Iterator<Item = Self>;
 }
 
-struct NodeWalker<'tree> {
-  cursor: tree_sitter::TreeCursor<'tree>,
-  count: usize,
-}
-
-impl<'tree> Iterator for NodeWalker<'tree> {
-  type Item = Node<'tree>;
-  fn next(&mut self) -> Option<Self::Item> {
-    if self.count == 0 {
-      return None;
-    }
-    let ret = Some(self.cursor.node());
-    self.cursor.goto_next_sibling();
-    self.count -= 1;
-    ret
-  }
-}
-
-impl ExactSizeIterator for NodeWalker<'_> {
-  fn len(&self) -> usize {
-    self.count
-  }
-}
-
-impl<'r> SgNode<'r> for Node<'r> {
-  fn parent(&self) -> Option<Self> {
-    Node::parent(self)
-  }
-  fn ancestors(&self, root: Self) -> impl Iterator<Item = Self> {
-    let mut ancestor = Some(root);
-    let self_id = self.id();
-    std::iter::from_fn(move || {
-      let inner = ancestor.take()?;
-      if inner.id() == self_id {
-        return None;
-      }
-      ancestor = inner.child_with_descendant(self.clone());
-      Some(inner)
-    })
-    // We must iterate up the tree to preserve backwards compatibility
-    .collect::<Vec<_>>()
-    .into_iter()
-    .rev()
-  }
-  fn dfs(&self) -> impl Iterator<Item = Self> {
-    TsPre::new(self)
-  }
-  fn child(&self, nth: usize) -> Option<Self> {
-    // TODO remove cast after migrating to tree-sitter
-    Node::child(self, nth as u32)
-  }
-  fn children(&self) -> impl ExactSizeIterator<Item = Self> {
-    let mut cursor = self.walk();
-    cursor.goto_first_child();
-    NodeWalker {
-      cursor,
-      count: self.child_count() as usize,
-    }
-  }
-  fn child_by_field_id(&self, field_id: u16) -> Option<Self> {
-    Node::child_by_field_id(self, field_id)
-  }
-  fn next(&self) -> Option<Self> {
-    self.next_sibling()
-  }
-  fn prev(&self) -> Option<Self> {
-    self.prev_sibling()
-  }
-  fn next_all(&self) -> impl Iterator<Item = Self> {
-    // if root is none, use self as fallback to return a type-stable Iterator
-    let node = self.parent().unwrap_or_else(|| self.clone());
-    let mut cursor = node.walk();
-    cursor.goto_first_child_for_byte(self.start_byte());
-    std::iter::from_fn(move || {
-      if cursor.goto_next_sibling() {
-        Some(cursor.node())
-      } else {
-        None
-      }
-    })
-  }
-  fn prev_all(&self) -> impl Iterator<Item = Self> {
-    // if root is none, use self as fallback to return a type-stable Iterator
-    let node = self.parent().unwrap_or_else(|| self.clone());
-    let mut cursor = node.walk();
-    cursor.goto_first_child_for_byte(self.start_byte());
-    std::iter::from_fn(move || {
-      if cursor.goto_previous_sibling() {
-        Some(cursor.node())
-      } else {
-        None
-      }
-    })
-  }
-  fn is_named(&self) -> bool {
-    Node::is_named(self)
-  }
-  /// N.B. it is different from is_named && is_leaf
-  /// if a node has no named children.
-  fn is_named_leaf(&self) -> bool {
-    self.named_child_count() == 0
-  }
-  fn is_leaf(&self) -> bool {
-    self.child_count() == 0
-  }
-  fn kind(&self) -> Cow<str> {
-    Node::kind(self)
-  }
-  fn kind_id(&self) -> KindId {
-    Node::kind_id(self)
-  }
-  fn node_id(&self) -> usize {
-    self.id()
-  }
-  fn range(&self) -> std::ops::Range<usize> {
-    (self.start_byte() as usize)..(self.end_byte() as usize)
-  }
-  fn start_pos(&self) -> Position {
-    let pos = self.start_position();
-    let byte = self.start_byte() as usize;
-    Position::new(pos.row() as usize, pos.column() as usize, byte)
-  }
-  fn end_pos(&self) -> Position {
-    let pos = self.end_position();
-    let byte = self.end_byte() as usize;
-    Position::new(pos.row() as usize, pos.column() as usize, byte)
-  }
-  // missing node is a tree-sitter specific concept
-  fn is_missing(&self) -> bool {
-    Node::is_missing(self)
-  }
-  fn is_error(&self) -> bool {
-    Node::is_error(self)
-  }
-
-  fn field(&self, name: &str) -> Option<Self> {
-    self.child_by_field_name(name)
-  }
-  fn field_children(&self, field_id: Option<u16>) -> impl Iterator<Item = Self> {
-    let mut cursor = self.walk();
-    cursor.goto_first_child();
-    // if field_id is not found, iteration is done
-    let mut done = field_id.is_none();
-
-    std::iter::from_fn(move || {
-      if done {
-        return None;
-      }
-      while cursor.field_id() != field_id {
-        if !cursor.goto_next_sibling() {
-          return None;
-        }
-      }
-      let ret = cursor.node();
-      if !cursor.goto_next_sibling() {
-        done = true;
-      }
-      Some(ret)
-    })
-  }
-}
-
 pub trait Doc: Clone + 'static {
   type Source: Content;
   type Lang: Language;
@@ -282,57 +79,6 @@ pub trait Doc: Clone + 'static {
   fn do_edit(&mut self, edit: &Edit<Self::Source>) -> Result<(), String>;
   fn root_node(&self) -> Self::Node<'_>;
   fn get_node_text<'a>(&'a self, node: &Self::Node<'a>) -> Cow<'a, str>;
-}
-
-#[derive(Clone)]
-pub struct StrDoc<L: LanguageExt> {
-  pub src: String,
-  pub lang: L,
-  pub tree: Tree,
-}
-
-impl<L: LanguageExt> StrDoc<L> {
-  pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
-    let src = src.to_string();
-    let ts_lang = lang.get_ts_language();
-    let tree =
-      parse_lang(|p| src.parse_tree_sitter(p, None), ts_lang).map_err(|e| e.to_string())?;
-    Ok(Self { src, lang, tree })
-  }
-  pub fn new(src: &str, lang: L) -> Self {
-    Self::try_new(src, lang).expect("Parser tree error")
-  }
-  fn parse(&self, old_tree: Option<&Tree>) -> Result<Tree, TSParseError> {
-    let source = self.get_source();
-    let lang = self.get_lang().get_ts_language();
-    parse_lang(|p| source.parse_tree_sitter(p, old_tree), lang)
-  }
-}
-
-impl<L: LanguageExt> Doc for StrDoc<L> {
-  type Source = String;
-  type Lang = L;
-  type Node<'r> = Node<'r>;
-  fn get_lang(&self) -> &Self::Lang {
-    &self.lang
-  }
-  fn get_source(&self) -> &Self::Source {
-    &self.src
-  }
-  fn do_edit(&mut self, edit: &Edit<Self::Source>) -> Result<(), String> {
-    let source = &mut self.src;
-    perform_edit(&mut self.tree, source, edit);
-    self.tree = self.parse(Some(&self.tree)).map_err(|e| e.to_string())?;
-    Ok(())
-  }
-  fn root_node(&self) -> Node<'_> {
-    self.tree.root_node()
-  }
-  fn get_node_text<'a>(&'a self, node: &Self::Node<'a>) -> Cow<'a, str> {
-    node
-      .utf8_text(self.src.as_bytes())
-      .expect("invalid source text encoding")
-  }
 }
 
 pub trait Content: Sized {
@@ -408,81 +154,5 @@ impl Content for String {
       }
     }
     col
-  }
-}
-
-#[cfg(test)]
-mod test {
-  use super::*;
-  use crate::language::Tsx;
-
-  fn parse(src: &str) -> Result<Tree, TSParseError> {
-    parse_lang(|p| p.parse(src, None), Tsx.get_ts_language())
-  }
-
-  #[test]
-  fn test_tree_sitter() -> Result<(), TSParseError> {
-    let tree = parse("var a = 1234")?;
-    let root_node = tree.root_node();
-    assert_eq!(root_node.kind(), "program");
-    assert_eq!(root_node.start_position().column(), 0);
-    assert_eq!(root_node.end_position().column(), 12);
-    assert_eq!(
-      root_node.to_sexp(),
-      "(program (variable_declaration (variable_declarator name: (identifier) value: (number))))"
-    );
-    Ok(())
-  }
-
-  #[test]
-  fn test_object_literal() -> Result<(), TSParseError> {
-    let tree = parse("{a: $X}")?;
-    let root_node = tree.root_node();
-    // wow this is not label. technically it is wrong but practically it is better LOL
-    assert_eq!(root_node.to_sexp(), "(program (expression_statement (object (pair key: (property_identifier) value: (identifier)))))");
-    Ok(())
-  }
-
-  #[test]
-  fn test_string() -> Result<(), TSParseError> {
-    let tree = parse("'$A'")?;
-    let root_node = tree.root_node();
-    assert_eq!(
-      root_node.to_sexp(),
-      "(program (expression_statement (string (string_fragment))))"
-    );
-    Ok(())
-  }
-
-  #[test]
-  fn test_row_col() -> Result<(), TSParseError> {
-    let tree = parse("😄")?;
-    let root = tree.root_node();
-    assert_eq!(root.start_position(), Point::new(0, 0));
-    // NOTE: Point in tree-sitter is counted in bytes instead of char
-    assert_eq!(root.end_position(), Point::new(0, 4));
-    Ok(())
-  }
-
-  #[test]
-  fn test_edit() -> Result<(), TSParseError> {
-    let mut src = "a + b".to_string();
-    let mut tree = parse(&src)?;
-    let _ = perform_edit(
-      &mut tree,
-      &mut src,
-      &Edit {
-        position: 1,
-        deleted_length: 0,
-        inserted_text: " * b".into(),
-      },
-    );
-    let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), Tsx.get_ts_language())?;
-    assert_eq!(
-      tree.root_node().to_sexp(),
-      "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
-    );
-    assert_eq!(tree2.root_node().to_sexp(), "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))");
-    Ok(())
   }
 }

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -291,9 +291,11 @@ pub struct StrDoc<L: Language> {
 }
 
 impl<L: Language> StrDoc<L> {
-  pub fn try_new(src: &str, lang: L) -> Result<Self, TSParseError> {
+  pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
     let src = src.to_string();
-    let tree = parse_lang(|p| src.parse_tree_sitter(p, None), lang.get_ts_language())?;
+    let ts_lang = lang.get_ts_language();
+    let tree =
+      parse_lang(|p| src.parse_tree_sitter(p, None), ts_lang).map_err(|e| e.to_string())?;
     Ok(Self { src, lang, tree })
   }
   pub fn new(src: &str, lang: L) -> Self {

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -352,8 +352,6 @@ pub trait Content: Sized {
   fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<str>;
   /// Get the character column at the given position
   fn get_char_column(&self, column: usize, offset: usize) -> usize;
-  /// get full string
-  fn get_full_string(&self) -> String;
 }
 
 impl Content for String {
@@ -410,9 +408,6 @@ impl Content for String {
       }
     }
     col
-  }
-  fn get_full_string(&self) -> String {
-    self.clone()
   }
 }
 

--- a/crates/core/src/tree_sitter.rs
+++ b/crates/core/src/tree_sitter.rs
@@ -1,0 +1,370 @@
+use crate::source::{Content, Doc, Edit, SgNode};
+use crate::traversal::TsPre;
+use crate::AstGrep;
+use crate::{node::KindId, Language, Position};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use thiserror::Error;
+use tree_sitter::{
+  InputEdit, Language as TSLanguage, LanguageError, Node, Parser, ParserError, Range as TSRange,
+  Tree,
+};
+
+/// Represents tree-sitter related error
+#[derive(Debug, Error)]
+pub enum TSParseError {
+  #[error("web-tree-sitter parser is not available")]
+  Parse(#[from] ParserError),
+  #[error("incompatible `Language` is assigned to a `Parser`.")]
+  Language(#[from] LanguageError),
+  /// A general error when tree sitter fails to parse in time. It can be caused by
+  /// the following reasons but tree-sitter does not provide error detail.
+  /// * The timeout set with [Parser::set_timeout_micros] expired
+  /// * The cancellation flag set with [Parser::set_cancellation_flag] was flipped
+  /// * The parser has not yet had a language assigned with [Parser::set_language]
+  #[error("general error when tree-sitter fails to parse.")]
+  TreeUnavailable,
+}
+
+#[inline]
+fn parse_lang(
+  parse_fn: impl Fn(&mut Parser) -> Result<Option<Tree>, ParserError>,
+  ts_lang: TSLanguage,
+) -> Result<Tree, TSParseError> {
+  let mut parser = Parser::new()?;
+  parser.set_language(&ts_lang)?;
+  if let Some(tree) = parse_fn(&mut parser)? {
+    Ok(tree)
+  } else {
+    Err(TSParseError::TreeUnavailable)
+  }
+}
+
+#[derive(Clone)]
+pub struct StrDoc<L: LanguageExt> {
+  pub src: String,
+  pub lang: L,
+  pub tree: Tree,
+}
+
+impl<L: LanguageExt> StrDoc<L> {
+  pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
+    let src = src.to_string();
+    let ts_lang = lang.get_ts_language();
+    let tree =
+      parse_lang(|p| src.parse_tree_sitter(p, None), ts_lang).map_err(|e| e.to_string())?;
+    Ok(Self { src, lang, tree })
+  }
+  pub fn new(src: &str, lang: L) -> Self {
+    Self::try_new(src, lang).expect("Parser tree error")
+  }
+  fn parse(&self, old_tree: Option<&Tree>) -> Result<Tree, TSParseError> {
+    let source = self.get_source();
+    let lang = self.get_lang().get_ts_language();
+    parse_lang(|p| source.parse_tree_sitter(p, old_tree), lang)
+  }
+}
+
+impl<L: LanguageExt> Doc for StrDoc<L> {
+  type Source = String;
+  type Lang = L;
+  type Node<'r> = Node<'r>;
+  fn get_lang(&self) -> &Self::Lang {
+    &self.lang
+  }
+  fn get_source(&self) -> &Self::Source {
+    &self.src
+  }
+  fn do_edit(&mut self, edit: &Edit<Self::Source>) -> Result<(), String> {
+    let source = &mut self.src;
+    perform_edit(&mut self.tree, source, edit);
+    self.tree = self.parse(Some(&self.tree)).map_err(|e| e.to_string())?;
+    Ok(())
+  }
+  fn root_node(&self) -> Node<'_> {
+    self.tree.root_node()
+  }
+  fn get_node_text<'a>(&'a self, node: &Self::Node<'a>) -> Cow<'a, str> {
+    node
+      .utf8_text(self.src.as_bytes())
+      .expect("invalid source text encoding")
+  }
+}
+
+struct NodeWalker<'tree> {
+  cursor: tree_sitter::TreeCursor<'tree>,
+  count: usize,
+}
+
+impl<'tree> Iterator for NodeWalker<'tree> {
+  type Item = Node<'tree>;
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.count == 0 {
+      return None;
+    }
+    let ret = Some(self.cursor.node());
+    self.cursor.goto_next_sibling();
+    self.count -= 1;
+    ret
+  }
+}
+
+impl ExactSizeIterator for NodeWalker<'_> {
+  fn len(&self) -> usize {
+    self.count
+  }
+}
+
+impl<'r> SgNode<'r> for Node<'r> {
+  fn parent(&self) -> Option<Self> {
+    Node::parent(self)
+  }
+  fn ancestors(&self, root: Self) -> impl Iterator<Item = Self> {
+    let mut ancestor = Some(root);
+    let self_id = self.id();
+    std::iter::from_fn(move || {
+      let inner = ancestor.take()?;
+      if inner.id() == self_id {
+        return None;
+      }
+      ancestor = inner.child_with_descendant(self.clone());
+      Some(inner)
+    })
+    // We must iterate up the tree to preserve backwards compatibility
+    .collect::<Vec<_>>()
+    .into_iter()
+    .rev()
+  }
+  fn dfs(&self) -> impl Iterator<Item = Self> {
+    TsPre::new(self)
+  }
+  fn child(&self, nth: usize) -> Option<Self> {
+    // TODO remove cast after migrating to tree-sitter
+    Node::child(self, nth as u32)
+  }
+  fn children(&self) -> impl ExactSizeIterator<Item = Self> {
+    let mut cursor = self.walk();
+    cursor.goto_first_child();
+    NodeWalker {
+      cursor,
+      count: self.child_count() as usize,
+    }
+  }
+  fn child_by_field_id(&self, field_id: u16) -> Option<Self> {
+    Node::child_by_field_id(self, field_id)
+  }
+  fn next(&self) -> Option<Self> {
+    self.next_sibling()
+  }
+  fn prev(&self) -> Option<Self> {
+    self.prev_sibling()
+  }
+  fn next_all(&self) -> impl Iterator<Item = Self> {
+    // if root is none, use self as fallback to return a type-stable Iterator
+    let node = self.parent().unwrap_or_else(|| self.clone());
+    let mut cursor = node.walk();
+    cursor.goto_first_child_for_byte(self.start_byte());
+    std::iter::from_fn(move || {
+      if cursor.goto_next_sibling() {
+        Some(cursor.node())
+      } else {
+        None
+      }
+    })
+  }
+  fn prev_all(&self) -> impl Iterator<Item = Self> {
+    // if root is none, use self as fallback to return a type-stable Iterator
+    let node = self.parent().unwrap_or_else(|| self.clone());
+    let mut cursor = node.walk();
+    cursor.goto_first_child_for_byte(self.start_byte());
+    std::iter::from_fn(move || {
+      if cursor.goto_previous_sibling() {
+        Some(cursor.node())
+      } else {
+        None
+      }
+    })
+  }
+  fn is_named(&self) -> bool {
+    Node::is_named(self)
+  }
+  /// N.B. it is different from is_named && is_leaf
+  /// if a node has no named children.
+  fn is_named_leaf(&self) -> bool {
+    self.named_child_count() == 0
+  }
+  fn is_leaf(&self) -> bool {
+    self.child_count() == 0
+  }
+  fn kind(&self) -> Cow<str> {
+    Node::kind(self)
+  }
+  fn kind_id(&self) -> KindId {
+    Node::kind_id(self)
+  }
+  fn node_id(&self) -> usize {
+    self.id()
+  }
+  fn range(&self) -> std::ops::Range<usize> {
+    (self.start_byte() as usize)..(self.end_byte() as usize)
+  }
+  fn start_pos(&self) -> Position {
+    let pos = self.start_position();
+    let byte = self.start_byte() as usize;
+    Position::new(pos.row() as usize, pos.column() as usize, byte)
+  }
+  fn end_pos(&self) -> Position {
+    let pos = self.end_position();
+    let byte = self.end_byte() as usize;
+    Position::new(pos.row() as usize, pos.column() as usize, byte)
+  }
+  // missing node is a tree-sitter specific concept
+  fn is_missing(&self) -> bool {
+    Node::is_missing(self)
+  }
+  fn is_error(&self) -> bool {
+    Node::is_error(self)
+  }
+
+  fn field(&self, name: &str) -> Option<Self> {
+    self.child_by_field_name(name)
+  }
+  fn field_children(&self, field_id: Option<u16>) -> impl Iterator<Item = Self> {
+    let mut cursor = self.walk();
+    cursor.goto_first_child();
+    // if field_id is not found, iteration is done
+    let mut done = field_id.is_none();
+
+    std::iter::from_fn(move || {
+      if done {
+        return None;
+      }
+      while cursor.field_id() != field_id {
+        if !cursor.goto_next_sibling() {
+          return None;
+        }
+      }
+      let ret = cursor.node();
+      if !cursor.goto_next_sibling() {
+        done = true;
+      }
+      Some(ret)
+    })
+  }
+}
+
+pub fn perform_edit<S: Content>(tree: &mut Tree, input: &mut S, edit: &Edit<S>) -> InputEdit {
+  let edit = input.accept_edit(edit);
+  tree.edit(&edit);
+  edit
+}
+
+/// tree-sitter specific language trait
+pub trait LanguageExt: Language {
+  /// Create an [`AstGrep`] instance for the language
+  fn ast_grep<S: AsRef<str>>(&self, source: S) -> AstGrep<StrDoc<Self>> {
+    AstGrep::new(source, self.clone())
+  }
+
+  /// tree sitter language to parse the source
+  fn get_ts_language(&self) -> TSLanguage;
+
+  fn injectable_languages(&self) -> Option<&'static [&'static str]> {
+    None
+  }
+
+  /// get injected language regions in the root document. e.g. get JavaScripts in HTML
+  /// it will return a list of tuples of (language, regions).
+  /// The first item is the embedded region language, e.g. javascript
+  /// The second item is a list of regions in tree_sitter.
+  /// also see https://tree-sitter.github.io/tree-sitter/using-parsers#multi-language-documents
+  fn extract_injections<L: LanguageExt>(
+    &self,
+    _root: crate::Node<StrDoc<L>>,
+  ) -> HashMap<String, Vec<TSRange>> {
+    HashMap::new()
+  }
+}
+
+impl LanguageExt for TSLanguage {
+  fn get_ts_language(&self) -> TSLanguage {
+    self.clone()
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::language::Tsx;
+  use tree_sitter::Point;
+
+  fn parse(src: &str) -> Result<Tree, TSParseError> {
+    parse_lang(|p| p.parse(src, None), Tsx.get_ts_language())
+  }
+
+  #[test]
+  fn test_tree_sitter() -> Result<(), TSParseError> {
+    let tree = parse("var a = 1234")?;
+    let root_node = tree.root_node();
+    assert_eq!(root_node.kind(), "program");
+    assert_eq!(root_node.start_position().column(), 0);
+    assert_eq!(root_node.end_position().column(), 12);
+    assert_eq!(
+      root_node.to_sexp(),
+      "(program (variable_declaration (variable_declarator name: (identifier) value: (number))))"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn test_object_literal() -> Result<(), TSParseError> {
+    let tree = parse("{a: $X}")?;
+    let root_node = tree.root_node();
+    // wow this is not label. technically it is wrong but practically it is better LOL
+    assert_eq!(root_node.to_sexp(), "(program (expression_statement (object (pair key: (property_identifier) value: (identifier)))))");
+    Ok(())
+  }
+
+  #[test]
+  fn test_string() -> Result<(), TSParseError> {
+    let tree = parse("'$A'")?;
+    let root_node = tree.root_node();
+    assert_eq!(
+      root_node.to_sexp(),
+      "(program (expression_statement (string (string_fragment))))"
+    );
+    Ok(())
+  }
+
+  #[test]
+  fn test_row_col() -> Result<(), TSParseError> {
+    let tree = parse("😄")?;
+    let root = tree.root_node();
+    assert_eq!(root.start_position(), Point::new(0, 0));
+    // NOTE: Point in tree-sitter is counted in bytes instead of char
+    assert_eq!(root.end_position(), Point::new(0, 4));
+    Ok(())
+  }
+
+  #[test]
+  fn test_edit() -> Result<(), TSParseError> {
+    let mut src = "a + b".to_string();
+    let mut tree = parse(&src)?;
+    let _ = perform_edit(
+      &mut tree,
+      &mut src,
+      &Edit {
+        position: 1,
+        deleted_length: 0,
+        inserted_text: " * b".into(),
+      },
+    );
+    let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), Tsx.get_ts_language())?;
+    assert_eq!(
+      tree.root_node().to_sexp(),
+      "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
+    );
+    assert_eq!(tree2.root_node().to_sexp(), "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))");
+    Ok(())
+  }
+}

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -299,7 +299,7 @@ mod test {
     let (_lib, lang) = unsafe { load_ts_language(path.into(), "tree_sitter_json".into()).unwrap() };
     let sg = lang.ast_grep("{\"a\": 123}");
     assert_eq!(
-      sg.root().to_sexp(),
+      sg.root().get_inner_node().to_sexp(),
       "(document (object (pair key: (string (string_content)) value: (number))))"
     );
   }

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -1,6 +1,7 @@
 use ast_grep_core::language::{CoreLanguage, TSLanguage};
-use ast_grep_core::Language;
+use ast_grep_core::{Language, StrDoc};
 
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ignore::types::{Types, TypesBuilder};
 use libloading::{Error as LibError, Library, Symbol};
 use serde::{Deserialize, Serialize};
@@ -255,6 +256,12 @@ impl CoreLanguage for DynamicLang {
       } else {
         None
       }
+    })
+  }
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+    builder.build(|src| {
+      let doc = StrDoc::try_new(src, *self)?;
+      Ok(doc)
     })
   }
 }

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -1,5 +1,5 @@
-use ast_grep_core::language::{CoreLanguage, TSLanguage};
-use ast_grep_core::{Language, StrDoc};
+use ast_grep_core::language::{Language, TSLanguage};
+use ast_grep_core::{LanguageExt, StrDoc};
 
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ignore::types::{Types, TypesBuilder};
@@ -203,7 +203,7 @@ impl DynamicLang {
     unsafe { &*addr_of!(DYNAMIC_LANG) }
   }
 }
-impl CoreLanguage for DynamicLang {
+impl Language for DynamicLang {
   /// normalize pattern code before matching
   /// e.g. remove expression_statement, or prefer parsing {} to object over block
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
@@ -266,7 +266,7 @@ impl CoreLanguage for DynamicLang {
   }
 }
 
-impl Language for DynamicLang {
+impl LanguageExt for DynamicLang {
   /// tree sitter language to parse the source
   fn get_ts_language(&self) -> TSLanguage {
     self.inner().lang.clone()

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,5 +1,6 @@
 use super::pre_process_pattern;
 use ast_grep_core::language::{CoreLanguage, TSRange};
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
 use ast_grep_core::{Language, StrDoc};
 use std::collections::HashMap;
@@ -20,6 +21,9 @@ impl CoreLanguage for Html {
   }
   fn field_to_id(&self, field: &str) -> Option<u16> {
     crate::parsers::language_html().field_id_for_name(field)
+  }
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+    builder.build(|src| StrDoc::try_new(src, *self))
   }
 }
 impl Language for Html {

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,15 +1,15 @@
 use super::pre_process_pattern;
-use ast_grep_core::language::{CoreLanguage, TSRange};
+use ast_grep_core::language::TSRange;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
-use ast_grep_core::{Language, StrDoc};
+use ast_grep_core::{Language, LanguageExt, StrDoc};
 use std::collections::HashMap;
 
 // tree-sitter-html uses locale dependent iswalnum for tagName
 // https://github.com/tree-sitter/tree-sitter-html/blob/b5d9758e22b4d3d25704b72526670759a9e4d195/src/scanner.c#L194
 #[derive(Clone, Copy, Debug)]
 pub struct Html;
-impl CoreLanguage for Html {
+impl Language for Html {
   fn expando_char(&self) -> char {
     'z'
   }
@@ -26,14 +26,14 @@ impl CoreLanguage for Html {
     builder.build(|src| StrDoc::try_new(src, *self))
   }
 }
-impl Language for Html {
+impl LanguageExt for Html {
   fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {
     crate::parsers::language_html()
   }
   fn injectable_languages(&self) -> Option<&'static [&'static str]> {
     Some(&["css", "js", "ts", "tsx", "scss", "less", "stylus", "coffee"])
   }
-  fn extract_injections<L: Language>(
+  fn extract_injections<L: LanguageExt>(
     &self,
     root: Node<StrDoc<L>>,
   ) -> HashMap<String, Vec<TSRange>> {

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -27,6 +27,7 @@ mod scala;
 mod swift;
 mod yaml;
 
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 pub use html::Html;
 
 use ast_grep_core::language::{TSLanguage, TSRange};
@@ -58,6 +59,9 @@ macro_rules! impl_lang {
       }
       fn field_to_id(&self, field: &str) -> Option<u16> {
         self.get_ts_language().field_id_for_name(field)
+      }
+      fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+        builder.build(|src| StrDoc::try_new(src, self.clone()))
       }
     }
     impl Language for $lang {
@@ -109,6 +113,9 @@ macro_rules! impl_lang_expando {
       }
       fn pre_process_pattern<'q>(&self, query: &'q str) -> std::borrow::Cow<'q, str> {
         pre_process_pattern(self.expando_char(), query)
+      }
+      fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+        builder.build(|src| StrDoc::try_new(src, self.clone()))
       }
     }
     impl ast_grep_core::language::Language for $lang {
@@ -420,6 +427,7 @@ impl CoreLanguage for SupportLang {
   impl_lang_method!(meta_var_char, () => char);
   impl_lang_method!(expando_char, () => char);
   impl_lang_method!(extract_meta_var, (source: &str) => Option<MetaVariable>);
+  impl_lang_method!(build_pattern, (builder: &PatternBuilder) => Result<Pattern, PatternError>);
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     execute_lang_method! { self, pre_process_pattern, query }
   }

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -531,7 +531,7 @@ mod test {
     assert!(
       pattern.find_node(cand.root()).is_some(),
       "goal: {pattern:?}, candidate: {}",
-      cand.root().to_sexp(),
+      cand.root().get_inner_node().to_sexp(),
     );
   }
 
@@ -541,7 +541,7 @@ mod test {
     assert!(
       pattern.find_node(cand.root()).is_none(),
       "goal: {pattern:?}, candidate: {}",
-      cand.root().to_sexp(),
+      cand.root().get_inner_node().to_sexp(),
     );
   }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
 use ast_grep_config::{CombinedScan, RuleCollection, RuleConfig, Severity};
-use ast_grep_core::{language::Language, AstGrep, Doc, StrDoc};
+use ast_grep_core::{AstGrep, Doc, LanguageExt, StrDoc};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -16,8 +16,8 @@ use utils::{convert_match_to_diagnostic, diagnostic_to_code_action, RewriteData}
 
 pub use tower_lsp::{LspService, Server};
 
-pub trait LSPLang: Language + Eq + Send + Sync + 'static {}
-impl<T> LSPLang for T where T: Language + Eq + Send + Sync + 'static {}
+pub trait LSPLang: LanguageExt + Eq + Send + Sync + 'static {}
+impl<T> LSPLang for T where T: LanguageExt + Eq + Send + Sync + 'static {}
 
 struct VersionedAst<D: Doc> {
   version: i32,

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -1,7 +1,7 @@
 //! Provides utility to convert ast-grep data types to lsp data types
 use ast_grep_config::RuleConfig;
 use ast_grep_config::Severity;
-use ast_grep_core::{language::Language, Doc, Node, NodeMatch, StrDoc};
+use ast_grep_core::{Doc, LanguageExt, Node, NodeMatch, StrDoc};
 
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::*;
@@ -19,7 +19,7 @@ impl RewriteData {
     serde_json::from_value(data).ok()
   }
 
-  fn from_node_match<L: Language>(
+  fn from_node_match<L: LanguageExt>(
     node_match: &NodeMatch<StrDoc<L>>,
     rule: &RuleConfig<L>,
   ) -> Option<Self> {
@@ -71,7 +71,7 @@ fn convert_node_to_range<D: Doc>(node_match: &Node<D>) -> Range {
   }
 }
 
-pub fn convert_match_to_diagnostic<L: Language>(
+pub fn convert_match_to_diagnostic<L: LanguageExt>(
   node_match: NodeMatch<StrDoc<L>>,
   rule: &RuleConfig<L>,
 ) -> Diagnostic {
@@ -97,7 +97,10 @@ pub fn convert_match_to_diagnostic<L: Language>(
   }
 }
 
-fn get_non_empty_message<L: Language>(rule: &RuleConfig<L>, nm: &NodeMatch<StrDoc<L>>) -> String {
+fn get_non_empty_message<L: LanguageExt>(
+  rule: &RuleConfig<L>,
+  nm: &NodeMatch<StrDoc<L>>,
+) -> String {
   // Note: The LSP client in vscode won't show any diagnostics at all if it receives one with an empty message
   let msg = if rule.message.is_empty() {
     rule.id.to_string()

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -1,7 +1,8 @@
 use crate::napi_lang::NapiLang;
 
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::source::{Content, Doc, Edit, TSParseError};
+use ast_grep_core::source::{Content, Doc, Edit};
+use ast_grep_core::tree_sitter::TSParseError;
 use ast_grep_core::LanguageExt;
 use napi::anyhow::{anyhow, Error};
 use napi::bindgen_prelude::Result as NapiResult;

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -99,6 +99,9 @@ impl Content for Wrapper {
     // utf-16 is 2 bytes per character, this is O(1) operation!
     column / 2
   }
+  fn get_full_string(&self) -> String {
+    String::from_utf16_lossy(self.inner.as_slice())
+  }
 }
 
 fn pos_for_byte_offset(input: &[u16], byte_offset: usize) -> Point {

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -2,7 +2,7 @@ use crate::napi_lang::NapiLang;
 
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
 use ast_grep_core::source::{Content, Doc, Edit, TSParseError};
-use ast_grep_core::Language;
+use ast_grep_core::LanguageExt;
 use napi::anyhow::{anyhow, Error};
 use napi::bindgen_prelude::Result as NapiResult;
 use napi_derive::napi;

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -99,9 +99,6 @@ impl Content for Wrapper {
     // utf-16 is 2 bytes per character, this is O(1) operation!
     column / 2
   }
-  fn get_full_string(&self) -> String {
-    String::from_utf16_lossy(self.inner.as_slice())
-  }
 }
 
 fn pos_for_byte_offset(input: &[u16], byte_offset: usize) -> Point {

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -86,9 +86,7 @@ pub fn parse_async(lang: String, src: String) -> Result<AsyncTask<ParseAsync>> {
 #[napi]
 pub fn kind(lang: String, kind_name: String) -> Result<u16> {
   let lang: NapiLang = lang.parse()?;
-  let kind = lang
-    .get_ts_language()
-    .id_for_node_kind(&kind_name, /* named */ true);
+  let kind = lang.kind_to_id(&kind_name);
   Ok(kind)
 }
 

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -1,8 +1,8 @@
 use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::Language;
+use ast_grep_core::LanguageExt;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
-use ast_grep_language::{CoreLanguage, SupportLang};
+use ast_grep_language::{Language, SupportLang};
 use ignore::types::{Types, TypesBuilder};
 use ignore::{WalkBuilder, WalkParallel};
 use napi::anyhow::anyhow;
@@ -115,7 +115,7 @@ impl From<SupportLang> for NapiLang {
 use NapiLang::*;
 
 use crate::doc::JsDoc;
-impl CoreLanguage for NapiLang {
+impl Language for NapiLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -155,7 +155,8 @@ impl CoreLanguage for NapiLang {
     builder.build(|src| JsDoc::try_new(src.to_string(), *self).map_err(|e| e.to_string()))
   }
 }
-impl Language for NapiLang {
+
+impl LanguageExt for NapiLang {
   fn get_ts_language(&self) -> TSLanguage {
     match self {
       Builtin(b) => b.get_ts_language(),

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -1,4 +1,5 @@
 use ast_grep_core::language::TSLanguage;
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::Language;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{CoreLanguage, SupportLang};
@@ -112,6 +113,8 @@ impl From<SupportLang> for NapiLang {
 }
 
 use NapiLang::*;
+
+use crate::doc::JsDoc;
 impl CoreLanguage for NapiLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
@@ -147,6 +150,9 @@ impl CoreLanguage for NapiLang {
       Builtin(b) => b.field_to_id(field),
       Custom(c) => c.field_to_id(field),
     }
+  }
+  fn build_pattern(&self, builder: &PatternBuilder) -> std::result::Result<Pattern, PatternError> {
+    builder.build(|src| JsDoc::try_new(src.to_string(), *self).map_err(|e| e.to_string()))
   }
 }
 impl Language for NapiLang {

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -8,7 +8,7 @@ use py_lang::register_dynamic_language;
 use py_node::{Edit, SgNode};
 use range::{Pos, Range};
 
-use ast_grep_core::{AstGrep, Language, NodeMatch, StrDoc};
+use ast_grep_core::{AstGrep, LanguageExt, NodeMatch, StrDoc};
 use py_lang::PyLang;
 use pyo3::prelude::*;
 

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use ast_grep_core::language::{CoreLanguage, TSLanguage};
+use ast_grep_core::language::{LanguageExt, TSLanguage};
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::StrDoc;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
@@ -89,7 +89,7 @@ impl FromStr for PyLang {
 }
 
 use PyLang::*;
-impl CoreLanguage for PyLang {
+impl Language for PyLang {
   fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
     match self {
       Builtin(b) => b.pre_process_pattern(query),
@@ -129,7 +129,7 @@ impl CoreLanguage for PyLang {
     builder.build(|src| StrDoc::try_new(src, *self))
   }
 }
-impl Language for PyLang {
+impl LanguageExt for PyLang {
   fn get_ts_language(&self) -> TSLanguage {
     match self {
       Builtin(b) => b.get_ts_language(),

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
 use ast_grep_core::language::{CoreLanguage, TSLanguage};
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::StrDoc;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};
 use serde::{Deserialize, Serialize};
@@ -122,6 +124,9 @@ impl CoreLanguage for PyLang {
       Builtin(b) => b.field_to_id(field),
       Custom(c) => c.field_to_id(field),
     }
+  }
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+    builder.build(|src| StrDoc::try_new(src, *self))
   }
 }
 impl Language for PyLang {

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use ast_grep_core::language::{LanguageExt, TSLanguage};
+use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::StrDoc;
+use ast_grep_core::{LanguageExt, StrDoc};
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};
 use serde::{Deserialize, Serialize};

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
-use ast_grep_core::language::{Language, LanguageExt, TSLanguage};
+use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::{Language, LanguageExt};
 use ast_grep_language::{
   Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
   Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
-use ast_grep_core::language::{CoreLanguage, TSLanguage};
-use ast_grep_core::Language;
+use ast_grep_core::language::{Language, LanguageExt, TSLanguage};
+use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_language::{
   Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
   Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
@@ -225,15 +225,18 @@ impl JsonSchema for PlaceholderLang {
   }
 }
 
-impl CoreLanguage for PlaceholderLang {
+impl Language for PlaceholderLang {
   fn kind_to_id(&self, _kind: &str) -> u16 {
     unreachable!("PlaceholderLang is only for json schema")
   }
   fn field_to_id(&self, _field: &str) -> Option<u16> {
     unreachable!("PlaceholderLang is only for json schema")
   }
+  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+    unreachable!("PlaceholderLang is only for json schema")
+  }
 }
-impl Language for PlaceholderLang {
+impl LanguageExt for PlaceholderLang {
   fn get_ts_language(&self) -> TSLanguage {
     unreachable!("PlaceholderLang is only for json schema")
   }

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -54,7 +54,7 @@ fn generate_lang_schemas() -> Result<()> {
   generate_lang_schema(Yaml, "yaml")
 }
 
-fn generate_lang_schema<T: Language + Alias>(lang: T, name: &str) -> Result<()> {
+fn generate_lang_schema<T: LanguageExt + Alias>(lang: T, name: &str) -> Result<()> {
   let mut schema = schema_for!(SerializableRuleConfig<PlaceholderLang>);
   tweak_schema(&mut schema)?;
   add_lang_info_to_schema(&mut schema, lang, name)?;
@@ -80,7 +80,7 @@ fn tweak_schema(schema: &mut RootSchema) -> Result<()> {
   Ok(())
 }
 
-fn add_lang_info_to_schema<T: Language + Alias>(
+fn add_lang_info_to_schema<T: LanguageExt + Alias>(
   schema: &mut RootSchema,
   lang: T,
   name: &str,
@@ -232,7 +232,7 @@ impl Language for PlaceholderLang {
   fn field_to_id(&self, _field: &str) -> Option<u16> {
     unreachable!("PlaceholderLang is only for json schema")
   }
-  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+  fn build_pattern(&self, _b: &PatternBuilder) -> Result<Pattern, PatternError> {
     unreachable!("PlaceholderLang is only for json schema")
   }
 }


### PR DESCRIPTION
https://github.com/ast-grep/ast-grep/issues/1918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new pattern builder for flexible and modular pattern creation across all supported languages.
  - Added pattern-building capability to language implementations, enabling more robust and extensible pattern matching.
  - Added comprehensive Tree-sitter integration with source document parsing, incremental editing, and node traversal utilities.

- **Refactor**
  - Unified and streamlined language trait hierarchy by renaming and splitting core traits into `Language` and `LanguageExt`, clarifying extension support.
  - Updated public APIs and trait bounds to use the new `LanguageExt` trait, improving extensibility and future compatibility.
  - Centralized pattern construction logic for improved maintainability and error handling.
  - Removed deprecated traits and simplified language implementations accordingly.
  - Reorganized imports and public re-exports to reflect new module and trait structure.
  - Removed legacy source document and parsing code in favor of Tree-sitter based implementations.

- **Bug Fixes**
  - Enhanced error reporting during pattern parsing for clearer diagnostics.

- **Chores**
  - Updated imports and internal references across the codebase to align with the new trait structure and pattern builder integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->