### PR TITLE
feat: extract tree-sitter out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ rust-version = "1.70"
 readme = "README.md"
 
 [workspace.dependencies]
-ast-grep-core = { path = "crates/core", version = "0.37.0" }
-ast-grep-config = { path = "crates/config", version = "0.37.0" }
-ast-grep-dynamic = { path = "crates/dynamic", version = "0.37.0" }
-ast-grep-language = { path = "crates/language", version = "0.37.0" }
-ast-grep-lsp = { path = "crates/lsp", version = "0.37.0" }
+ast-grep-core = { path = "crates/core" }
+ast-grep-config = { path = "crates/config" }
+ast-grep-dynamic = { path = "crates/dynamic" }
+ast-grep-language = { path = "crates/language" }
+ast-grep-lsp = { path = "crates/lsp" }
 
 bit-set = { version = "0.8.0" }
 ignore = { version = "0.4.22" }

--- a/benches/src/sg_benchmark.rs
+++ b/benches/src/sg_benchmark.rs
@@ -1,5 +1,6 @@
 use ast_grep_config::{from_yaml_string, RuleConfig};
-use ast_grep_core::{AstGrep, LanguageExt, Matcher, Pattern, StrDoc};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc};
+use ast_grep_core::{AstGrep, Matcher, Pattern};
 use ast_grep_language::SupportLang;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::env::current_dir;

--- a/crates/cli/src/lang/injection.rs
+++ b/crates/cli/src/lang/injection.rs
@@ -1,7 +1,10 @@
 use super::SgLang;
 use crate::utils::ErrorContext as EC;
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::{tree_sitter::TSRange, Doc, LanguageExt, Node, StrDoc};
+use ast_grep_core::{
+  tree_sitter::{LanguageExt, StrDoc, TSRange},
+  Doc, Node,
+};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -6,8 +6,8 @@ use crate::utils::ErrorContext as EC;
 use anyhow::{Context, Result};
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::{
-  tree_sitter::{TSLanguage, TSRange},
-  Node, StrDoc,
+  tree_sitter::{StrDoc, TSLanguage, TSRange},
+  Node,
 };
 use ast_grep_dynamic::DynamicLang;
 use ast_grep_language::{Language, LanguageExt, SupportLang};

--- a/crates/cli/src/lang/mod.rs
+++ b/crates/cli/src/lang/mod.rs
@@ -217,7 +217,7 @@ impl LanguageExt for SgLang {
     &self,
     root: Node<StrDoc<L>>,
   ) -> HashMap<String, Vec<TSRange>> {
-    injection::extract_injections(root)
+    injection::extract_injections(self, root)
   }
 }
 

--- a/crates/cli/src/print/colored_print/match_merger.rs
+++ b/crates/cli/src/print/colored_print/match_merger.rs
@@ -1,5 +1,5 @@
 use super::NodeMatch;
-use ast_grep_core::DisplayContext;
+use ast_grep_core::tree_sitter::DisplayContext;
 
 /// merging overlapping/adjacent matches
 /// adjacent matches: matches that starts or ends on the same line

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -344,8 +344,8 @@ fn open_in_editor(path: &Path, start_line: usize) -> Result<()> {
 mod test {
   use super::*;
   use ast_grep_config::{from_yaml_string, Fixer, GlobalRules};
-  use ast_grep_core::traversal::Visitor;
-  use ast_grep_core::{AstGrep, Matcher, StrDoc};
+  use ast_grep_core::tree_sitter::{StrDoc, Visitor};
+  use ast_grep_core::{AstGrep, Matcher};
   use ast_grep_language::SupportLang;
 
   fn make_rule(rule: &str) -> RuleConfig<SgLang> {

--- a/crates/cli/src/print/json_print.rs
+++ b/crates/cli/src/print/json_print.rs
@@ -1,6 +1,6 @@
 use crate::lang::SgLang;
 use ast_grep_config::{RuleConfig, Severity};
-use ast_grep_core::{meta_var::MetaVariable, Node as SgNode, StrDoc};
+use ast_grep_core::{meta_var::MetaVariable, tree_sitter::StrDoc, Node as SgNode};
 
 type Node<'a, L> = SgNode<'a, StrDoc<L>>;
 

--- a/crates/cli/src/print/mod.rs
+++ b/crates/cli/src/print/mod.rs
@@ -5,7 +5,7 @@ mod json_print;
 
 use crate::lang::SgLang;
 use ast_grep_config::{Fixer, RuleConfig};
-use ast_grep_core::{Matcher, NodeMatch as SgNodeMatch, StrDoc};
+use ast_grep_core::{tree_sitter::StrDoc, Matcher, NodeMatch as SgNodeMatch};
 
 use anyhow::Result;
 use clap::ValueEnum;

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ast_grep_config::{from_yaml_string, CombinedScan, RuleCollection, RuleConfig, Severity};
-use ast_grep_core::{NodeMatch, StrDoc};
+use ast_grep_core::{tree_sitter::StrDoc, NodeMatch};
 use ast_grep_language::SupportLang;
 use clap::Args;
 use ignore::WalkParallel;
@@ -269,7 +269,7 @@ impl StdInWorker for ScanStdin {
     src: String,
     processor: &P::Processor,
   ) -> Result<Vec<P::Processed>> {
-    use ast_grep_core::LanguageExt;
+    use ast_grep_core::tree_sitter::LanguageExt;
     let lang = self.rules[0].language;
     let combined = CombinedScan::new(self.rules.iter().collect());
     let grep = lang.ast_grep(src);

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -28,7 +28,7 @@ use smallvec::{smallvec, SmallVec};
 
 use ast_grep_config::RuleCollection;
 use ast_grep_core::Pattern;
-use ast_grep_core::{Matcher, StrDoc};
+use ast_grep_core::{tree_sitter::StrDoc, Matcher};
 use ast_grep_language::{Language, LanguageExt};
 
 use std::fs::read_to_string;

--- a/crates/cli/src/verify.rs
+++ b/crates/cli/src/verify.rs
@@ -9,7 +9,7 @@ use crate::lang::SgLang;
 use crate::utils::ErrorContext;
 use anyhow::{anyhow, Result};
 use ast_grep_config::RuleCollection;
-use ast_grep_core::{Node as SgNode, StrDoc};
+use ast_grep_core::{tree_sitter::StrDoc, Node as SgNode};
 use clap::Args;
 use regex::Regex;
 use serde_yaml::to_string;

--- a/crates/cli/src/verify/snapshot.rs
+++ b/crates/cli/src/verify/snapshot.rs
@@ -1,7 +1,10 @@
 use crate::lang::SgLang;
 use anyhow::{anyhow, Result};
 use ast_grep_config::RuleConfig;
-use ast_grep_core::{LanguageExt, NodeMatch, StrDoc};
+use ast_grep_core::{
+  tree_sitter::{LanguageExt, StrDoc},
+  NodeMatch,
+};
 
 use super::{CaseResult, Node};
 use serde::{Deserialize, Serialize, Serializer};

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,15 +11,16 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-default = ["regex"]
+default = ["tree-sitter"]
+tree-sitter = ["ast-grep-core/tree-sitter"]
 
 [dependencies]
-ast-grep-core.workspace = true
+ast-grep-core = { workspace = true, no-default-features = true }
 
 anyhow.workspace = true
 bit-set.workspace = true
 globset = "0.4.14"
-regex = { workspace = true, optional = true }
+regex.workspace = true
 serde.workspace = true
 serde_yaml = "0.9.33"
 thiserror.workspace = true

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -266,7 +266,7 @@ mod test {
   use crate::from_str;
   use crate::test::TypeScript;
   use crate::SerializableRuleConfig;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   fn create_rule() -> RuleConfig<TypeScript> {
     let rule: SerializableRuleConfig<TypeScript> = from_str(

--- a/crates/config/src/fixer.rs
+++ b/crates/config/src/fixer.rs
@@ -188,7 +188,7 @@ mod test {
   use crate::from_str;
   use crate::maybe::Maybe;
   use crate::test::TypeScript;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   #[test]
   fn test_parse() {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -43,9 +43,8 @@ pub fn from_yaml_string<'a, L: Language + Deserialize<'a>>(
 mod test {
   use super::*;
   use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-  use ast_grep_core::tree_sitter::TSLanguage;
-  use ast_grep_core::StrDoc;
-  use ast_grep_core::{Language, LanguageExt};
+  use ast_grep_core::tree_sitter::{LanguageExt, StrDoc, TSLanguage};
+  use ast_grep_core::Language;
   use std::path::Path;
 
   #[derive(Clone, Deserialize, PartialEq, Eq)]

--- a/crates/config/src/rule/deserialize_env.rs
+++ b/crates/config/src/rule/deserialize_env.rs
@@ -214,7 +214,7 @@ mod test {
   use crate::test::TypeScript;
   use crate::{from_str, Rule};
   use anyhow::Result;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_core::Matcher;
 
   fn get_dependent_utils() -> Result<(Rule, DeserializeEnv<TypeScript>)> {

--- a/crates/config/src/rule/mod.rs
+++ b/crates/config/src/rule/mod.rs
@@ -489,7 +489,7 @@ mod test {
   use super::*;
   use crate::from_str;
   use crate::test::TypeScript;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use PatternStyle::*;
 
   #[test]

--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -267,7 +267,7 @@ mod test {
   use crate::test::TypeScript as TS;
   use ast_grep_core::matcher::RegexMatcher;
   use ast_grep_core::meta_var::MetaVarEnv;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   #[test]
   fn test_positional() {

--- a/crates/config/src/rule/range.rs
+++ b/crates/config/src/rule/range.rs
@@ -97,7 +97,7 @@ mod test {
   use super::*;
   use crate::test::TypeScript as TS;
   use ast_grep_core::matcher::MatcherExt;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   #[test]
   fn test_invalid_range() {

--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -271,7 +271,7 @@ mod test {
   use ast_grep_core::matcher::KindMatcher;
   use ast_grep_core::ops as o;
   use ast_grep_core::Pattern;
-  use ast_grep_core::{Language, LanguageExt};
+  use ast_grep_core::{tree_sitter::LanguageExt, Language};
 
   fn find_rule<M: Matcher>(src: &str, matcher: M) -> Option<String> {
     let grep = TS::Tsx.ast_grep(src);

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -7,7 +7,8 @@ use crate::rule_core::{RuleCore, RuleCoreError, SerializableRuleCore};
 
 use ast_grep_core::language::Language;
 use ast_grep_core::replacer::Replacer;
-use ast_grep_core::{LanguageExt, Matcher, NodeMatch, StrDoc};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc};
+use ast_grep_core::{Matcher, NodeMatch};
 
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -279,7 +279,7 @@ mod test {
   use crate::rule::referent_rule::{ReferentRule, ReferentRuleError};
   use crate::test::TypeScript;
   use ast_grep_core::matcher::{Pattern, RegexMatcher};
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   fn get_matcher(src: &str) -> RResult<RuleCore> {
     let env = DeserializeEnv::new(TypeScript::Tsx);

--- a/crates/config/src/transform/mod.rs
+++ b/crates/config/src/transform/mod.rs
@@ -83,7 +83,7 @@ mod test {
   use super::*;
   use crate::from_str;
   use crate::test::TypeScript;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
 
   #[test]
   fn test_single_cyclic_transform() {

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -342,7 +342,7 @@ fix: $D
     rewrite: Rewrite<String>,
     reg: RuleRegistration,
   ) -> Option<String> {
-    use ast_grep_core::LanguageExt;
+    use ast_grep_core::tree_sitter::LanguageExt;
     let grep = TypeScript::Tsx.ast_grep(src);
     let root = grep.root();
     let mut nm = root.find(pat).expect("should find");

--- a/crates/config/src/transform/transformation.rs
+++ b/crates/config/src/transform/transformation.rs
@@ -207,7 +207,7 @@ mod test {
   use super::*;
   use crate::test::TypeScript;
   use crate::DeserializeEnv;
-  use ast_grep_core::LanguageExt;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use serde_yaml::with::singleton_map_recursive;
   use std::collections::HashMap;
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,12 +15,12 @@ version.workspace = true
 
 [dependencies]
 bit-set.workspace = true
-regex = { workspace = true, optional = true }
+regex.workspace = true
 thiserror.workspace = true
-tree-sitter.workspace = true
+tree-sitter = { workspace = true, optional = true }
 
 [features]
-default = ["regex"]
+default = ["tree-sitter"]
 
 [dev-dependencies]
 tree-sitter-typescript = "0.23.2"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod meta_var;
 pub mod ops;
 pub mod replacer;
 pub mod source;
+#[cfg(feature = "tree-sitter")]
 pub mod tree_sitter;
 
 #[doc(hidden)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,69 +31,9 @@ pub use tree_sitter::{LanguageExt, StrDoc};
 #[doc(hidden)]
 pub use tree_sitter::DisplayContext;
 
-use replacer::Replacer;
-
 use node::Root;
-use source::Edit;
 
-#[derive(Clone)]
-pub struct AstGrep<D: Doc> {
-  #[doc(hidden)]
-  pub inner: Root<D>,
-}
-impl<D: Doc> AstGrep<D> {
-  pub fn root(&self) -> Node<D> {
-    self.inner.root()
-  }
-
-  pub fn edit(&mut self, edit: Edit<D::Source>) -> Result<&mut Self, String> {
-    self.inner.do_edit(edit)?;
-    Ok(self)
-  }
-
-  pub fn replace<M: Matcher, R: Replacer<D>>(
-    &mut self,
-    pattern: M,
-    replacer: R,
-  ) -> Result<bool, String> {
-    let root = self.root();
-    if let Some(edit) = root.replace(pattern, replacer) {
-      drop(root); // rust cannot auto drop root if D is not specified
-      self.edit(edit)?;
-      Ok(true)
-    } else {
-      Ok(false)
-    }
-  }
-
-  pub fn lang(&self) -> &D::Lang {
-    self.inner.lang()
-  }
-
-  /// Use this method to avoid expensive string encoding overhead
-  /// TODO: add more documents on what is happening
-  pub fn doc(d: D) -> Self {
-    Self {
-      inner: Root::doc(d),
-    }
-  }
-}
-
-impl<L: LanguageExt> AstGrep<StrDoc<L>> {
-  pub fn new<S: AsRef<str>>(src: S, lang: L) -> Self {
-    Self {
-      inner: Root::str(src.as_ref(), lang),
-    }
-  }
-
-  pub fn source(&self) -> &str {
-    self.inner.doc.get_source().as_str()
-  }
-
-  pub fn generate(self) -> String {
-    self.inner.doc.src
-  }
-}
+pub type AstGrep<D> = Root<D>;
 
 #[cfg(test)]
 mod test {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,11 +12,10 @@ pub mod meta_var;
 pub mod ops;
 pub mod replacer;
 pub mod source;
-pub mod traversal;
+pub mod tree_sitter;
 
 #[doc(hidden)]
 pub mod pinned;
-pub mod tree_sitter;
 
 mod match_tree;
 mod node;
@@ -26,10 +25,6 @@ pub use match_tree::MatchStrictness;
 pub use matcher::{Matcher, NodeMatch, Pattern, PatternError};
 pub use node::{Node, Position};
 pub use source::Doc;
-pub use tree_sitter::{LanguageExt, StrDoc};
-
-#[doc(hidden)]
-pub use tree_sitter::DisplayContext;
 
 use node::Root;
 
@@ -38,6 +33,7 @@ pub type AstGrep<D> = Root<D>;
 #[cfg(test)]
 mod test {
   use super::*;
+  use crate::tree_sitter::LanguageExt;
   use language::Tsx;
   use ops::Op;
 

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -148,8 +148,8 @@ mod test {
   use super::*;
   use crate::language::Tsx;
   use crate::meta_var::MetaVarEnv;
-  use crate::Node;
-  use crate::{Root, StrDoc};
+  use crate::tree_sitter::StrDoc;
+  use crate::{Node, Root};
   use std::collections::HashMap;
 
   fn find_node_recursive<'tree>(

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -8,7 +8,6 @@
 mod kind;
 mod node_match;
 mod pattern;
-#[cfg(feature = "regex")]
 mod text;
 
 use crate::Doc;
@@ -20,7 +19,6 @@ use std::borrow::Cow;
 pub use kind::{kind_utils, KindMatcher, KindMatcherError};
 pub use node_match::NodeMatch;
 pub use pattern::{Pattern, PatternBuilder, PatternError, PatternNode};
-#[cfg(feature = "regex")]
 pub use text::{RegexMatcher, RegexMatcherError};
 
 /// `Matcher` defines whether a tree-sitter node matches certain pattern,

--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -99,7 +99,7 @@ mod test {
   use super::*;
   use crate::language::Tsx;
   use crate::matcher::MatcherExt;
-  use crate::{Root, StrDoc};
+  use crate::{tree_sitter::StrDoc, Root};
 
   fn pattern_node(s: &str) -> Root<StrDoc<Tsx>> {
     Root::str(s, Tsx)

--- a/crates/core/src/matcher/node_match.rs
+++ b/crates/core/src/matcher/node_match.rs
@@ -99,7 +99,7 @@ impl<'tree, D: Doc> Borrow<Node<'tree, D>> for NodeMatch<'tree, D> {
 mod test {
   use super::*;
   use crate::language::Tsx;
-  use crate::{LanguageExt, StrDoc};
+  use crate::tree_sitter::{LanguageExt, StrDoc};
 
   fn use_node<L: LanguageExt>(n: &Node<StrDoc<L>>) -> String {
     n.text().to_string()

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -347,7 +347,7 @@ mod test {
   use crate::language::Tsx;
   use crate::matcher::MatcherExt;
   use crate::meta_var::MetaVarEnv;
-  use crate::StrDoc;
+  use crate::tree_sitter::StrDoc;
   use std::collections::HashMap;
 
   fn pattern_node(s: &str) -> Root<StrDoc<Tsx>> {

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -302,7 +302,7 @@ impl<'tree, D: Doc> From<MetaVarEnv<'tree, D>> for HashMap<String, String> {
 mod test {
   use super::*;
   use crate::language::Tsx;
-  use crate::LanguageExt;
+  use crate::tree_sitter::LanguageExt;
   use crate::Pattern;
 
   fn extract_var(s: &str) -> Option<MetaVariable> {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -23,7 +23,7 @@ pub struct Position {
 }
 
 impl Position {
-  pub(crate) fn new(line: usize, byte_column: usize, byte_offset: usize) -> Self {
+  pub fn new(line: usize, byte_column: usize, byte_offset: usize) -> Self {
     Self {
       line,
       byte_column,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -67,9 +67,24 @@ impl<D: Doc> Root<D> {
   }
 
   // extract non generic implementation to reduce code size
-  pub fn do_edit(&mut self, edit: Edit<D>) -> Result<(), String> {
+  pub fn edit(&mut self, edit: Edit<D>) -> Result<&mut Self, String> {
     self.doc.do_edit(&edit)?;
-    Ok(())
+    Ok(self)
+  }
+
+  pub fn replace<M: Matcher, R: Replacer<D>>(
+    &mut self,
+    pattern: M,
+    replacer: R,
+  ) -> Result<bool, String> {
+    let root = self.root();
+    if let Some(edit) = root.replace(pattern, replacer) {
+      drop(root); // rust cannot auto drop root if D is not specified
+      self.edit(edit)?;
+      Ok(true)
+    } else {
+      Ok(false)
+    }
   }
 
   /// Adopt the tree_sitter as the descendant of the root and return the wrapped sg Node.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -381,8 +381,8 @@ impl<D: Doc> Node<'_, D> {
 
 #[cfg(test)]
 mod test {
-  use crate::language::Tsx;
-  use crate::{Language, LanguageExt};
+  use crate::language::{Language, Tsx};
+  use crate::tree_sitter::LanguageExt;
   #[test]
   fn test_is_leaf() {
     let root = Tsx.ast_grep("let a = 123");

--- a/crates/core/src/pinned.rs
+++ b/crates/core/src/pinned.rs
@@ -118,7 +118,7 @@ mod test {
   use super::*;
   use crate::language::Tsx;
   use crate::node::Root;
-  use crate::StrDoc;
+  use crate::tree_sitter::StrDoc;
 
   fn return_from_func() -> PinnedNodeData<StrDoc<Tsx>, Node<'static, StrDoc<Tsx>>> {
     let root = Root::str("let a = 123", Tsx);

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -101,10 +101,7 @@ mod test {
 
   fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
     let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
+    let roots: Vec<_> = vars.iter().map(|(v, p)| (v, Tsx.ast_grep(p))).collect();
     for (var, root) in &roots {
       env.insert(var, root.root());
     }
@@ -164,10 +161,7 @@ mod test {
 
   fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
     let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
+    let roots: Vec<_> = vars.iter().map(|(v, p)| (v, Tsx.ast_grep(p))).collect();
     for (var, root) in &roots {
       env.insert_multi(var, root.root().children().collect());
     }

--- a/crates/core/src/replacer/structural.rs
+++ b/crates/core/src/replacer/structural.rs
@@ -96,7 +96,7 @@ fn get_meta_var_replacement<D: Doc>(
 mod test {
   use crate::language::Tsx;
   use crate::meta_var::MetaVarEnv;
-  use crate::{replacer::Replacer, LanguageExt, NodeMatch, Root};
+  use crate::{replacer::Replacer, tree_sitter::LanguageExt, NodeMatch, Root};
   use std::collections::HashMap;
 
   fn test_pattern_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -194,10 +194,7 @@ if (true) {
 
   fn test_str_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
     let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
+    let roots: Vec<_> = vars.iter().map(|(v, p)| (v, Tsx.ast_grep(p))).collect();
     for (var, root) in &roots {
       env.insert(var, root.root());
     }
@@ -256,10 +253,7 @@ if (true) {
 
   fn test_ellipsis_replace(replacer: &str, vars: &[(&str, &str)], expected: &str) {
     let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
+    let roots: Vec<_> = vars.iter().map(|(v, p)| (v, Tsx.ast_grep(p))).collect();
     for (var, root) in &roots {
       env.insert_multi(var, root.root().children().collect());
     }
@@ -305,10 +299,7 @@ if (true) {
 
   fn test_template_replace(template: &str, vars: &[(&str, &str)], expected: &str) {
     let mut env = MetaVarEnv::new();
-    let roots: Vec<_> = vars
-      .iter()
-      .map(|(v, p)| (v, Tsx.ast_grep(p).inner))
-      .collect();
+    let roots: Vec<_> = vars.iter().map(|(v, p)| (v, Tsx.ast_grep(p))).collect();
     for (var, root) in &roots {
       env.insert(var, root.root());
     }

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -160,7 +160,7 @@ mod test {
   use crate::language::Tsx;
   use crate::matcher::NodeMatch;
   use crate::meta_var::{MetaVarEnv, MetaVariable};
-  use crate::LanguageExt;
+  use crate::tree_sitter::LanguageExt;
   use crate::Pattern;
   use std::collections::HashMap;
 

--- a/crates/core/src/tree_sitter.rs
+++ b/crates/core/src/tree_sitter.rs
@@ -300,6 +300,20 @@ fn position_for_offset(input: &[u8], offset: usize) -> Point {
   Point::new(row, col)
 }
 
+impl<L: LanguageExt> AstGrep<StrDoc<L>> {
+  pub fn new<S: AsRef<str>>(src: S, lang: L) -> Self {
+    Root::str(src.as_ref(), lang)
+  }
+
+  pub fn source(&self) -> &str {
+    self.doc.get_source().as_str()
+  }
+
+  pub fn generate(self) -> String {
+    self.doc.src
+  }
+}
+
 pub trait ContentExt: Content {
   fn accept_edit(&mut self, edit: &Edit<Self>) -> InputEdit;
 }

--- a/crates/core/src/tree_sitter/mod.rs
+++ b/crates/core/src/tree_sitter/mod.rs
@@ -1,12 +1,14 @@
+mod traversal;
+
 use crate::node::Root;
 use crate::replacer::Replacer;
 use crate::source::{Content, Doc, Edit, SgNode};
-use crate::traversal::{TsPre, Visitor};
 use crate::{node::KindId, Language, Position};
 use crate::{AstGrep, Matcher};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use thiserror::Error;
+pub use traversal::{TsPre, Visitor};
 pub use tree_sitter::Language as TSLanguage;
 use tree_sitter::{InputEdit, LanguageError, Node, Parser, ParserError, Point, Tree};
 pub use tree_sitter::{Point as TSPoint, Range as TSRange};

--- a/crates/core/src/tree_sitter/traversal.rs
+++ b/crates/core/src/tree_sitter/traversal.rs
@@ -18,8 +18,10 @@
 //! It is recommended to use traversal instead of tree recursion to avoid stack overflow and memory overhead.
 //! Level order is also included for completeness and should be used sparingly.
 
+use super::StrDoc;
 use crate::matcher::{Matcher, MatcherExt};
-use crate::{Doc, LanguageExt, Node, NodeMatch, Root, StrDoc};
+use crate::tree_sitter::LanguageExt;
+use crate::{Doc, Node, NodeMatch, Root};
 
 use tree_sitter as ts;
 
@@ -410,7 +412,6 @@ impl<'tree, L: LanguageExt> Iterator for Level<'tree, L> {
 mod test {
   use super::*;
   use crate::language::Tsx;
-  use crate::StrDoc;
   use std::ops::Range;
 
   // recursive pre order as baseline

--- a/crates/dynamic/src/lib.rs
+++ b/crates/dynamic/src/lib.rs
@@ -1,5 +1,5 @@
-use ast_grep_core::tree_sitter::TSLanguage;
-use ast_grep_core::{Language, LanguageExt, StrDoc};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc, TSLanguage};
+use ast_grep_core::Language;
 
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ignore::types::{Types, TypesBuilder};

--- a/crates/language/src/html.rs
+++ b/crates/language/src/html.rs
@@ -1,8 +1,8 @@
 use super::pre_process_pattern;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::tree_sitter::{TSLanguage, TSRange};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc, TSLanguage, TSRange};
+use ast_grep_core::Language;
 use ast_grep_core::{matcher::KindMatcher, Doc, Node};
-use ast_grep_core::{Language, LanguageExt, StrDoc};
 use std::collections::HashMap;
 
 // tree-sitter-html uses locale dependent iswalnum for tagName

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -31,8 +31,8 @@ use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 pub use html::Html;
 
 use ast_grep_core::meta_var::MetaVariable;
-use ast_grep_core::tree_sitter::{TSLanguage, TSRange};
-use ast_grep_core::{Node, StrDoc};
+use ast_grep_core::tree_sitter::{StrDoc, TSLanguage, TSRange};
+use ast_grep_core::Node;
 use ignore::types::{Types, TypesBuilder};
 use serde::de::Visitor;
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -44,7 +44,8 @@ use std::iter::repeat;
 use std::path::Path;
 use std::str::FromStr;
 
-pub use ast_grep_core::{language::Language, LanguageExt};
+pub use ast_grep_core::language::Language;
+pub use ast_grep_core::tree_sitter::LanguageExt;
 
 /// this macro implements bare-bone methods for a language
 macro_rules! impl_lang {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -7,7 +7,10 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
 use ast_grep_config::{CombinedScan, RuleCollection, RuleConfig, Severity};
-use ast_grep_core::{AstGrep, Doc, LanguageExt, StrDoc};
+use ast_grep_core::{
+  tree_sitter::{LanguageExt, StrDoc},
+  AstGrep, Doc,
+};
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -1,7 +1,8 @@
 //! Provides utility to convert ast-grep data types to lsp data types
 use ast_grep_config::RuleConfig;
 use ast_grep_config::Severity;
-use ast_grep_core::{Doc, LanguageExt, Node, NodeMatch, StrDoc};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc};
+use ast_grep_core::{Doc, Node, NodeMatch};
 
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::*;

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -2,9 +2,7 @@ use crate::napi_lang::NapiLang;
 
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
 use ast_grep_core::source::{Content, Doc, Edit};
-use ast_grep_core::tree_sitter::ContentExt;
-use ast_grep_core::tree_sitter::TSParseError;
-use ast_grep_core::LanguageExt;
+use ast_grep_core::tree_sitter::{ContentExt, LanguageExt, TSParseError};
 use napi::anyhow::Error;
 use napi::bindgen_prelude::Result as NapiResult;
 use napi_derive::napi;
@@ -160,7 +158,7 @@ impl Doc for JsDoc {
     let source = &mut self.source;
     let input_edit = source.accept_edit(edit);
     self.tree.edit(&input_edit);
-    self.tree = parse(&source, &self.lang, Some(&self.tree)).map_err(|e| e.to_string())?;
+    self.tree = parse(source, &self.lang, Some(&self.tree)).map_err(|e| e.to_string())?;
     Ok(())
   }
   fn root_node(&self) -> Node<'_> {

--- a/crates/napi/src/find_files.rs
+++ b/crates/napi/src/find_files.rs
@@ -188,14 +188,14 @@ pub fn find_in_files_impl(
 // TODO: optimize
 fn from_pinned_data(pinned: PinnedNodes, env: napi::Env) -> Result<Vec<Vec<SgNode>>> {
   let (root, nodes) = pinned.0.into_raw();
-  let sg_root = SgRoot(AstGrep { inner: root }, pinned.1);
+  let sg_root = SgRoot(root, pinned.1);
   let reference = SgRoot::into_reference(sg_root, env)?;
   let mut v = vec![];
   for mut node in nodes {
     let root_ref = reference.clone(env)?;
     let sg_node = SgNode {
       inner: root_ref.share_with(env, |root| {
-        let r = &root.0.inner;
+        let r = &root.0;
         node.visit_nodes(|n| unsafe { r.readopt(n) });
         Ok(node)
       })?,
@@ -222,7 +222,7 @@ fn call_sg_node(
     return Ok(false);
   }
   let (root, path) = get_root(entry, lang_option)?;
-  let mut pinned = PinnedNodeData::new(root.inner, |r| r.root().find_all(rule).collect());
+  let mut pinned = PinnedNodeData::new(root, |r| r.root().find_all(rule).collect());
   let hits: &Vec<_> = pinned.get_data();
   if hits.is_empty() {
     return Ok(false);

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -1,6 +1,5 @@
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::tree_sitter::TSLanguage;
-use ast_grep_core::LanguageExt;
+use ast_grep_core::tree_sitter::{LanguageExt, TSLanguage};
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};
 use ignore::types::{Types, TypesBuilder};

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -8,7 +8,10 @@ use py_lang::register_dynamic_language;
 use py_node::{Edit, SgNode};
 use range::{Pos, Range};
 
-use ast_grep_core::{AstGrep, LanguageExt, NodeMatch, StrDoc};
+use ast_grep_core::{
+  tree_sitter::{LanguageExt, StrDoc},
+  AstGrep, NodeMatch,
+};
 use py_lang::PyLang;
 use pyo3::prelude::*;
 

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::tree_sitter::TSLanguage;
-use ast_grep_core::{LanguageExt, StrDoc};
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc, TSLanguage};
 use ast_grep_dynamic::{CustomLang, DynamicLang};
 use ast_grep_language::{Language, SupportLang};
 use serde::{Deserialize, Serialize};

--- a/crates/pyo3/src/py_node.rs
+++ b/crates/pyo3/src/py_node.rs
@@ -3,7 +3,7 @@ use crate::range::Range;
 use crate::SgRoot;
 
 use ast_grep_config::{DeserializeEnv, RuleCore, SerializableRuleCore};
-use ast_grep_core::{NodeMatch, StrDoc};
+use ast_grep_core::{tree_sitter::StrDoc, NodeMatch};
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,32 +106,12 @@ fn update_napi(version: &str) -> Result<()> {
   Ok(())
 }
 
-fn edit_root_toml<P: AsRef<Path>>(path: P, version: &str) -> Result<()> {
-  let mut toml: DocumentMut = read_to_string(&path)?.parse()?;
-  toml["workspace"]["package"]["version"] = to_toml(version);
-  let deps = toml["workspace"]["dependencies"]
-    .as_table_mut()
-    .context("dep should be table")?;
-  for (key, value) in deps.iter_mut() {
-    if !key.starts_with("ast-grep-") {
-      continue;
-    }
-    if value.is_str() {
-      *value = to_toml(version);
-      continue;
-    }
-    if let Some(inline) = value.as_inline_table_mut() {
-      inline["version"] = version.into();
-    }
-  }
-  fs::write(path, toml.to_string())?;
-  Ok(())
-}
-
 fn update_crates(version: &str) -> Result<()> {
   // update root toml
-  let root_toml = Path::new("Cargo.toml");
-  edit_root_toml(root_toml, version)?;
+  let root_path = Path::new("Cargo.toml");
+  let mut toml: DocumentMut = read_to_string(root_path)?.parse()?;
+  toml["workspace"]["package"]["version"] = to_toml(version);
+  fs::write(root_path, toml.to_string())?;
   // no need to update crates or benches
   Ok(())
 }

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Context, Result};
 use ast_grep_config::SerializableRuleConfig;
 use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
-use ast_grep_core::tree_sitter::TSLanguage;
-use ast_grep_core::{Language, LanguageExt};
+use ast_grep_core::tree_sitter::{LanguageExt, TSLanguage};
+use ast_grep_core::Language;
 use ast_grep_language::{
   Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
   Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified import paths for language-related types across the codebase, improving clarity and maintainability.
  - Replaced a wrapper struct with a type alias for a more direct and transparent API.
  - Centralized traversal functionality and added new methods for easier construction and access to language-annotated syntax trees.
  - Updated function signatures and usage patterns for injection extraction to improve type safety and explicitness.
  - Streamlined handling of injected language subtrees and removed unnecessary wrapping and indirection.
  - Updated root editing and replacement methods to provide enhanced editing capabilities with clearer API.

- **Chores**
  - Removed explicit version constraints for internal dependencies in the workspace configuration.
  - Cleaned up and reorganized import statements for consistency.
  - Adjusted default features and dependency declarations to prioritize tree-sitter integration.

- **New Features**
  - Added new methods for creating, accessing, and generating source from language-annotated syntax trees.

- **Bug Fixes**
  - Improved type safety in injection extraction logic, eliminating unsafe casting.

- **Style**
  - Reorganized and grouped import statements for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->