### PR TITLE
feat: Add s390x architecture support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,6 @@ rustflags = ["-C", "target-feature=-crt-static"]
 
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"
+
+[target.s390x-unknown-linux-gnu]
+linker = "s390x-linux-gnu-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
             os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
+          - target: s390x-unknown-linux-gnu
+            os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -85,8 +87,8 @@ jobs:
           out-file-path: artifacts
       - name: Unzip packages
         run: |
-          files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu)
-          target_dir=(darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu)
+          files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu s390x-unknown-linux-gnu)
+          target_dir=(darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu linux-s390x-gnu)
           length=${#files[@]}
           for (( i=0; i<${length}; i++ ));
           do

--- a/npm/package.json
+++ b/npm/package.json
@@ -35,7 +35,8 @@
     "@ast-grep/cli-darwin-arm64": "0.38.5",
     "@ast-grep/cli-darwin-x64": "0.38.5",
     "@ast-grep/cli-linux-arm64-gnu": "0.38.5",
-    "@ast-grep/cli-linux-x64-gnu": "0.38.5"
+    "@ast-grep/cli-linux-x64-gnu": "0.38.5",
+    "@ast-grep/cli-linux-s390x-gnu": "0.38.5"
   },
   "bin": {
     "sg": "sg",

--- a/npm/platforms/linux-s390x-gnu/README.md
+++ b/npm/platforms/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@ast-grep/cli-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@ast-grep/cli`

--- a/npm/platforms/linux-s390x-gnu/package.json
+++ b/npm/platforms/linux-s390x-gnu/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@ast-grep/cli-linux-s390x-gnu",
+  "version": "0.38.5",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "files": [
+    "ast-grep"
+  ],
+  "description": "Search and Rewrite code at large scale using precise AST pattern",
+  "keywords": [
+    "ast",
+    "pattern",
+    "codemod",
+    "search",
+    "rewrite"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": "https://github.com/ast-grep/ast-grep"
+}


### PR DESCRIPTION
- Add s390x-unknown-linux-gnu target to release workflow
- Create npm platform package for s390x Linux distribution
- Update main npm package to include s390x optional dependency
- Configure cross-compilation linker for s390x builds
- Enable automated s390x binary releases via GitHub Actions

This enables first-class s390x support with the same feature parity as other supported architectures (x86_64, aarch64, etc.).

Tested on: s390x hardware with successful compilation and execution