### PR TITLE
feat(language): add hcl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-haskell",
+ "tree-sitter-hcl",
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -980,7 +981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2016,6 +2017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-html"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,7 +2290,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -78,4 +78,3 @@ napi-lang = [
   "tree-sitter-typescript",
 ]
 default = ["builtin-parser"]
-tree-sitter-hcl = ["dep:tree-sitter-hcl"]

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -41,6 +41,7 @@ tree-sitter-solidity = { version = "1.2.11", optional = true }
 tree-sitter-swift = { version = "0.7.0", optional = true }
 tree-sitter-typescript = { version = "0.23.2", optional = true }
 tree-sitter-yaml = { version = "0.7.0", optional = true }
+tree-sitter-hcl = { version = "1.1.0", optional = true }
 
 [features]
 builtin-parser = [
@@ -52,6 +53,7 @@ builtin-parser = [
   "tree-sitter-elixir",
   "tree-sitter-go",
   "tree-sitter-haskell",
+  "tree-sitter-hcl",
   "tree-sitter-html",
   "tree-sitter-java",
   "tree-sitter-javascript",
@@ -76,3 +78,4 @@ napi-lang = [
   "tree-sitter-typescript",
 ]
 default = ["builtin-parser"]
+tree-sitter-hcl = ["dep:tree-sitter-hcl"]

--- a/crates/language/src/hcl.rs
+++ b/crates/language/src/hcl.rs
@@ -1,0 +1,47 @@
+#![cfg(test)]
+use super::*;
+use crate::test::{test_match_lang,test_replace_lang};
+
+fn test_match(s1: &str, s2: &str) {
+  test_match_lang(s1, s2, Hcl)
+}
+
+#[test]
+fn test_hcl_pattern() {
+  test_match("$A = $B", "foo = \"bar\"");
+  test_match("resource $TYPE $NAME $BODY", "resource \"aws_instance\" \"example\" { ami = \"ami-123\" }");
+  test_match("$BLOCK $BODY", "terraform { required_providers { aws = { source = \"hashicorp/aws\" } } }");
+  test_match("variable $NAME $CONFIG", "variable \"region\" { default = \"us-west-2\" }");
+  test_match("output $NAME $VALUE", "output \"instance_ip\" { value = aws_instance.example.public_ip }");
+  test_match("$VAR = [$$$ITEMS]", "tags = [\"production\", \"web\"]");
+  test_match("$VAR = { $$$PAIRS }", "labels = { environment = \"prod\", team = \"backend\" }");
+  test_match("$VAR = \"$CONTENT\"", "name = \"instance\"");
+}
+
+fn test_replace(src: &str, pattern: &str, replacer: &str) -> String {
+  test_replace_lang(src, pattern, replacer, Hcl)
+}
+
+#[test]
+fn test_hcl_replace() {
+    let ret = test_replace(
+      "foo = \"bar\"",
+      "$A = $B",
+      "$B = $A"
+    );
+    assert_eq!(ret, "\"bar\" = foo");
+
+    let ret = test_replace(
+      "resource \"aws_instance\" \"example\" { ami = \"ami-123\" }",
+      "resource $TYPE $NAME $BODY",
+      "resource $NAME $TYPE $BODY",
+    );
+    assert_eq!(ret, "resource \"example\" \"aws_instance\" { ami = \"ami-123\" }");
+
+    let ret = test_replace(
+        "variable \"region\" { default = \"us-west-2\" }",
+        "variable \"region\" { default = $DEFAULT }",
+        "variable \"region\" { default = \"eu-west-1\" }",
+    );
+    assert_eq!(ret, "variable \"region\" { default = \"eu-west-1\" }");
+}

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -14,6 +14,7 @@ mod css;
 mod elixir;
 mod go;
 mod haskell;
+mod hcl;
 mod html;
 mod json;
 mod kotlin;
@@ -205,6 +206,8 @@ impl_lang_expando!(Go, language_go, 'µ');
 // https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/unicode_syntax.html
 // and the tree-sitter-haskell grammar parses it too.
 impl_lang_expando!(Haskell, language_haskell, 'µ');
+// https://developer.hashicorp.com/terraform/language/syntax/configuration#identifiers
+impl_lang_expando!(Hcl, language_hcl, 'µ');
 // https://github.com/fwcd/tree-sitter-kotlin/pull/93
 impl_lang_expando!(Kotlin, language_kotlin, 'µ');
 // Nix uses $ for string interpolation (e.g., "${pkgs.hello}")
@@ -249,6 +252,7 @@ pub enum SupportLang {
   Go,
   Elixir,
   Haskell,
+  Hcl,
   Html,
   Java,
   JavaScript,
@@ -272,7 +276,7 @@ impl SupportLang {
   pub const fn all_langs() -> &'static [SupportLang] {
     use SupportLang::*;
     &[
-      Bash, C, Cpp, CSharp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
+      Bash, C, Cpp, CSharp, Css, Elixir, Go, Haskell, Hcl, Html, Java, JavaScript, Json, Kotlin, Lua,
       Nix, Php, Python, Ruby, Rust, Scala, Solidity, Swift, Tsx, TypeScript, Yaml,
     ]
   }
@@ -362,6 +366,7 @@ impl_aliases! {
   Elixir => &["ex", "elixir"],
   Go => &["go", "golang"],
   Haskell => &["hs", "haskell"],
+  Hcl => &["hcl"],
   Html => &["html"],
   Java => &["java"],
   JavaScript => &["javascript", "js", "jsx"],
@@ -408,6 +413,7 @@ macro_rules! execute_lang_method {
       S::Elixir => Elixir.$method($($pname,)*),
       S::Go => Go.$method($($pname,)*),
       S::Haskell => Haskell.$method($($pname,)*),
+      S::Hcl => Hcl.$method($($pname,)*),
       S::Html => Html.$method($($pname,)*),
       S::Java => Java.$method($($pname,)*),
       S::JavaScript => JavaScript.$method($($pname,)*),
@@ -479,6 +485,7 @@ fn extensions(lang: SupportLang) -> &'static [&'static str] {
     Elixir => &["ex", "exs"],
     Go => &["go"],
     Haskell => &["hs"],
+    Hcl => &["hcl"],
     Html => &["html", "htm", "xhtml"],
     Java => &["java"],
     JavaScript => &["cjs", "js", "mjs", "jsx"],

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -67,6 +67,9 @@ pub fn language_go() -> TSLanguage {
 pub fn language_haskell() -> TSLanguage {
   into_lang!(tree_sitter_haskell)
 }
+pub fn language_hcl() -> TSLanguage {
+  into_lang!(tree_sitter_hcl)
+}
 pub fn language_html() -> TSLanguage {
   into_napi_lang!(tree_sitter_html::LANGUAGE)
 }


### PR DESCRIPTION
Following #2103 and #2107 as per comment https://github.com/ast-grep/ast-grep/discussions/419#discussioncomment-13960221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for HashiCorp Configuration Language (HCL), including syntax highlighting, pattern matching, and replacement capabilities.
  * HCL files are now recognized by their file extension and can be used with language-specific features.

* **Tests**
  * Introduced tests to verify HCL pattern matching and replacement functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->