### PR TITLE
Reduce error size for targetting `Windows`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,5 +14,11 @@ rustflags = [
 linker = "aarch64-linux-musl-gcc"
 rustflags = ["-C", "target-feature=-crt-static"]
 
+[target.'cfg(target_os = "windows")']
+rustflags = [
+  "--cfg",
+  "windows_slim_errors" # Reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
+]
+
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"


### PR DESCRIPTION
Reduce error size for targetting `Windows`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Windows build configuration to reduce binary size by adjusting error handling compilation flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->