### PR TITLE
fix: override severity on `rule` & `inline-rules` flags

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -295,11 +295,13 @@ struct ScanStdin {
 }
 impl ScanStdin {
   fn try_new(arg: ScanArg) -> Result<Self> {
+    let overwrite = RuleOverwrite::new(&arg.overwrite)?;
     let rules = if let Some(path) = &arg.rule {
-      read_rule_file(path, None)?
+      read_rule_file(path, None).and_then(|configs| overwrite.process_configs(configs))?
     } else if let Some(text) = &arg.inline_rules {
-      from_yaml_string(text, &Default::default())
-        .with_context(|| EC::ParseRule("INLINE_RULES".into()))?
+      let configs = from_yaml_string(text, &Default::default())
+        .with_context(|| EC::ParseRule("INLINE_RULES".into()))?;
+      overwrite.process_configs(configs)?
     } else {
       return Err(anyhow::anyhow!(EC::RuleNotSpecified));
     };

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -261,6 +261,24 @@ fn test_severity_override_with_inline_rule() -> Result<()> {
   Ok(())
 }
 
+#[test]
+fn test_severity_override_with_inline_rule_and_stdin() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args([
+      "scan",
+      "--error",
+      "--stdin",
+      "--inline-rules",
+      "{language: ts, rule: {pattern: console.log($A)}}",
+      "--json",
+    ])
+    .write_stdin("console.log(123)")
+    .assert()
+    .failure()
+    .stdout(contains("error"));
+  Ok(())
+}
+
 const PY_RULE: &str = r"
 id: transform-indent
 language: python


### PR DESCRIPTION
The severity override doesn't work for the commands:
- `ast-grep scan --rule myRule.yml --error`
- `ast-grep scan --error --inline-rules <my rule>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rule override processing now runs consistently for both file-based and inline rule sources, including stdin paths, ensuring severity overrides are correctly applied.

* **Tests**
  * Added tests validating severity override behavior for rule-file, inline-rule, and inline-rule with stdin scenarios, ensuring failures surface as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->