### PR TITLE
Replace shim comment text with echo/exit

### DIFF
--- a/npm/ast-grep
+++ b/npm/ast-grep
@@ -1,2 +1,3 @@
-This file is required so that dumb npm creates the ast-grep binary.
-N.B. pnpm does not have this issue.
+echo "ast-grep shim file was executed. This file exists so that npm tries to create the binary. It should be replaced after the 'postinstall' script is executed."
+echo "Did your package manager execute the post-install script? (N.B. not all of them do)"
+exit 1


### PR DESCRIPTION
👋 I thought I'd give [`bun`](https://bun.sh/) a try and was confused by:

```terminal
josh $ bun run ast-grep scan 
/path/to/node_modules/.bin/ast-grep: line 1: This: command not found
/path/to/node_modules/.bin/ast-grep: line 2: N.B.: command not found
```

I had to do some digging to find/realize that this was happening b/c the `postinstall` script wasn't executing.
Once I had that info I found https://bun.sh/docs/install/lifecycle.

So, hoping that outputting a more helpful message might alleviate other users' woes quicker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an executable script that provides clearer messaging when the shim file is run, including instructions for verifying post-install script execution and an explicit error exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->