### PR TITLE
docs(installation): add mise installation alternative method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Try the [online playground](https://ast-grep.github.io/playground.html) for a ta
 See more screenshots on the [website](https://ast-grep.github.io/).
 
 ## Installation
-You can install it from [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [pip](https://pypi.org/), [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html),  [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), [homebrew](https://brew.sh/), [scoop](https://scoop.sh/) or [MacPorts](https://www.macports.org)!
+You can install it from [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [pip](https://pypi.org/), [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html),  [cargo-binstall](https://github.com/cargo-bins/cargo-binstall), [homebrew](https://brew.sh/), [scoop](https://scoop.sh/), [mise](https://github.com/jdx/mise) or [MacPorts](https://www.macports.org)!
 
 ```bash
 npm install --global @ast-grep/cli
@@ -55,6 +55,9 @@ sudo port install ast-grep
 
 # try ast-grep in nix-shell
 nix-shell -p ast-grep
+
+# try ast-grep with mise
+mise use -g ast-grep
 ```
 </details>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added mise as an installation option for ast-grep, now available alongside existing package managers.
  * Included setup instructions and command examples for installing and managing ast-grep via mise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->