### PR TITLE
feat: multiple fixer support 

### DIFF
--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -269,7 +269,8 @@ impl PrintProcessor<Buffer> for ColoredProcessor {
           .print_diff(source, &new_str, writer, context)?;
       }
       if matches!(display_style, DisplayStyle::Medium | DisplayStyle::Rich) {
-        if let Some(note) = &rule.note {
+        let notes = self.markdown.render_note(rule);
+        if let Some(note) = notes {
           writeln!(writer, "{}", self.styles.rule.note.paint("Note:"))?;
           writeln!(writer, "{note}")?;
         }

--- a/crates/cli/src/print/colored_print/test.rs
+++ b/crates/cli/src/print/colored_print/test.rs
@@ -263,7 +263,7 @@ fix: '{rewrite}'"
   .pop()
   .unwrap();
   let matcher = rule.get_matcher(&globals).expect("should parse");
-  let fixer = matcher.fixer.as_ref().expect("should have fixer");
+  let fixer = matcher.fixer.first().expect("should have fixer");
   let root = grep.root();
   let matches = root.find_all(&matcher);
   let diffs = matches.map(|n| (Diff::generate(n, &pattern, fixer), &rule));

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -402,7 +402,7 @@ rule:
 fix: ($B, lifecycle.update(['$A']))",
     );
     let mut matcher = config.matcher;
-    let fixer = matcher.fixer.take().unwrap();
+    let fixer = matcher.fixer.remove(0);
     let diffs = make_diffs(&root, matcher, &fixer);
     let ret = apply_rewrite(diffs);
     assert_eq!(ret, "let a = () => (c++, lifecycle.update(['c']))");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -304,7 +304,7 @@ fn match_rule_diff_on_file<T>(
   let diffs = matches
     .into_iter()
     .filter_map(|(rule, m)| {
-      let fix = rule.matcher.fixer.as_ref()?;
+      let fix = rule.matcher.fixer.first()?;
       let diff = Diff::generate(m, &rule.matcher, fix);
       Some((diff, rule))
     })
@@ -321,7 +321,7 @@ fn match_rule_on_file<T>(
   processor: &impl PrintProcessor<T>,
 ) -> Result<T> {
   let file = SimpleFile::new(path.to_string_lossy(), file_content);
-  let processed = if let Some(fixer) = &rule.matcher.fixer {
+  let processed = if let Some(fixer) = &rule.matcher.fixer.first() {
     let diffs = matches
       .into_iter()
       .map(|m| (Diff::generate(m, &rule.matcher, fixer), rule))

--- a/crates/cli/src/verify/snapshot.rs
+++ b/crates/cli/src/verify/snapshot.rs
@@ -95,7 +95,7 @@ impl TestSnapshot {
       .into_iter()
       .map(LabelSnapshot::from)
       .collect();
-    let Some(fix) = &rule_config.matcher.fixer else {
+    let Some(fix) = rule_config.matcher.fixer.first() else {
       return Ok(Some(Self {
         fixed: None,
         labels,

--- a/crates/config/src/check_var.rs
+++ b/crates/config/src/check_var.rs
@@ -23,7 +23,7 @@ pub fn check_rule_with_hint<'r>(
   utils: &'r RuleRegistration,
   constraints: &'r HashMap<String, Rule>,
   transform: &'r Option<Transform>,
-  fixer: &Option<Fixer>,
+  fixer: &Vec<Fixer>,
   hint: CheckHint<'r>,
 ) -> RResult<()> {
   match hint {
@@ -49,7 +49,7 @@ fn check_vars_in_rewriter<'r>(
   utils: &'r RuleRegistration,
   constraints: &'r HashMap<String, Rule>,
   transform: &'r Option<Transform>,
-  fixer: &Option<Fixer>,
+  fixer: &Vec<Fixer>,
   upper_var: &HashSet<&str>,
 ) -> RResult<()> {
   let vars = get_vars_from_rules(rule, utils);
@@ -75,7 +75,7 @@ fn check_vars<'r>(
   utils: &'r RuleRegistration,
   constraints: &'r HashMap<String, Rule>,
   transform: &'r Option<Transform>,
-  fixer: &Option<Fixer>,
+  fixer: &Vec<Fixer>,
 ) -> RResult<()> {
   let vars = get_vars_from_rules(rule, utils);
   let vars = check_var_in_constraints(vars, constraints)?;
@@ -140,13 +140,12 @@ fn check_var_in_transform<'r>(
   Ok(vars)
 }
 
-fn check_var_in_fix(vars: HashSet<&str>, fixer: &Option<Fixer>) -> RResult<()> {
-  let Some(fixer) = fixer else {
-    return Ok(());
-  };
-  for var in fixer.used_vars() {
-    if !vars.contains(&var) {
-      return Err(RuleCoreError::UndefinedMetaVar(var.to_string(), "fix"));
+fn check_var_in_fix(vars: HashSet<&str>, fixers: &Vec<Fixer>) -> RResult<()> {
+  for fixer in fixers {
+    for var in fixer.used_vars() {
+      if !vars.contains(&var) {
+        return Err(RuleCoreError::UndefinedMetaVar(var.to_string(), "fix"));
+      }
     }
   }
   Ok(())

--- a/crates/config/src/check_var.rs
+++ b/crates/config/src/check_var.rs
@@ -1,4 +1,4 @@
-use crate::fixer::Fixer;
+use crate::fixer::{Fixer, FixerError};
 use crate::rule::referent_rule::RuleRegistration;
 use crate::rule::Rule;
 use crate::rule_config::RuleConfigError;
@@ -37,6 +37,9 @@ pub fn check_rule_with_hint<'r>(
     }
     // upper_vars is needed to check metavar defined in containing vars
     CheckHint::Rewriter(upper_vars) => {
+      if fixer.is_empty() {
+        return Err(RuleCoreError::Fixer(FixerError::InvalidRewriter));
+      }
       check_utils_defined(rule, constraints)?;
       check_vars_in_rewriter(rule, utils, constraints, transform, fixer, upper_vars)?;
     }

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -223,13 +223,13 @@ impl<L: Language> RuleConfig<L> {
     let bytes = parsed.generate_replacement(node);
     <D::Source as Content>::encode_bytes(&bytes).to_string()
   }
-  pub fn get_fixer(&self) -> Result<Option<Fixer>, RuleConfigError> {
+  pub fn get_fixer(&self) -> Result<Vec<Fixer>, RuleConfigError> {
     if let Some(fix) = &self.fix {
       let env = self.matcher.get_env(self.language.clone());
       let parsed = Fixer::parse(fix, &env, &self.transform).map_err(RuleCoreError::Fixer)?;
-      Ok(Some(parsed))
+      Ok(parsed)
     } else {
-      Ok(None)
+      Ok(vec![])
     }
   }
   pub fn get_labels<'t, D: Doc>(&self, node: &NodeMatch<'t, D>) -> Vec<Label<'_, 't, D>> {
@@ -433,7 +433,7 @@ test-rule:
     let mut config = get_matches_config();
     config.fix = Some(from_str("string!!").unwrap());
     let rule = RuleConfig::try_from(config, &globals).unwrap();
-    let fixer = rule.get_fixer().unwrap().unwrap();
+    let fixer = rule.get_fixer().unwrap().remove(0);
     let grep = TypeScript::Tsx.ast_grep("some(123)");
     let nm = grep.root().find(&rule.matcher).unwrap();
     let replacement = fixer.generate_replacement(&nm);

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -87,12 +87,12 @@ impl SerializableRuleCore {
     Ok(constraints)
   }
 
-  fn get_fixer<L: Language>(&self, env: &DeserializeEnv<L>) -> RResult<Option<Fixer>> {
+  fn get_fixer<L: Language>(&self, env: &DeserializeEnv<L>) -> RResult<Vec<Fixer>> {
     if let Some(fix) = &self.fix {
       let parsed = Fixer::parse(fix, env, &self.transform)?;
-      Ok(Some(parsed))
+      Ok(parsed)
     } else {
-      Ok(None)
+      Ok(vec![])
     }
   }
 
@@ -142,7 +142,7 @@ pub struct RuleCore {
   constraints: HashMap<String, Rule>,
   kinds: Option<BitSet>,
   pub(crate) transform: Option<Transform>,
-  pub fixer: Option<Fixer>,
+  pub fixer: Vec<Fixer>,
   // this is required to hold util rule reference
   registration: RuleRegistration,
 }
@@ -180,7 +180,7 @@ impl RuleCore {
   }
 
   #[inline]
-  pub fn with_fixer(self, fixer: Option<Fixer>) -> Self {
+  pub fn with_fixer(self, fixer: Vec<Fixer>) -> Self {
     Self { fixer, ..self }
   }
 
@@ -258,7 +258,7 @@ impl Default for RuleCore {
       constraints: HashMap::default(),
       kinds: None,
       transform: None,
-      fixer: None,
+      fixer: vec![],
       registration: RuleRegistration::default(),
     }
   }

--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -115,7 +115,7 @@ fn replace_one<'n, D: Doc>(
       // in future, we can use the explict `expose` to control env inheritance
       if let Some(n) = rule.do_match(child.clone(), &mut env, Some(ctx.enclosing_env)) {
         let nm = NodeMatch::new(n, env.into_owned());
-        edits.push(nm.make_edit(rule, rule.fixer.as_ref().expect("rewriter must have fix")));
+        edits.push(nm.make_edit(rule, rule.fixer.first().expect("rewriter must have fix")));
         // stop at first fix, skip duplicate fix
         break;
       }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -421,7 +421,8 @@ impl<L: LSPLang> Backend<L> {
           return None;
         }
         let rewrite_data = RewriteData::from_value(d.data?)?;
-        let edit = TextEdit::new(d.range, rewrite_data.fixed);
+        let fixed = rewrite_data.fixers.first()?.fixed.to_string();
+        let edit = TextEdit::new(d.range, fixed);
         last = d.range.end;
         Some(edit)
       })
@@ -478,6 +479,7 @@ impl<L: LSPLang> Backend<L> {
           .unwrap_or(false)
       })
       .filter_map(|d| diagnostic_to_code_action(&text_doc, d))
+      .flatten()
       .map(CodeActionOrCommand::from)
       .collect();
     Some(response)

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -27,7 +27,7 @@ impl RewriteData {
     node_match: &NodeMatch<StrDoc<L>>,
     rule: &RuleConfig<L>,
   ) -> Option<Self> {
-    let fixer = rule.matcher.fixer.as_ref()?;
+    let fixer = rule.matcher.fixer.first()?;
     let edit = node_match.replace_by(fixer);
     let rewrite = String::from_utf8(edit.inserted_text).ok()?;
     Some(Self { fixed: rewrite })


### PR DESCRIPTION
fix #1603 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for rules with multiple fixers, allowing a rule to specify and use more than one fixer.
  - Introduced an optional title field for fixers to provide descriptive labels.

- **Bug Fixes**
  - Improved handling and validation of fixers across configuration, scanning, and rewriting processes.

- **Refactor**
  - Updated internal logic and APIs to treat fixers as collections instead of single values, ensuring consistent handling throughout the application.
  - Enhanced code actions to support multiple fixes with titles for better user clarity.
  - Improved note rendering for rules to support richer formatting in printed outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->