### PR TITLE
Refactor lsp tests to allow more realistic testing, add test lsp client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,18 @@ dependencies = [
  "backtrace",
  "bytes",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -31,4 +31,6 @@ tokio = { version = "1.45.0", features = [
   "rt-multi-thread",
   "io-std",
   "io-util",
+  "macros",
+  "time",
 ] }

--- a/crates/lsp/tests/lsp_client.rs
+++ b/crates/lsp/tests/lsp_client.rs
@@ -1,0 +1,193 @@
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::mpsc;
+use tower_lsp_server::lsp_types::{request::Request, notification::Notification};
+
+#[derive(Debug)]
+pub enum LspError {
+  ChannelClosed,
+}
+
+mod jsonrpc {
+  use serde_json::Value;
+
+  pub fn format_message(content: &str) -> String {
+    format!("Content-Length: {}\r\n\r\n{}", content.len(), content)
+  }
+
+  fn parse_message_from_string(input: &mut &str) -> Option<Value> {
+    let input_str = input.trim_start().trim_start_matches("Content-Length: ");
+
+    let index = input_str.find('\r')?;
+    let length = input_str[..index].parse::<usize>().ok()?;
+    let input_str = &input_str[length.to_string().len()..];
+
+    let input_str = input_str.trim_start_matches("\r\n\r\n");
+
+    let body = &input_str[..length];
+    let value = serde_json::from_str(&body[..length]).ok()?;
+    *input = &input_str[length..];
+    value
+  }
+
+  pub fn parse_messages_from_bytes(input: &[u8]) -> Vec<Value> {
+    let mut input_str = std::str::from_utf8(input).unwrap();
+    let mut messages = Vec::new();
+
+    while let Some(message) = parse_message_from_string(&mut input_str) {
+      messages.push(message);
+    }
+    messages
+  }
+}
+
+pub struct LspStreams {
+  pub request_stream: DuplexStream,
+  pub response_stream: DuplexStream,
+}
+
+pub struct LspClient {
+  request_sender: mpsc::UnboundedSender<String>,
+  next_id: i32,
+  message_receiver: mpsc::UnboundedReceiver<Value>,
+}
+
+impl LspClient {
+  pub fn new(streams: LspStreams) -> Self {
+    let (message_sender, message_receiver) = mpsc::unbounded_channel();
+    let (request_sender, mut request_receiver) = mpsc::unbounded_channel::<String>();
+    
+    
+    tokio::spawn(async move {
+      let mut resp_client = streams.response_stream;
+      let mut req_client = streams.request_stream;
+      loop {
+        tokio::select! {
+          // Handle outgoing requests from main thread
+          Some(request_str) = request_receiver.recv() => {
+            if req_client.write_all(request_str.as_bytes()).await.is_err() {
+              break;
+            }
+          }
+          
+          // Handle incoming responses from server
+          read_result = async {
+            let mut buf = vec![0; 1024];
+            let result = resp_client.read(&mut buf).await;
+            (result, buf)
+          } => {
+            let (result, buf) = read_result;
+            match result {
+              Ok(0) => break, // Connection closed
+              Ok(_) => {
+                let messages = jsonrpc::parse_messages_from_bytes(&buf);
+                
+                for message in messages {
+                  if message_sender.send(message).is_err() {
+                    break;
+                  }
+                }
+              }
+              Err(_) => break, // Read error
+            }
+          }
+        }
+      }
+    });
+
+    LspClient {
+      request_sender,
+      next_id: 1,
+      message_receiver,
+    }
+  }
+
+  fn send_message<T: serde::Serialize>(&mut self, message: T) {
+    let message_json = serde_json::to_string(&message).unwrap();
+    let message_str = jsonrpc::format_message(&message_json);
+    self.request_sender.send(message_str).unwrap();
+  }
+
+  pub fn send_request<R: Request>(&mut self, params: R::Params) -> i32
+  where
+    R::Params: serde::Serialize,
+  {
+    let id = self.next_id;
+    self.next_id += 1;
+    
+    let request = serde_json::json!({
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": R::METHOD,
+      "params": params
+    });
+
+    self.send_message(request);
+    id
+  }
+
+
+  pub fn send_response<R: Request>(&mut self, id: i32, result: R::Result)
+  where
+    R::Result: serde::Serialize,
+  {
+    let response = serde_json::json!({
+      "jsonrpc": "2.0",
+      "id": id,
+      "result": result
+    });
+
+    self.send_message(response);
+  }
+
+  pub fn send_notification<N: Notification>(&mut self, params: N::Params)
+  where
+    N::Params: serde::Serialize,
+  {
+    let notification = serde_json::json!({
+      "jsonrpc": "2.0",
+      "method": N::METHOD,
+      "params": params
+    });
+
+    self.send_message(notification);
+  }
+
+  pub async fn wait_for_message(&mut self) -> Result<Value, LspError> {
+    self.message_receiver.recv().await.ok_or(LspError::ChannelClosed)
+  }
+
+  pub async fn wait_for_response<R: Request>(&mut self, id: i32) -> Result<R::Result, LspError>
+  where
+    R::Result: serde::de::DeserializeOwned,
+  {
+    loop {
+      let message = self.wait_for_message().await?;
+      
+      // Check if it's a response (has id, no method) with matching ID
+      if message.get("method").is_none() {
+        if let Some(response_id) = message.get("id").and_then(|v| v.as_i64()).filter(|&rid| rid as i32 == id) {
+          if let Some(result) = message.get("result") {
+            return serde_json::from_value(result.clone())
+              .map_err(|_| LspError::ChannelClosed);
+          }
+        }
+      }
+    }
+  }
+
+  pub async fn wait_for_server_request<R: Request>(&mut self) -> Result<R::Params, LspError>
+  where
+    R::Params: serde::de::DeserializeOwned,
+  {
+    loop {
+      let message = self.wait_for_message().await?;
+      if message.get("method").and_then(|v| v.as_str()) == Some(R::METHOD) {
+        if let Some(params) = message.get("params") {
+          return serde_json::from_value(params.clone())
+            .map_err(|_| LspError::ChannelClosed); // Could add a new error variant for deserialization
+        }
+      }
+    }
+  }
+}

--- a/crates/lsp/tests/lsp_client/jsonrpc.rs
+++ b/crates/lsp/tests/lsp_client/jsonrpc.rs
@@ -62,11 +62,11 @@ pub fn try_parse_request(message: &Value) -> Option<JsonRpcRequest> {
   if !is_request(message) {
     return None;
   }
-  
+
   let id = message.get("id")?.as_i64()?;
   let method = message.get("method")?.as_str()?.to_string();
   let params = message.get("params").cloned().unwrap_or(Value::Null);
-  
+
   Some(JsonRpcRequest { id, method, params })
 }
 
@@ -74,11 +74,11 @@ pub fn try_parse_response(message: &Value) -> Option<JsonRpcResponse> {
   if !is_response(message) {
     return None;
   }
-  
+
   let id = message.get("id")?.as_i64()?;
   let result = message.get("result").cloned();
   let error = message.get("error").cloned();
-  
+
   Some(JsonRpcResponse { id, result, error })
 }
 
@@ -86,9 +86,9 @@ pub fn try_parse_notification(message: &Value) -> Option<JsonRpcNotification> {
   if !is_notification(message) {
     return None;
   }
-  
+
   let method = message.get("method")?.as_str()?.to_string();
   let params = message.get("params").cloned().unwrap_or(Value::Null);
-  
+
   Some(JsonRpcNotification { method, params })
 }

--- a/crates/lsp/tests/lsp_client/jsonrpc.rs
+++ b/crates/lsp/tests/lsp_client/jsonrpc.rs
@@ -1,0 +1,94 @@
+use serde_json::Value;
+
+pub fn format_message(content: &str) -> String {
+  format!("Content-Length: {}\r\n\r\n{}", content.len(), content)
+}
+
+fn parse_message_from_string(input: &mut &str) -> Option<Value> {
+  let input_str = input.trim_start().trim_start_matches("Content-Length: ");
+
+  let index = input_str.find('\r')?;
+  let length = input_str[..index].parse::<usize>().ok()?;
+  let input_str = &input_str[length.to_string().len()..];
+
+  let input_str = input_str.trim_start_matches("\r\n\r\n");
+
+  let body = &input_str[..length];
+  let value = serde_json::from_str(&body[..length]).ok()?;
+  *input = &input_str[length..];
+  value
+}
+
+pub fn parse_messages_from_bytes(input: &[u8]) -> Vec<Value> {
+  let mut input_str = std::str::from_utf8(input).unwrap();
+  let mut messages = Vec::new();
+
+  while let Some(message) = parse_message_from_string(&mut input_str) {
+    messages.push(message);
+  }
+  messages
+}
+
+pub fn is_request(message: &Value) -> bool {
+  message.get("method").is_some() && message.get("id").is_some()
+}
+
+pub fn is_response(message: &Value) -> bool {
+  message.get("method").is_none() && message.get("id").is_some()
+}
+
+pub fn is_notification(message: &Value) -> bool {
+  message.get("method").is_some() && message.get("id").is_none()
+}
+
+pub struct JsonRpcRequest {
+  pub id: i64,
+  pub method: String,
+  pub params: Value,
+}
+
+pub struct JsonRpcResponse {
+  pub id: i64,
+  pub result: Option<Value>,
+  pub error: Option<Value>,
+}
+
+pub struct JsonRpcNotification {
+  pub method: String,
+  pub params: Value,
+}
+
+pub fn try_parse_request(message: &Value) -> Option<JsonRpcRequest> {
+  if !is_request(message) {
+    return None;
+  }
+  
+  let id = message.get("id")?.as_i64()?;
+  let method = message.get("method")?.as_str()?.to_string();
+  let params = message.get("params").cloned().unwrap_or(Value::Null);
+  
+  Some(JsonRpcRequest { id, method, params })
+}
+
+pub fn try_parse_response(message: &Value) -> Option<JsonRpcResponse> {
+  if !is_response(message) {
+    return None;
+  }
+  
+  let id = message.get("id")?.as_i64()?;
+  let result = message.get("result").cloned();
+  let error = message.get("error").cloned();
+  
+  Some(JsonRpcResponse { id, result, error })
+}
+
+pub fn try_parse_notification(message: &Value) -> Option<JsonRpcNotification> {
+  if !is_notification(message) {
+    return None;
+  }
+  
+  let method = message.get("method")?.as_str()?.to_string();
+  let params = message.get("params").cloned().unwrap_or(Value::Null);
+  
+  Some(JsonRpcNotification { method, params })
+}

--- a/crates/lsp/tests/lsp_client/mod.rs
+++ b/crates/lsp/tests/lsp_client/mod.rs
@@ -1,44 +1,15 @@
 use serde_json::Value;
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::sync::mpsc;
 use tower_lsp_server::lsp_types::{request::Request, notification::Notification};
+use dashmap::DashMap;
+
+mod jsonrpc;
 
 #[derive(Debug)]
 pub enum LspError {
   ChannelClosed,
-}
-
-mod jsonrpc {
-  use serde_json::Value;
-
-  pub fn format_message(content: &str) -> String {
-    format!("Content-Length: {}\r\n\r\n{}", content.len(), content)
-  }
-
-  fn parse_message_from_string(input: &mut &str) -> Option<Value> {
-    let input_str = input.trim_start().trim_start_matches("Content-Length: ");
-
-    let index = input_str.find('\r')?;
-    let length = input_str[..index].parse::<usize>().ok()?;
-    let input_str = &input_str[length.to_string().len()..];
-
-    let input_str = input_str.trim_start_matches("\r\n\r\n");
-
-    let body = &input_str[..length];
-    let value = serde_json::from_str(&body[..length]).ok()?;
-    *input = &input_str[length..];
-    value
-  }
-
-  pub fn parse_messages_from_bytes(input: &[u8]) -> Vec<Value> {
-    let mut input_str = std::str::from_utf8(input).unwrap();
-    let mut messages = Vec::new();
-
-    while let Some(message) = parse_message_from_string(&mut input_str) {
-      messages.push(message);
-    }
-    messages
-  }
 }
 
 pub struct LspStreams {
@@ -46,17 +17,21 @@ pub struct LspStreams {
   pub response_stream: DuplexStream,
 }
 
+type Handler = Box<dyn Fn(Value) -> Value + Send + Sync>;
+
 pub struct LspClient {
   request_sender: mpsc::UnboundedSender<String>,
   next_id: i32,
   message_receiver: mpsc::UnboundedReceiver<Value>,
+  handlers: Arc<DashMap<String, Handler>>,
 }
 
 impl LspClient {
   pub fn new(streams: LspStreams) -> Self {
     let (message_sender, message_receiver) = mpsc::unbounded_channel();
     let (request_sender, mut request_receiver) = mpsc::unbounded_channel::<String>();
-    
+    let handlers = Arc::new(DashMap::<String, Handler>::new());
+    let handlers_clone = handlers.clone();
     
     tokio::spawn(async move {
       let mut resp_client = streams.response_stream;
@@ -77,18 +52,36 @@ impl LspClient {
             (result, buf)
           } => {
             let (result, buf) = read_result;
-            match result {
-              Ok(0) => break, // Connection closed
-              Ok(_) => {
-                let messages = jsonrpc::parse_messages_from_bytes(&buf);
-                
-                for message in messages {
-                  if message_sender.send(message).is_err() {
+            if let Ok(0) | Err(_) = result {
+              break;
+            }
+
+            let messages = jsonrpc::parse_messages_from_bytes(&buf);
+            
+            for message in messages {
+              // Check if it's a server request and try to handle it
+              if let Some(request) = jsonrpc::try_parse_request(&message) {
+                if let Some(handler) = handlers_clone.get(&request.method) {
+                  let result = handler(request.params);
+                  let response = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": request.id,
+                    "result": result
+                  });
+                  let response_json = serde_json::to_string(&response).unwrap();
+                  let response_str = jsonrpc::format_message(&response_json);
+                  
+                  if req_client.write_all(response_str.as_bytes()).await.is_err() {
                     break;
                   }
+                  continue; // Don't forward handled requests to main thread
                 }
               }
-              Err(_) => break, // Read error
+              
+              // Forward unhandled messages to main thread
+              if message_sender.send(message).is_err() {
+                break;
+              }
             }
           }
         }
@@ -99,6 +92,7 @@ impl LspClient {
       request_sender,
       next_id: 1,
       message_receiver,
+      handlers,
     }
   }
 
@@ -164,16 +158,28 @@ impl LspClient {
     loop {
       let message = self.wait_for_message().await?;
       
-      // Check if it's a response (has id, no method) with matching ID
-      if message.get("method").is_none() {
-        if let Some(response_id) = message.get("id").and_then(|v| v.as_i64()).filter(|&rid| rid as i32 == id) {
-          if let Some(result) = message.get("result") {
-            return serde_json::from_value(result.clone())
-              .map_err(|_| LspError::ChannelClosed);
-          }
+      // Check if it's a response with matching ID
+      if let Some(response) = jsonrpc::try_parse_response(&message) {
+        if response.id as i32 == id && response.result.is_some() {
+          return serde_json::from_value(response.result.unwrap())
+            .map_err(|_| LspError::ChannelClosed);
         }
       }
     }
+  }
+
+  pub fn add_handler<R: Request, F>(&mut self, handler: F)
+  where
+    R::Params: serde::de::DeserializeOwned,
+    R::Result: serde::Serialize,
+    F: Fn(R::Params) -> R::Result + Send + Sync + 'static,
+  {
+    let wrapper = Box::new(move |params_value: Value| -> Value {
+      let params: R::Params = serde_json::from_value(params_value).unwrap();
+      let result = handler(params);
+      serde_json::to_value(result).unwrap()
+    });
+    self.handlers.insert(R::METHOD.to_string(), wrapper);
   }
 
   pub async fn wait_for_server_request<R: Request>(&mut self) -> Result<R::Params, LspError>
@@ -182,9 +188,9 @@ impl LspClient {
   {
     loop {
       let message = self.wait_for_message().await?;
-      if message.get("method").and_then(|v| v.as_str()) == Some(R::METHOD) {
-        if let Some(params) = message.get("params") {
-          return serde_json::from_value(params.clone())
+      if let Some(request) = jsonrpc::try_parse_request(&message) {
+        if request.method == R::METHOD {
+          return serde_json::from_value(request.params)
             .map_err(|_| LspError::ChannelClosed); // Could add a new error variant for deserialization
         }
       }

--- a/crates/lsp/tests/lsp_client/mod.rs
+++ b/crates/lsp/tests/lsp_client/mod.rs
@@ -1,15 +1,17 @@
+use dashmap::DashMap;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::sync::mpsc;
-use tower_lsp_server::lsp_types::{request::Request, notification::Notification};
-use dashmap::DashMap;
+use tokio::time::{timeout, Duration};
+use tower_lsp_server::lsp_types::{notification::Notification, request::Request};
 
-mod jsonrpc;
+pub mod jsonrpc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum LspError {
   ChannelClosed,
+  Timeout,
 }
 
 pub struct LspStreams {
@@ -21,7 +23,7 @@ type Handler = Box<dyn Fn(Value) -> Value + Send + Sync>;
 
 pub struct LspClient {
   request_sender: mpsc::UnboundedSender<String>,
-  next_id: i32,
+  next_id: i64,
   message_receiver: mpsc::UnboundedReceiver<Value>,
   handlers: Arc<DashMap<String, Handler>>,
 }
@@ -32,7 +34,7 @@ impl LspClient {
     let (request_sender, mut request_receiver) = mpsc::unbounded_channel::<String>();
     let handlers = Arc::new(DashMap::<String, Handler>::new());
     let handlers_clone = handlers.clone();
-    
+
     tokio::spawn(async move {
       let mut resp_client = streams.response_stream;
       let mut req_client = streams.request_stream;
@@ -40,11 +42,17 @@ impl LspClient {
         tokio::select! {
           // Handle outgoing requests from main thread
           Some(request_str) = request_receiver.recv() => {
+            // Debug log outgoing message
+            let messages = jsonrpc::parse_messages_from_bytes(request_str.as_bytes());
+            for message in &messages {
+              log_message(message, "SENT");
+            }
+
             if req_client.write_all(request_str.as_bytes()).await.is_err() {
               break;
             }
           }
-          
+
           // Handle incoming responses from server
           read_result = async {
             let mut buf = vec![0; 1024];
@@ -57,8 +65,11 @@ impl LspClient {
             }
 
             let messages = jsonrpc::parse_messages_from_bytes(&buf);
-            
+
             for message in messages {
+              // Debug log incoming message
+              log_message(&message, "RECV");
+
               // Check if it's a server request and try to handle it
               if let Some(request) = jsonrpc::try_parse_request(&message) {
                 if let Some(handler) = handlers_clone.get(&request.method) {
@@ -70,14 +81,17 @@ impl LspClient {
                   });
                   let response_json = serde_json::to_string(&response).unwrap();
                   let response_str = jsonrpc::format_message(&response_json);
-                  
+
+                  // Debug log outgoing response
+                  log_handler_response(request.id);
+
                   if req_client.write_all(response_str.as_bytes()).await.is_err() {
                     break;
                   }
                   continue; // Don't forward handled requests to main thread
                 }
               }
-              
+
               // Forward unhandled messages to main thread
               if message_sender.send(message).is_err() {
                 break;
@@ -102,13 +116,13 @@ impl LspClient {
     self.request_sender.send(message_str).unwrap();
   }
 
-  pub fn send_request<R: Request>(&mut self, params: R::Params) -> i32
+  pub fn send_request<R: Request>(&mut self, params: R::Params) -> i64
   where
     R::Params: serde::Serialize,
   {
     let id = self.next_id;
     self.next_id += 1;
-    
+
     let request = serde_json::json!({
       "jsonrpc": "2.0",
       "id": id,
@@ -120,8 +134,7 @@ impl LspClient {
     id
   }
 
-
-  pub fn send_response<R: Request>(&mut self, id: i32, result: R::Result)
+  pub fn send_response<R: Request>(&mut self, id: i64, result: R::Result)
   where
     R::Result: serde::Serialize,
   {
@@ -148,24 +161,31 @@ impl LspClient {
   }
 
   pub async fn wait_for_message(&mut self) -> Result<Value, LspError> {
-    self.message_receiver.recv().await.ok_or(LspError::ChannelClosed)
+    timeout(Duration::from_secs(10), self.message_receiver.recv())
+      .await
+      .map_err(|_| LspError::Timeout)?
+      .ok_or(LspError::ChannelClosed)
   }
 
-  pub async fn wait_for_response<R: Request>(&mut self, id: i32) -> Result<R::Result, LspError>
+  pub async fn wait_for_response<R: Request>(&mut self, id: i64) -> Result<R::Result, LspError>
   where
     R::Result: serde::de::DeserializeOwned,
   {
-    loop {
-      let message = self.wait_for_message().await?;
-      
-      // Check if it's a response with matching ID
-      if let Some(response) = jsonrpc::try_parse_response(&message) {
-        if response.id as i32 == id && response.result.is_some() {
+    timeout(Duration::from_secs(10), async {
+      loop {
+        let message = self.wait_for_message().await?;
+
+        // Check if it's a response with matching ID
+        if let Some(response) =
+          jsonrpc::try_parse_response(&message).filter(|r| r.id == id && r.result.is_some())
+        {
           return serde_json::from_value(response.result.unwrap())
             .map_err(|_| LspError::ChannelClosed);
         }
       }
-    }
+    })
+    .await
+    .map_err(|_| LspError::Timeout)?
   }
 
   pub fn add_handler<R: Request, F>(&mut self, handler: F)
@@ -186,14 +206,46 @@ impl LspClient {
   where
     R::Params: serde::de::DeserializeOwned,
   {
-    loop {
-      let message = self.wait_for_message().await?;
-      if let Some(request) = jsonrpc::try_parse_request(&message) {
-        if request.method == R::METHOD {
-          return serde_json::from_value(request.params)
-            .map_err(|_| LspError::ChannelClosed); // Could add a new error variant for deserialization
+    timeout(Duration::from_secs(10), async {
+      loop {
+        let message = self.wait_for_message().await?;
+        if let Some(request) =
+          jsonrpc::try_parse_request(&message).filter(|req| req.method == R::METHOD)
+        {
+          return serde_json::from_value(request.params).map_err(|_| LspError::ChannelClosed);
+          // Could add a new error variant for deserialization
         }
       }
-    }
+    })
+    .await
+    .map_err(|_| LspError::Timeout)?
+  }
+}
+
+fn log_message(message: &Value, direction: &str) {
+  if cfg!(test) {
+    let message_type = if jsonrpc::is_request(message) {
+      "request"
+    } else if jsonrpc::is_response(message) {
+      "response"
+    } else {
+      "notification"
+    };
+    eprintln!(
+      "LSP_CLIENT {} {}: {} (id: {:?})",
+      direction,
+      message_type,
+      message
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("N/A"),
+      message.get("id").and_then(|v| v.as_i64())
+    );
+  }
+}
+
+fn log_handler_response(id: i64) {
+  if cfg!(test) {
+    eprintln!("LSP_CLIENT SENT response: N/A (id: {})", id);
   }
 }


### PR DESCRIPTION
⚠️ DRAFT PR. NOT COMPLETE. Also mainly just want feedback. ⚠️ 

OH MY GOD NO THERE'S DEBUG LOGGING LEFT IN THERE UGH I NEED TO REMOVE THAT

Looked at the codecov and saw the LSP tests were lacking coverage so I was like "let's try and improve that". A few hours later I realized that is not very easy to do because it's difficult to write more realistic tests for this thing lol.

This PR does a few things:

- JSON RPC-related functions `req` and stuff) get their own module and get a little more fleshed out.
- This adds a generic LSP client that behaves more like an LSP client and adds a few things:
  - Sending / receiving happens in a background thread (important for reasons explained later).
  - **NOT IMPLEMENTED YET**: A vec of all the requests / responses sent so that you can assert that a specific command was sent.
  - Timeouts while you're waiting for a command - this ensures tests don't hang.
  - _Handlers_ are functions that take a specific request type from the _server to the client_, and return the response to the server.
  - Requests, responses, etc. can be sent using the typed structs from `lsp_types`. Thanks to the nice trait there the response types are also inferred!
  - Message logging (requests, responses, notifications) when tests fail (also important for reasons below).

## Why is a separate thread needed for sending / receiving messages?

As I learned, LSP clients are not just API wrappers, they're their own mini-server. When you send a request to the LSP server, the LSP server can send requests back to you while you're waiting on the response from it, and you need to be able to answer them. This is exactly what the LSP server currently does: in the last test, when the `ast-grep.applyAllFixes` method is sent, the server sends a request to the client asking what the current workspace folders are (so it can filter files outside of it or whatever). If the client doesn't respond, the entire thing hangs and nothing happens.

To fix this, I created a background thread that handles all reads / writes to the client. Then I added _handlers_, which run in the background thread basically as mock responses. Handlers can be set up at the start of the test, and then the rest of the test can use a nice async / await syntax so that things are nice and simpler. This keeps the tests uncoupled from the order that the commands are sent in. That means you can safely send a request using `.send_request` and then do `wait_for_server_response` or something after that. 

## Why use a separate LSP client struct thing?

Because it makes debugging a LOT easier. Knowing the request / response order of the LSP client / server is important as it turns out to be able to figure out what is actually going on. (You can see my manic attempts at adding eprintlns everywhere to try to find out what's happening). Having logging in the client built-in (so you can see everything sent and received by the client) is VERY helpful.

On top of that, this mimics VSCode behavior a little more directly. eg. now we send an `openFile` notification or whatever to make sure the file is opened and actually processed.

Also once I add a vec of all the messages sent and received, this will allow the tests to be able to assert after the setup is done that the right things (like `applyFile`) are sent back.

## Am I overcomplicating things?

Probably. Idk if this is necessary or not, that's why I'm putting it up as a draft PR. Pls ignore changes to the code (not the tests) cause I'll be undoing those before this PR is actually actually done. But just wanted to get this up for early feedback to see if this is desired at all or if I'm wasting time 😅 