### PR TITLE
Fix rust-1.89 warnings about mismatched lifetimes

### DIFF
--- a/crates/cli/src/print/colored_print/styles.rs
+++ b/crates/cli/src/print/colored_print/styles.rs
@@ -102,7 +102,7 @@ impl PrintStyles {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn adjust_dir_separator(p: &Path) -> Cow<str> {
+fn adjust_dir_separator(p: &Path) -> Cow<'_, str> {
   p.to_string_lossy()
 }
 

--- a/crates/cli/src/verify/test_case.rs
+++ b/crates/cli/src/verify/test_case.rs
@@ -22,16 +22,16 @@ pub struct TestCase {
 }
 
 impl TestCase {
-  pub fn verify_rule(&self, rule_config: &RuleConfig<SgLang>) -> CaseResult {
+  pub fn verify_rule(&self, rule_config: &RuleConfig<SgLang>) -> CaseResult<'_> {
     debug_assert_eq!(self.id, rule_config.id);
     verify_test_case(self, rule_config)
   }
 
   pub fn verify_with_snapshot(
-    &self,
+    &'_ self,
     rule_config: &RuleConfig<SgLang>,
     snapshots: Option<&TestSnapshots>,
-  ) -> CaseResult {
+  ) -> CaseResult<'_> {
     debug_assert_eq!(self.id, rule_config.id);
     verify_test_case_with_snapshots(self, rule_config, snapshots)
   }

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -138,7 +138,7 @@ impl Suppressions {
     }
   }
 
-  fn file_suppression(&self) -> MaySuppressed {
+  fn file_suppression(&self) -> MaySuppressed<'_> {
     if let Some(sup) = &self.file {
       MaySuppressed::Yes(sup)
     } else {
@@ -146,7 +146,7 @@ impl Suppressions {
     }
   }
 
-  fn line_suppression<D: Doc>(&self, node: &Node<'_, D>) -> MaySuppressed {
+  fn line_suppression<D: Doc>(&self, node: &Node<'_, D>) -> MaySuppressed<'_> {
     let line = node.start_pos().line();
     if let Some(sup) = self.lines.get(&line) {
       MaySuppressed::Yes(sup)

--- a/crates/config/src/rule/selector.rs
+++ b/crates/config/src/rule/selector.rs
@@ -290,7 +290,7 @@ mod test {
   use crate::test::TypeScript as TS;
   use ast_grep_core::tree_sitter::LanguageExt;
 
-  fn input_to_tokens(input: &str) -> Result<Vec<Token>, SelectorError> {
+  fn input_to_tokens(input: &str) -> Result<Vec<Token<'_>>, SelectorError> {
     let mut input = Input::new(input, TS::Tsx);
     let mut tokens = Vec::new();
     while let Some(token) = input.next()? {

--- a/crates/config/src/transform/parse.rs
+++ b/crates/config/src/transform/parse.rs
@@ -41,7 +41,7 @@ struct DecomposedTransString<'a> {
   args: Vec<(&'a str, &'a str)>,
 }
 
-fn decompose_str(input: &str) -> Result<DecomposedTransString, ParseTransError> {
+fn decompose_str(input: &str) -> Result<DecomposedTransString<'_>, ParseTransError> {
   let error = || ParseTransError::Syntax(input.to_string());
   let input = input.trim();
   let (func, rest) = input.split_once('(').ok_or_else(error)?;

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -93,7 +93,7 @@ impl PatternNode {
     }
   }
 
-  pub fn fixed_string(&self) -> Cow<str> {
+  pub fn fixed_string(&self) -> Cow<'_, str> {
     match &self {
       PatternNode::Terminal { text, .. } => Cow::Borrowed(text),
       PatternNode::MetaVar { .. } => Cow::Borrowed(""),
@@ -197,7 +197,7 @@ impl Pattern {
     kind_utils::is_error_kind(kind)
   }
 
-  pub fn fixed_string(&self) -> Cow<str> {
+  pub fn fixed_string(&self) -> Cow<'_, str> {
     self.node.fixed_string()
   }
 
@@ -269,7 +269,7 @@ impl Pattern {
     };
     lang.build_pattern(&builder)
   }
-  fn single_matcher<D: Doc>(root: &Root<D>) -> Node<D> {
+  fn single_matcher<D: Doc>(root: &Root<D>) -> Node<'_, D> {
     // debug_assert!(matches!(self.style, PatternStyle::Single));
     let node = root.root();
     let mut inner = node.inner;

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -60,7 +60,7 @@ impl<D: Doc> Root<D> {
     self.doc.get_lang()
   }
   /// The root node represents the entire source
-  pub fn root(&self) -> Node<D> {
+  pub fn root(&self) -> Node<'_, D> {
     Node {
       inner: self.doc.root_node(),
       root: self,
@@ -140,7 +140,7 @@ impl<'r, D: Doc> Node<'r, D> {
   pub fn is_error(&self) -> bool {
     self.inner.is_error()
   }
-  pub fn kind(&self) -> Cow<str> {
+  pub fn kind(&self) -> Cow<'_, str> {
     self.inner.kind()
   }
   pub fn kind_id(&self) -> KindId {

--- a/crates/core/src/replacer/indent.rs
+++ b/crates/core/src/replacer/indent.rs
@@ -136,7 +136,10 @@ pub enum DeindentedExtract<'a, C: Content> {
 }
 
 /// Returns DeindentedExtract for later de-indent/re-indent.
-pub fn extract_with_deindent<C: Content>(content: &C, range: Range<usize>) -> DeindentedExtract<C> {
+pub fn extract_with_deindent<C: Content>(
+  content: &C,
+  range: Range<usize>,
+) -> DeindentedExtract<'_, C> {
   let extract_slice = content.get_range(range.clone());
   // no need to compute indentation for single line
   if !extract_slice.contains(&get_new_line::<C>()) {

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -28,7 +28,7 @@ pub struct Edit<S: Content> {
 pub trait SgNode<'r>: Clone {
   fn parent(&self) -> Option<Self>;
   fn children(&self) -> impl ExactSizeIterator<Item = Self>;
-  fn kind(&self) -> Cow<str>;
+  fn kind(&self) -> Cow<'_, str>;
   fn kind_id(&self) -> KindId;
   fn node_id(&self) -> usize;
   fn range(&self) -> std::ops::Range<usize>;
@@ -140,10 +140,10 @@ pub trait Content: Sized {
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying];
   /// Used for string replacement. We need this for
   /// indentation and deindentation.
-  fn decode_str(src: &str) -> Cow<[Self::Underlying]>;
+  fn decode_str(src: &str) -> Cow<'_, [Self::Underlying]>;
   /// Used for string replacement. We need this for
   /// transformation.
-  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<str>;
+  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<'_, str>;
   /// Get the character column at the given position
   fn get_char_column(&self, column: usize, offset: usize) -> usize;
 }
@@ -153,10 +153,10 @@ impl Content for String {
   fn get_range(&self, range: Range<usize>) -> &[Self::Underlying] {
     &self.as_bytes()[range]
   }
-  fn decode_str(src: &str) -> Cow<[Self::Underlying]> {
+  fn decode_str(src: &str) -> Cow<'_, [Self::Underlying]> {
     Cow::Borrowed(src.as_bytes())
   }
-  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<str> {
+  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<'_, str> {
     String::from_utf8_lossy(bytes)
   }
 

--- a/crates/core/src/tree_sitter/mod.rs
+++ b/crates/core/src/tree_sitter/mod.rs
@@ -199,7 +199,7 @@ impl<'r> SgNode<'r> for Node<'r> {
   fn is_leaf(&self) -> bool {
     self.child_count() == 0
   }
-  fn kind(&self) -> Cow<str> {
+  fn kind(&self) -> Cow<'_, str> {
     Cow::Borrowed(Node::kind(self))
   }
   fn kind_id(&self) -> KindId {

--- a/crates/core/src/tree_sitter/traversal.rs
+++ b/crates/core/src/tree_sitter/traversal.rs
@@ -75,7 +75,7 @@ where
 {
   pub fn visit<L: LanguageExt>(
     self,
-    node: Node<StrDoc<L>>,
+    node: Node<'_, StrDoc<L>>,
   ) -> Visit<'_, StrDoc<L>, A::Traversal<'_, L>, M>
   where
     M: Matcher,
@@ -136,20 +136,20 @@ where
 
 pub trait Algorithm {
   type Traversal<'t, L: LanguageExt>: Traversal<'t, StrDoc<L>>;
-  fn traverse<L: LanguageExt>(node: Node<StrDoc<L>>) -> Self::Traversal<'_, L>;
+  fn traverse<L: LanguageExt>(node: Node<'_, StrDoc<L>>) -> Self::Traversal<'_, L>;
 }
 
 pub struct PreOrder;
 impl Algorithm for PreOrder {
   type Traversal<'t, L: LanguageExt> = Pre<'t, L>;
-  fn traverse<L: LanguageExt>(node: Node<StrDoc<L>>) -> Self::Traversal<'_, L> {
+  fn traverse<L: LanguageExt>(node: Node<'_, StrDoc<L>>) -> Self::Traversal<'_, L> {
     Pre::new(&node)
   }
 }
 pub struct PostOrder;
 impl Algorithm for PostOrder {
   type Traversal<'t, L: LanguageExt> = Post<'t, L>;
-  fn traverse<L: LanguageExt>(node: Node<StrDoc<L>>) -> Self::Traversal<'_, L> {
+  fn traverse<L: LanguageExt>(node: Node<'_, StrDoc<L>>) -> Self::Traversal<'_, L> {
     Post::new(&node)
   }
 }

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -79,7 +79,7 @@ macro_rules! impl_lang {
   };
 }
 
-fn pre_process_pattern(expando: char, query: &str) -> std::borrow::Cow<str> {
+fn pre_process_pattern(expando: char, query: &str) -> std::borrow::Cow<'_, str> {
   let mut ret = Vec::with_capacity(query.len());
   let mut dollar_count = 0;
   for c in query.chars() {

--- a/crates/napi/src/doc.rs
+++ b/crates/napi/src/doc.rs
@@ -61,12 +61,12 @@ impl Content for Wrapper {
     let end = range.end / 2;
     &self.inner.as_slice()[start..end]
   }
-  fn decode_str(src: &str) -> Cow<[Self::Underlying]> {
+  fn decode_str(src: &str) -> Cow<'_, [Self::Underlying]> {
     let v: Vec<_> = src.encode_utf16().collect();
     Cow::Owned(v)
   }
 
-  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<str> {
+  fn encode_bytes(bytes: &[Self::Underlying]) -> Cow<'_, str> {
     let s = String::from_utf16_lossy(bytes);
     Cow::Owned(s)
   }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/138677.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized explicit lifetimes across multiple APIs to align borrowing semantics (e.g., return types using Cow and Node now include anonymous lifetimes).
  - Traversal and content-related interfaces updated to accept/return lifetime-parameterized types for consistency.
  - No runtime or behavioral changes.

- Chores
  - Minor type signature adjustments in internal tests and helpers to reflect lifetime annotations.

- Developer Impact
  - This may require small code updates for integrators to accommodate explicit lifetimes in type signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->