### PR TITLE
feat(cli): impl. comp-time flag for `Commands::Docs`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -61,6 +61,7 @@ enum Commands {
   /// Generate shell completion script.
   Completions(CompletionsArg),
   /// Generate rule docs for current configuration. (Not Implemented Yet)
+  #[cfg(debug_assertions)]
   Docs,
 }
 
@@ -139,6 +140,7 @@ pub fn main_with_args(args: impl Iterator<Item = String>) -> Result<()> {
     Commands::New(arg) => run_create_new(arg, project),
     Commands::Lsp(arg) => run_language_server(arg, project),
     Commands::Completions(arg) => run_shell_completion::<App>(arg),
+    #[cfg(debug_assertions)]
     Commands::Docs => todo!("todo, generate rule docs based on current config"),
   }
 }


### PR DESCRIPTION
## Summary 

Very small PR that implements a feature-flag/compile time macro to strip out the `Commands::Docs` enum via `#[cfg(debug_assertions)]` as it's currently marked and handled via a `todo!()`.

Instead of having an explicit path to crash the program- preferring to hide it behind a compile time flag, this ensures that the `--release` version (aka Production) doesn't compile with unnecessary code, and doesn't have an empty path-flow that crashes the program.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Restricted the experimental “docs” CLI subcommand to debug builds; it no longer appears or runs in production/release binaries.
  - Updated CLI help/usage so the “docs” command is omitted in release builds, reducing confusion.

- Chores
  - Streamlined build configuration to clearly separate debug-only tooling from production features, with no impact on standard release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->