### PR TITLE
fix(schemas): recognize all sgconfig fields

### DIFF
--- a/schemas/project.json
+++ b/schemas/project.json
@@ -79,6 +79,15 @@
       "properties": {
         "libraryPath": {
           "type": ["string", "object"],
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          ],
           "description": "The path to the tree-sitter dynamic library of the language."
         },
         "extensions": {


### PR DESCRIPTION
When creating the root `sconfig.yaml` some fields are not recognized by the yaml lsp.

This PR adds the fields that were not recognized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom language configuration so projects can define language variants with custom extensions and attributes.
  * Added language injection support to recognize and handle embedded languages inside host language files.
  * Added language-to-file mapping to associate languages with non-standard file extensions and syntax variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->