### PR TITLE
fix: sg completions redirect to ast-grep

### DIFF
--- a/crates/cli/src/bin/alias.rs
+++ b/crates/cli/src/bin/alias.rs
@@ -1,16 +1,5 @@
-// The alias command `sg` redirects everything to ast-grep
-// we need this to avoid "multiple build target" warning
-// See https://github.com/rust-lang/cargo/issues/5930
-fn main() -> std::io::Result<()> {
-  // redirect to ast-grep
-  use std::env::args;
-  use std::process::{Command, Stdio};
-  let mut child = Command::new("ast-grep")
-    .args(args().skip(1))
-    .stdin(Stdio::inherit())
-    .stdout(Stdio::inherit())
-    .stderr(Stdio::inherit())
-    .spawn()?;
-  let status = child.wait()?;
-  std::process::exit(status.code().unwrap_or(1))
+use ast_grep::execute_main;
+
+fn main() -> anyhow::Result<()> {
+  execute_main()
 }


### PR DESCRIPTION
Hello, my problem is that doing
```sh
sg completions fish > sg.fish
```

was outputting always `ast-grep` as the binary name.

The code in completions.rs seems to be good but the redirect for the sg aliases is undoing the binary name detection.
I don't have the whole context, maybe the fix is not right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced manual subprocess spawning with a thin delegating CLI entry that forwards execution.
  * Switched to a richer error-returning style for improved error reporting and diagnostics.
  * Simplified command execution flow for easier maintenance and clearer runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->