### PR TITLE
parser abstraction part 4

### DIFF
--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -1,7 +1,7 @@
 use super::SgLang;
 use crate::utils::ErrorContext as EC;
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::{language::TSRange, Doc, LanguageExt, Node, StrDoc};
+use ast_grep_core::{tree_sitter::TSRange, Doc, LanguageExt, Node, StrDoc};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -6,7 +6,7 @@ use crate::utils::ErrorContext as EC;
 use anyhow::{Context, Result};
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::{
-  language::{TSLanguage, TSRange},
+  tree_sitter::{TSLanguage, TSRange},
   Node, StrDoc,
 };
 use ast_grep_dynamic::DynamicLang;

--- a/crates/cli/src/utils/debug_query.rs
+++ b/crates/cli/src/utils/debug_query.rs
@@ -1,6 +1,8 @@
 use crate::lang::SgLang;
 use ansi_term::Style;
-use ast_grep_core::{language::TSLanguage, matcher::PatternNode, meta_var::MetaVariable, Pattern};
+use ast_grep_core::{
+  matcher::PatternNode, meta_var::MetaVariable, tree_sitter::TSLanguage, Pattern,
+};
 use ast_grep_language::LanguageExt;
 use clap::ValueEnum;
 use tree_sitter as ts;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -42,8 +42,8 @@ pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
 #[cfg(test)]
 mod test {
   use super::*;
-  use ast_grep_core::language::TSLanguage;
   use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+  use ast_grep_core::tree_sitter::TSLanguage;
   use ast_grep_core::StrDoc;
   use ast_grep_core::{Language, LanguageExt};
   use std::path::Path;

--- a/crates/core/src/language.rs
+++ b/crates/core/src/language.rs
@@ -1,11 +1,8 @@
 use crate::matcher::PatternBuilder;
 use crate::meta_var::{extract_meta_var, MetaVariable};
-use crate::StrDoc;
 use crate::{Pattern, PatternError};
 use std::borrow::Cow;
 use std::path::Path;
-pub use tree_sitter::Language as TSLanguage;
-pub use tree_sitter::{Point as TSPoint, Range as TSRange};
 
 /// Trait to abstract ts-language usage in ast-grep, which includes:
 /// * which character is used for meta variable.
@@ -49,25 +46,13 @@ pub trait Language: Clone + 'static {
   fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError>;
 }
 
-impl Language for TSLanguage {
-  fn kind_to_id(&self, kind: &str) -> u16 {
-    self.id_for_node_kind(kind, /* named */ true)
-  }
-  fn field_to_id(&self, field: &str) -> Option<u16> {
-    self.field_id_for_name(field)
-  }
-  fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
-    builder.build(|src| StrDoc::try_new(src, self.clone()))
-  }
-}
-
 #[cfg(test)]
 pub use test::*;
 
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::tree_sitter::LanguageExt;
+  use crate::tree_sitter::{LanguageExt, StrDoc, TSLanguage};
 
   #[derive(Clone)]
   pub struct Tsx;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,7 +29,7 @@ pub use source::Doc;
 pub use tree_sitter::{LanguageExt, StrDoc};
 
 #[doc(hidden)]
-pub use node::DisplayContext;
+pub use tree_sitter::DisplayContext;
 
 use replacer::Replacer;
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -51,43 +51,6 @@ pub struct Root<D: Doc> {
   pub(crate) doc: D,
 }
 
-impl<L: LanguageExt> Root<StrDoc<L>> {
-  pub fn str(src: &str, lang: L) -> Self {
-    Self::try_new(src, lang).expect("should parse")
-  }
-  pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
-    let doc = StrDoc::try_new(src, lang)?;
-    Ok(Self { doc })
-  }
-  pub fn get_text(&self) -> &str {
-    &self.doc.src
-  }
-
-  pub fn get_injections<F: Fn(&str) -> Option<L>>(&self, get_lang: F) -> Vec<Self> {
-    let root = self.root();
-    let range = self.lang().extract_injections(root);
-    let roots = range
-      .into_iter()
-      .filter_map(|(lang, ranges)| {
-        let lang = get_lang(&lang)?;
-        let source = self.doc.get_source();
-        let mut parser = tree_sitter::Parser::new().ok()?;
-        parser.set_included_ranges(&ranges).ok()?;
-        parser.set_language(&lang.get_ts_language()).ok()?;
-        let tree = parser.parse(source, None).ok()?;
-        tree.map(|t| Self {
-          doc: StrDoc {
-            src: self.doc.src.clone(),
-            lang,
-            tree: t,
-          },
-        })
-      })
-      .collect();
-    roots
-  }
-}
-
 impl<D: Doc> Root<D> {
   pub fn doc(doc: D) -> Self {
     Self { doc }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -74,7 +74,7 @@ impl<L: LanguageExt> Root<StrDoc<L>> {
         let mut parser = tree_sitter::Parser::new().ok()?;
         parser.set_included_ranges(&ranges).ok()?;
         parser.set_language(&lang.get_ts_language()).ok()?;
-        let tree = source.parse_tree_sitter(&mut parser, None).ok()?;
+        let tree = parser.parse(source, None).ok()?;
         tree.map(|t| Self {
           doc: StrDoc {
             src: self.doc.src.clone(),

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,12 +1,12 @@
 use crate::matcher::Matcher;
 use crate::meta_var::{is_valid_meta_var_char, MetaVariableID, Underlying};
-use crate::{Doc, Node, NodeMatch};
+use crate::{Doc, Node, NodeMatch, Root};
 use std::ops::Range;
 
 pub(crate) use indent::formatted_slice;
 
-// use crate::source::Edit as E;
-// type Edit<D> = E<<D as Doc>::Source>;
+use crate::source::Edit as E;
+type Edit<D> = E<<D as Doc>::Source>;
 
 mod indent;
 mod structural;
@@ -34,11 +34,11 @@ impl<D: Doc> Replacer<D> for str {
   }
 }
 
-// impl<D: Doc> Replacer<D> for Root<D> {
-//   fn generate_replacement<'t, N: SgNode<'t, Doc=D>>(&self, nm: &SgNodeMatch<'t, N>) -> Underlying<D::Source> {
-//     structural::gen_replacement(self, nm)
-//   }
-// }
+impl<D: Doc> Replacer<D> for Root<D> {
+  fn generate_replacement(&self, nm: &NodeMatch<'_, D>) -> Underlying<D> {
+    structural::gen_replacement(self, nm)
+  }
+}
 
 impl<D, T> Replacer<D> for &T
 where

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -1,215 +1,219 @@
-// use super::{Edit, Underlying};
-// use crate::language::CoreLanguage;
-// use crate::matcher::NodeMatch;
-// use crate::meta_var::MetaVarEnv;
-// use crate::source::Content;
-// use crate::{Doc, Node, Root};
+use super::{Edit, Underlying};
+use crate::language::Language;
+use crate::meta_var::MetaVarEnv;
+use crate::source::{Content, SgNode};
+use crate::{Doc, Node, NodeMatch, Root};
 
-// fn collect_edits<D: Doc>(root: &Root<D>, env: &MetaVarEnv<D>, lang: &D::Lang) -> Vec<Edit<D>> {
-//   let mut node = root.root();
-//   let root_id = node.inner.id();
-//   let mut edits = vec![];
+pub fn gen_replacement<D: Doc>(root: &Root<D>, nm: &NodeMatch<D>) -> Underlying<D> {
+  let edits = collect_edits(root, nm.get_env(), nm.lang());
+  merge_edits_to_vec(edits, root)
+}
 
-//   // this is a post-order DFS that stops traversal when the node matches
-//   'outer: loop {
-//     if let Some(text) = get_meta_var_replacement(&node, env, lang.clone()) {
-//       let position = node.inner.start_byte();
-//       let length = node.inner.end_byte() - position;
-//       edits.push(Edit::<D> {
-//         position: position as usize,
-//         deleted_length: length as usize,
-//         inserted_text: text,
-//       });
-//     } else if let Some(first_child) = node.child(0) {
-//       // traverse down to child
-//       node = first_child;
-//       continue;
-//     } else if node.inner.is_missing() {
-//       // TODO: better handling missing node
-//       if let Some(sibling) = node.next() {
-//         node = sibling;
-//         continue;
-//       } else {
-//         break;
-//       }
-//     }
-//     // traverse up to parent until getting to root
-//     loop {
-//       // come back to the root node, terminating dfs
-//       if node.inner.id() == root_id {
-//         break 'outer;
-//       }
-//       if let Some(sibling) = node.next() {
-//         node = sibling;
-//         break;
-//       }
-//       node = node.parent().unwrap();
-//     }
-//   }
-//   // add the missing one
-//   edits.push(Edit::<D> {
-//     position: root.root().range().end,
-//     deleted_length: 0,
-//     inserted_text: vec![],
-//   });
-//   edits
-// }
+fn collect_edits<D: Doc>(root: &Root<D>, env: &MetaVarEnv<D>, lang: &D::Lang) -> Vec<Edit<D>> {
+  let mut node = root.root();
+  let root_id = node.node_id();
+  let mut edits = vec![];
 
-// fn merge_edits_to_vec<D: Doc>(edits: Vec<Edit<D>>, root: &Root<D>) -> Underlying<D::Source> {
-//   let mut ret = vec![];
-//   let mut start = 0;
-//   for edit in edits {
-//     debug_assert!(start <= edit.position, "Edit must be ordered!");
-//     ret.extend(
-//       root
-//         .doc
-//         .get_source()
-//         .get_range(start..edit.position)
-//         .iter()
-//         .cloned(),
-//     );
-//     ret.extend(edit.inserted_text.iter().cloned());
-//     start = edit.position + edit.deleted_length;
-//   }
-//   ret
-// }
+  // this is a post-order DFS that stops traversal when the node matches
+  'outer: loop {
+    if let Some(text) = get_meta_var_replacement(&node, env, lang.clone()) {
+      let range = node.range();
+      let position = range.start;
+      let length = range.len();
+      edits.push(Edit::<D> {
+        position,
+        deleted_length: length,
+        inserted_text: text,
+      });
+    } else if let Some(first_child) = node.child(0) {
+      // traverse down to child
+      node = first_child;
+      continue;
+    } else if node.inner.is_missing() {
+      // TODO: better handling missing node
+      if let Some(sibling) = node.next() {
+        node = sibling;
+        continue;
+      } else {
+        break;
+      }
+    }
+    // traverse up to parent until getting to root
+    loop {
+      // come back to the root node, terminating dfs
+      if node.node_id() == root_id {
+        break 'outer;
+      }
+      if let Some(sibling) = node.next() {
+        node = sibling;
+        break;
+      }
+      node = node.parent().unwrap();
+    }
+  }
+  // add the missing one
+  edits.push(Edit::<D> {
+    position: root.root().range().end,
+    deleted_length: 0,
+    inserted_text: vec![],
+  });
+  edits
+}
 
-// fn get_meta_var_replacement<D: Doc>(
-//   node: &Node<D>,
-//   env: &MetaVarEnv<D>,
-//   lang: D::Lang,
-// ) -> Option<Underlying<D::Source>> {
-//   if !node.is_named_leaf() {
-//     return None;
-//   }
-//   let meta_var = lang.extract_meta_var(&node.text())?;
-//   let replaced = env.get_var_bytes(&meta_var)?;
-//   Some(replaced.to_vec())
-// }
+fn merge_edits_to_vec<D: Doc>(edits: Vec<Edit<D>>, root: &Root<D>) -> Underlying<D> {
+  let mut ret = vec![];
+  let mut start = 0;
+  for edit in edits {
+    debug_assert!(start <= edit.position, "Edit must be ordered!");
+    ret.extend(
+      root
+        .doc
+        .get_source()
+        .get_range(start..edit.position)
+        .iter()
+        .cloned(),
+    );
+    ret.extend(edit.inserted_text.iter().cloned());
+    start = edit.position + edit.deleted_length;
+  }
+  ret
+}
 
-// #[cfg(test)]
-// mod test {
-//   use super::*;
-//   use crate::language::{Language, Tsx};
-//   use crate::meta_var::MetaVarEnv;
-//   use crate::{replacer::Replacer, Root};
-//   use std::collections::HashMap;
+fn get_meta_var_replacement<D: Doc>(
+  node: &Node<D>,
+  env: &MetaVarEnv<D>,
+  lang: D::Lang,
+) -> Option<Underlying<D>> {
+  if !node.is_named_leaf() {
+    return None;
+  }
+  let meta_var = lang.extract_meta_var(&node.text())?;
+  let replaced = env.get_var_bytes(&meta_var)?;
+  Some(replaced.to_vec())
+}
 
-//   fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
-//     let mut env = MetaVarEnv::new();
-//     let roots: Vec<_> = vars
-//       .iter()
-//       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-//       .collect();
-//     for (var, root) in &roots {
-//       env.insert(var, root.root());
-//     }
-//     let dummy = Tsx.ast_grep("dummy");
-//     let node_match = NodeMatch::new(dummy.root(), env.clone());
-//     let replacer = Root::new(replacer, Tsx);
-//     let replaced = replacer.generate_replacement(&node_match);
-//     let replaced = String::from_utf8_lossy(&replaced);
-//     assert_eq!(
-//       replaced,
-//       expected,
-//       "wrong replacement {replaced} {expected} {:?}",
-//       HashMap::from(env)
-//     );
-//   }
+#[cfg(test)]
+mod test {
+  use crate::language::Tsx;
+  use crate::meta_var::MetaVarEnv;
+  use crate::{replacer::Replacer, LanguageExt, NodeMatch, Root};
+  use std::collections::HashMap;
 
-//   #[test]
-//   fn test_no_env() {
-//     test_pattern_replace("let a = 123", &[], "let a = 123");
-//     test_pattern_replace(
-//       "console.log('hello world'); let b = 123;",
-//       &[],
-//       "console.log('hello world'); let b = 123;",
-//     );
-//   }
+  fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
+    let mut env = MetaVarEnv::new();
+    let roots: Vec<_> = vars
+      .iter()
+      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
+      .collect();
+    for (var, root) in &roots {
+      env.insert(var, root.root());
+    }
+    let dummy = Tsx.ast_grep("dummy");
+    let node_match = NodeMatch::new(dummy.root(), env.clone());
+    let replacer = Root::str(replacer, Tsx);
+    let replaced = replacer.generate_replacement(&node_match);
+    let replaced = String::from_utf8_lossy(&replaced);
+    assert_eq!(
+      replaced,
+      expected,
+      "wrong replacement {replaced} {expected} {:?}",
+      HashMap::from(env)
+    );
+  }
 
-//   #[test]
-//   fn test_single_env() {
-//     test_pattern_replace("let a = $A", &[("A", "123")], "let a = 123");
-//     test_pattern_replace(
-//       "console.log($HW); let b = 123;",
-//       &[("HW", "'hello world'")],
-//       "console.log('hello world'); let b = 123;",
-//     );
-//   }
+  #[test]
+  fn test_no_env() {
+    test_pattern_replace("let a = 123", &[], "let a = 123");
+    test_pattern_replace(
+      "console.log('hello world'); let b = 123;",
+      &[],
+      "console.log('hello world'); let b = 123;",
+    );
+  }
 
-//   #[test]
-//   fn test_multiple_env() {
-//     test_pattern_replace("let $V = $A", &[("A", "123"), ("V", "a")], "let a = 123");
-//     test_pattern_replace(
-//       "console.log($HW); let $B = 123;",
-//       &[("HW", "'hello world'"), ("B", "b")],
-//       "console.log('hello world'); let b = 123;",
-//     );
-//   }
+  #[test]
+  fn test_single_env() {
+    test_pattern_replace("let a = $A", &[("A", "123")], "let a = 123");
+    test_pattern_replace(
+      "console.log($HW); let b = 123;",
+      &[("HW", "'hello world'")],
+      "console.log('hello world'); let b = 123;",
+    );
+  }
 
-//   #[test]
-//   fn test_multiple_occurrences() {
-//     test_pattern_replace("let $A = $A", &[("A", "a")], "let a = a");
-//     test_pattern_replace("var $A = () => $A", &[("A", "a")], "var a = () => a");
-//     test_pattern_replace(
-//       "const $A = () => { console.log($B); $A(); };",
-//       &[("B", "'hello world'"), ("A", "a")],
-//       "const a = () => { console.log('hello world'); a(); };",
-//     );
-//   }
+  #[test]
+  fn test_multiple_env() {
+    test_pattern_replace("let $V = $A", &[("A", "123"), ("V", "a")], "let a = 123");
+    test_pattern_replace(
+      "console.log($HW); let $B = 123;",
+      &[("HW", "'hello world'"), ("B", "b")],
+      "console.log('hello world'); let b = 123;",
+    );
+  }
 
-//   fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
-//     let mut env = MetaVarEnv::new();
-//     let roots: Vec<_> = vars
-//       .iter()
-//       .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-//       .collect();
-//     for (var, root) in &roots {
-//       env.insert_multi(var, root.root().children().collect());
-//     }
-//     let dummy = Tsx.ast_grep("dummy");
-//     let node_match = NodeMatch::new(dummy.root(), env.clone());
-//     let replacer = Root::new(replacer, Tsx);
-//     let replaced = replacer.generate_replacement(&node_match);
-//     let replaced = String::from_utf8_lossy(&replaced);
-//     assert_eq!(
-//       replaced,
-//       expected,
-//       "wrong replacement {replaced} {expected} {:?}",
-//       HashMap::from(env)
-//     );
-//   }
+  #[test]
+  fn test_multiple_occurrences() {
+    test_pattern_replace("let $A = $A", &[("A", "a")], "let a = a");
+    test_pattern_replace("var $A = () => $A", &[("A", "a")], "var a = () => a");
+    test_pattern_replace(
+      "const $A = () => { console.log($B); $A(); };",
+      &[("B", "'hello world'"), ("A", "a")],
+      "const a = () => { console.log('hello world'); a(); };",
+    );
+  }
 
-//   #[test]
-//   fn test_ellipsis_meta_var() {
-//     test_ellipsis_replace(
-//       "let a = () => { $$$B }",
-//       &[("B", "alert('works!')")],
-//       "let a = () => { alert('works!') }",
-//     );
-//     test_ellipsis_replace(
-//       "let a = () => { $$$B }",
-//       &[("B", "alert('works!');console.log(123)")],
-//       "let a = () => { alert('works!');console.log(123) }",
-//     );
-//   }
+  fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
+    let mut env = MetaVarEnv::new();
+    let roots: Vec<_> = vars
+      .iter()
+      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
+      .collect();
+    for (var, root) in &roots {
+      env.insert_multi(var, root.root().children().collect());
+    }
+    let dummy = Tsx.ast_grep("dummy");
+    let node_match = NodeMatch::new(dummy.root(), env.clone());
+    let replacer = Root::str(replacer, Tsx);
+    let replaced = replacer.generate_replacement(&node_match);
+    let replaced = String::from_utf8_lossy(&replaced);
+    assert_eq!(
+      replaced,
+      expected,
+      "wrong replacement {replaced} {expected} {:?}",
+      HashMap::from(env)
+    );
+  }
 
-//   #[test]
-//   fn test_multi_ellipsis() {
-//     test_ellipsis_replace(
-//       "import {$$$A, B, $$$C} from 'a'",
-//       &[("A", "A"), ("C", "C")],
-//       "import {A, B, C} from 'a'",
-//     );
-//   }
+  #[test]
+  fn test_ellipsis_meta_var() {
+    test_ellipsis_replace(
+      "let a = () => { $$$B }",
+      &[("B", "alert('works!')")],
+      "let a = () => { alert('works!') }",
+    );
+    test_ellipsis_replace(
+      "let a = () => { $$$B }",
+      &[("B", "alert('works!');console.log(123)")],
+      "let a = () => { alert('works!');console.log(123) }",
+    );
+  }
 
-//   #[test]
-//   fn test_replace_in_string() {
-//     test_pattern_replace("'$A'", &[("A", "123")], "'123'");
-//   }
+  #[test]
+  fn test_multi_ellipsis() {
+    test_ellipsis_replace(
+      "import {$$$A, B, $$$C} from 'a'",
+      &[("A", "A"), ("C", "C")],
+      "import {A, B, C} from 'a'",
+    );
+  }
 
-//   #[test]
-//   fn test_nested_matching_replace() {
-//     // TODO
-//   }
-// }
+  #[test]
+  fn test_replace_in_string() {
+    test_pattern_replace("'$A'", &[("A", "123")], "'123'");
+  }
+
+  #[test]
+  fn test_nested_matching_replace() {
+    // TODO
+  }
+}

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -14,7 +14,7 @@
 use crate::{language::Language, node::KindId, Position};
 use std::borrow::Cow;
 use std::ops::Range;
-use tree_sitter::{InputEdit, Parser, ParserError, Point, Tree};
+use tree_sitter::{InputEdit, Point};
 
 // https://github.com/tree-sitter/tree-sitter/blob/e4e5ffe517ca2c668689b24cb17c51b8c6db0790/cli/src/parse.rs
 #[derive(Debug)]
@@ -83,11 +83,6 @@ pub trait Doc: Clone + 'static {
 
 pub trait Content: Sized {
   type Underlying: Clone + PartialEq;
-  fn parse_tree_sitter(
-    &self,
-    parser: &mut Parser,
-    tree: Option<&Tree>,
-  ) -> Result<Option<Tree>, ParserError>;
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying];
   fn accept_edit(&mut self, edit: &Edit<Self>) -> InputEdit;
   /// Used for string replacement. We need this for
@@ -102,13 +97,6 @@ pub trait Content: Sized {
 
 impl Content for String {
   type Underlying = u8;
-  fn parse_tree_sitter(
-    &self,
-    parser: &mut Parser,
-    tree: Option<&Tree>,
-  ) -> Result<Option<Tree>, ParserError> {
-    parser.parse(self.as_bytes(), tree)
-  }
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
     &self.as_bytes()[range]
   }

--- a/crates/core/src/tree_sitter.rs
+++ b/crates/core/src/tree_sitter.rs
@@ -51,8 +51,7 @@ impl<L: LanguageExt> StrDoc<L> {
   pub fn try_new(src: &str, lang: L) -> Result<Self, String> {
     let src = src.to_string();
     let ts_lang = lang.get_ts_language();
-    let tree =
-      parse_lang(|p| src.parse_tree_sitter(p, None), ts_lang).map_err(|e| e.to_string())?;
+    let tree = parse_lang(|p| p.parse(src.as_bytes(), None), ts_lang).map_err(|e| e.to_string())?;
     Ok(Self { src, lang, tree })
   }
   pub fn new(src: &str, lang: L) -> Self {
@@ -61,7 +60,7 @@ impl<L: LanguageExt> StrDoc<L> {
   fn parse(&self, old_tree: Option<&Tree>) -> Result<Tree, TSParseError> {
     let source = self.get_source();
     let lang = self.get_lang().get_ts_language();
-    parse_lang(|p| source.parse_tree_sitter(p, old_tree), lang)
+    parse_lang(|p| p.parse(source.as_bytes(), old_tree), lang)
   }
 }
 

--- a/crates/core/src/tree_sitter.rs
+++ b/crates/core/src/tree_sitter.rs
@@ -5,10 +5,9 @@ use crate::{node::KindId, Language, Position};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use thiserror::Error;
-use tree_sitter::{
-  InputEdit, Language as TSLanguage, LanguageError, Node, Parser, ParserError, Point,
-  Range as TSRange, Tree,
-};
+pub use tree_sitter::Language as TSLanguage;
+use tree_sitter::{InputEdit, LanguageError, Node, Parser, ParserError, Point, Tree};
+pub use tree_sitter::{Point as TSPoint, Range as TSRange};
 
 /// Represents tree-sitter related error
 #[derive(Debug, Error)]
@@ -282,12 +281,6 @@ pub trait LanguageExt: Language {
     _root: crate::Node<StrDoc<L>>,
   ) -> HashMap<String, Vec<TSRange>> {
     HashMap::new()
-  }
-}
-
-impl LanguageExt for TSLanguage {
-  fn get_ts_language(&self) -> TSLanguage {
-    self.clone()
   }
 }
 

--- a/crates/core/src/tree_sitter.rs
+++ b/crates/core/src/tree_sitter.rs
@@ -1,8 +1,9 @@
 use crate::node::Root;
+use crate::replacer::Replacer;
 use crate::source::{Content, Doc, Edit, SgNode};
-use crate::traversal::TsPre;
-use crate::AstGrep;
+use crate::traversal::{TsPre, Visitor};
 use crate::{node::KindId, Language, Position};
+use crate::{AstGrep, Matcher};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -357,6 +358,77 @@ impl<L: LanguageExt> Root<StrDoc<L>> {
       })
       .collect();
     roots
+  }
+}
+
+pub struct DisplayContext<'r> {
+  /// content for the matched node
+  pub matched: Cow<'r, str>,
+  /// content before the matched node
+  pub leading: &'r str,
+  /// content after the matched node
+  pub trailing: &'r str,
+  /// zero-based start line of the context
+  pub start_line: usize,
+}
+
+/// these methods are only for `StrDoc`
+impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
+  #[doc(hidden)]
+  pub fn display_context(&self, before: usize, after: usize) -> DisplayContext<'r> {
+    let source = self.root.doc.get_source().as_str();
+    let bytes = source.as_bytes();
+    let start = self.inner.start_byte() as usize;
+    let end = self.inner.end_byte() as usize;
+    let (mut leading, mut trailing) = (start, end);
+    let mut lines_before = before + 1;
+    while leading > 0 {
+      if bytes[leading - 1] == b'\n' {
+        lines_before -= 1;
+        if lines_before == 0 {
+          break;
+        }
+      }
+      leading -= 1;
+    }
+    let mut lines_after = after + 1;
+    // tree-sitter will append line ending to source so trailing can be out of bound
+    trailing = trailing.min(bytes.len());
+    while trailing < bytes.len() {
+      if bytes[trailing] == b'\n' {
+        lines_after -= 1;
+        if lines_after == 0 {
+          break;
+        }
+      }
+      trailing += 1;
+    }
+    // lines_before means we matched all context, offset is `before` itself
+    let offset = if lines_before == 0 {
+      before
+    } else {
+      // otherwise, there are fewer than `before` line in src, compute the actual line
+      before + 1 - lines_before
+    };
+    DisplayContext {
+      matched: self.text(),
+      leading: &source[leading..start],
+      trailing: &source[end..trailing],
+      start_line: self.start_pos().line() - offset,
+    }
+  }
+
+  pub fn replace_all<M: Matcher, R: Replacer<StrDoc<L>>>(
+    &self,
+    matcher: M,
+    replacer: R,
+  ) -> Vec<Edit<String>> {
+    // TODO: support nested matches like Some(Some(1)) with pattern Some($A)
+    Visitor::new(&matcher)
+      .reentrant(false)
+      .visit(self.clone())
+      .map(|matched| matched.make_edit(&matcher, &replacer))
+      .collect()
   }
 }
 

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,6 +1,6 @@
 use super::pre_process_pattern;
-use ast_grep_core::language::TSRange;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::tree_sitter::{TSLanguage, TSRange};
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
 use ast_grep_core::{Language, LanguageExt, StrDoc};
 use std::collections::HashMap;
@@ -27,7 +27,7 @@ impl Language for Html {
   }
 }
 impl LanguageExt for Html {
-  fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {
+  fn get_ts_language(&self) -> TSLanguage {
     crate::parsers::language_html()
   }
   fn injectable_languages(&self) -> Option<&'static [&'static str]> {

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -30,8 +30,8 @@ mod yaml;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 pub use html::Html;
 
-use ast_grep_core::language::{TSLanguage, TSRange};
 use ast_grep_core::meta_var::MetaVariable;
+use ast_grep_core::tree_sitter::{TSLanguage, TSRange};
 use ast_grep_core::{Node, StrDoc};
 use ignore::types::{Types, TypesBuilder};
 use serde::de::Visitor;
@@ -119,7 +119,7 @@ macro_rules! impl_lang_expando {
       }
     }
     impl LanguageExt for $lang {
-      fn get_ts_language(&self) -> ast_grep_core::language::TSLanguage {
+      fn get_ts_language(&self) -> TSLanguage {
         $crate::parsers::$func().into()
       }
     }

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -41,7 +41,7 @@ macro_rules! into_napi_lang {
   };
 }
 
-use ast_grep_core::language::TSLanguage;
+use ast_grep_core::tree_sitter::TSLanguage;
 
 pub fn language_bash() -> TSLanguage {
   into_lang!(tree_sitter_bash)

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -1,5 +1,5 @@
-use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::tree_sitter::TSLanguage;
 use ast_grep_core::LanguageExt;
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
-use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::tree_sitter::TSLanguage;
 use ast_grep_core::{LanguageExt, StrDoc};
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
-use ast_grep_core::language::TSLanguage;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
+use ast_grep_core::tree_sitter::TSLanguage;
 use ast_grep_core::{Language, LanguageExt};
 use ast_grep_language::{
   Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,


### PR DESCRIPTION
https://github.com/ast-grep/ast-grep/issues/1918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating replacements in documents using a new replacement engine, enabling advanced find-and-replace scenarios with meta-variables.
  - Introduced a new trait to handle content edits with improved incremental parsing support.
  - Added contextual display features to show matched text with surrounding lines for better debugging and inspection.

- **Bug Fixes**
  - Improved parsing reliability by updating the underlying parsing logic to use the latest parser APIs.

- **Refactor**
  - Streamlined and modernized the parsing and replacement logic for better maintainability and performance.
  - Centralized and simplified parsing routines, removing deprecated methods and consolidating parsing functions.
  - Updated language trait implementations and import paths to align with new module structures.
  - Removed legacy code related to specialized string document handling to reduce complexity.
  - Reorganized imports and re-exports to improve module clarity and consistency.

- **Tests**
  - Enhanced and updated tests to cover new and existing replacement scenarios, ensuring robust functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->