### PR TITLE
fix(interactive_print): do not use the alternate screen without stdin

### DIFF
--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -71,18 +71,23 @@ impl InteractivePrinter {
       first_line,
       inner,
     } = highlights;
-    utils::run_in_alternate_screen(|| {
+    if self.from_stdin {
+      utils::run_in_alternate_screen(|| {
+        self.inner.process(inner)?;
+        let resp = self.prompt_view();
+        if resp == 'q' {
+          Err(anyhow::anyhow!(EC::ExitInteractiveEditing))
+        } else if resp == 'e' {
+          open_in_editor(&path, first_line)?;
+          Ok(())
+        } else {
+          Ok(())
+        }
+      })
+    } else {
       self.inner.process(inner)?;
-      let resp = self.prompt_view();
-      if resp == 'q' {
-        Err(anyhow::anyhow!(EC::ExitInteractiveEditing))
-      } else if resp == 'e' {
-        open_in_editor(&path, first_line)?;
-        Ok(())
-      } else {
-        Ok(())
-      }
-    })
+      Ok(())
+    }
   }
 
   fn process_diffs(&mut self, diffs: Diffs<Buffer>) -> Result<()> {


### PR DESCRIPTION
When using `ast-grep` in scripts, the alternate screen ends up injecting ANSI sequences which can confuse tooling not expecting to emulate a TTY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-prompt actions for interactive highlights: quick quit or open the content in your editor after viewing.

* **Bug Fixes**
  * Improved interactive editing flow when input is piped or redirected, with alternate-screen rendering for a cleaner prompt experience and correct post-prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->