### PR TITLE
Remove whitespace and a comment that is no longer true

### DIFF
--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -126,7 +126,7 @@ pub struct OutputArgs {
   #[clap(short = 'U', long)]
   pub update_all: bool,
 
-  /// Output matches in structured JSON .
+  /// Output matches in structured JSON.
   ///
   /// If this flag is set, ast-grep will output matches in JSON format.
   /// You can pass optional value to this flag by using `--json=<STYLE>` syntax

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -186,8 +186,6 @@ macro_rules! impl_aliases {
 
 /* Customized Language with expando_char / pre_process_pattern */
 // https://en.cppreference.com/w/cpp/language/identifiers
-// Due to some issues in the tree-sitter parser, it is not possible to use
-// unicode literals in identifiers for C/C++ parsers
 impl_lang_expando!(C, language_c, 'µ');
 impl_lang_expando!(Cpp, language_cpp, 'µ');
 // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#643-identifiers


### PR DESCRIPTION
On a separate note, do we still want to try switching to 𐀀 (U+10000) as per https://github.com/ast-grep/ast-grep/issues/2086#issuecomment-3049760141 or some other Unicode scalar value that is not as popular as µ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a minor formatting issue in a documentation comment for output arguments.
  * Removed outdated explanatory comments regarding Unicode identifier limitations in C and C++ parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->