### PR TITLE
Document example of using ast-grep via rust API.

### DIFF
--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -6,6 +6,17 @@
 //! You need use `impl_lang_expando!` macro and a standalone file for testing.
 //! Otherwise, you can define it as a stub language using `impl_lang!`.
 //! To see the full list of languages, visit `<https://ast-grep.github.io/reference/languages.html>`
+//!
+//! ```
+//! use ast_grep_language::{LanguageExt, SupportLang};
+//!
+//! let lang: SupportLang = "rs".parse().unwrap();
+//! let src = "fn foo() {}";
+//! let root = lang.ast_grep(src);
+//! let found = root.root().find_all("fn $FNAME() {}").next().unwrap();
+//! assert_eq!(found.start_pos().line(), 0);
+//! assert_eq!(found.text(), "fn foo() {}");
+//! ```
 
 mod bash;
 mod cpp;


### PR DESCRIPTION
The Python/Javascript APIs have nice "getting started" examples here:
https://ast-grep.github.io/guide/api-usage.html

However, rust just says:

> Rust: ast-grep's Rust API is the most efficient way, but also the most challenging way, to use ast-grep. You can refer to ast_grep_core if you are familiar with Rust.

I actually don't think the the rust API is that challenging if you know where to look, but it took me a while to piece this together, and I had to use the ast-grep source code as an example. I think having a basic "get started" example for rust would be really helpful.

I think it would be nice to have this example at https://ast-grep.github.io/guide/api-usage.html as well, I can submit a PR for that too if you'd like.

Also, I had to doc this in the `language` crate even though the guide directs you to the `core` crate -- it seemed like `language` provided the "easy mode" "I just want to search stuff using the builtin languages".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved module documentation with a clear, runnable example demonstrating basic usage: parsing source, creating an AST, searching for a simple function pattern, and validating the first match. This helps new users get started quickly and increases confidence through executable docs.
  * No changes to public APIs or runtime behavior; example is provided as a doctest to ensure accuracy over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->