### PR TITLE
fix: remove debug println! from KindMatcher

### DIFF
--- a/crates/core/src/matcher/kind.rs
+++ b/crates/core/src/matcher/kind.rs
@@ -35,7 +35,6 @@ impl KindMatcher {
   }
 
   pub fn try_new<L: Language>(node_kind: &str, lang: L) -> Result<Self, KindMatcherError> {
-    println!("KindMatcher created with kind id: {}", node_kind);
     let s = Self::new(node_kind, lang);
     if s.is_invalid() {
       Err(KindMatcherError::InvalidKindName(node_kind.into()))


### PR DESCRIPTION
My `ast-grep scan` runs started outputting this log after updating:

```
KindMatcher created with kind id: expression_statement
KindMatcher created with kind id: expression_statement
KindMatcher created with kind id: catch_clause
KindMatcher created with kind id: call_expression
KindMatcher created with kind id: as_expression
KindMatcher created with kind id: pair
KindMatcher created with kind id: pair
KindMatcher created with kind id: type_annotation
KindMatcher created with kind id: object_type
KindMatcher created with kind id: interface_declaration
KindMatcher created with kind id: object_type
KindMatcher created with kind id: variable_declarator
KindMatcher created with kind id: variable_declarator
KindMatcher created with kind id: pair
KindMatcher created with kind id: object
KindMatcher created with kind id: object
KindMatcher created with kind id: pair
KindMatcher created with kind id: pair
KindMatcher created with kind id: object
KindMatcher created with kind id: as_expression
KindMatcher created with kind id: pair
KindMatcher created with kind id: shorthand_property_identifier
KindMatcher created with kind id: spread_element
KindMatcher created with kind id: identifier
KindMatcher created with kind id: type_assertion
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup removing unnecessary debug output, with no impact to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->