### PR TITLE
Add Erlang support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-css",
  "tree-sitter-elixir",
+ "tree-sitter-erlang",
  "tree-sitter-go",
  "tree-sitter-haskell",
  "tree-sitter-hcl",
@@ -2117,6 +2118,16 @@ name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-erlang"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2091cce4eda19c03d77928c608ac6617445a6a25691dde1e93ac0102467a6be"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -23,6 +23,7 @@ tree-sitter-c-sharp = { version = "0.23.0", optional = true }
 tree-sitter-css = { version = "0.25.0", optional = true }
 tree-sitter-c = { version = "0.24.0", optional = true }
 tree-sitter-elixir = { version = "0.3.0", optional = true }
+tree-sitter-erlang = { version = "0.15.0", optional = true }
 tree-sitter-go = { version = "0.25.0", optional = true }
 tree-sitter-haskell = { version = "0.23.0", optional = true }
 tree-sitter-html = { version = "0.23.0", optional = true }
@@ -51,6 +52,7 @@ builtin-parser = [
   "tree-sitter-c-sharp",
   "tree-sitter-css",
   "tree-sitter-elixir",
+  "tree-sitter-erlang",
   "tree-sitter-go",
   "tree-sitter-haskell",
   "tree-sitter-hcl",

--- a/crates/language/src/erlang.rs
+++ b/crates/language/src/erlang.rs
@@ -1,0 +1,48 @@
+#![cfg(test)]
+
+use super::*;
+
+fn test_match(query: &str, source: &str) {
+  use crate::test::test_match_lang;
+  test_match_lang(query, source, Erlang);
+}
+
+fn test_non_match(query: &str, source: &str) {
+  use crate::test::test_non_match_lang;
+  test_non_match_lang(query, source, Erlang);
+}
+
+#[test]
+fn test_erlang_str() {
+  test_match("io:format($A)", "io:format(\"Hello\")");
+  test_non_match("io:format(\"Hello\")", "io:format(\"World\")");
+  test_non_match("\"Hello\"", "\"World\"");
+}
+
+#[test]
+fn test_erlang_pattern() {
+  test_match("$A", "ok");
+  test_match("$A =:= $B", "X =:= Y");
+  test_match("$F($$$ARGS)", "foo(1, 2, 3)");
+}
+
+fn test_replace(src: &str, pattern: &str, replacer: &str) -> String {
+  use crate::test::test_replace_lang;
+  test_replace_lang(src, pattern, replacer, Erlang)
+}
+
+#[test]
+fn test_erlang_module_attribute() {
+  test_match("-module($NAME).", "-module(foo).");
+  test_non_match("-module($NAME).", "-behaviour(gen_server).");
+}
+
+#[test]
+fn test_erlang_replace() {
+  let ret = test_replace(
+    "lists:map(Fun, List)",
+    "lists:map($FUN, $LIST)",
+    "lists:filtermap($FUN, $LIST)",
+  );
+  assert_eq!(ret, "lists:filtermap(Fun, List)");
+}

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -23,6 +23,7 @@ mod cpp;
 mod csharp;
 mod css;
 mod elixir;
+mod erlang;
 mod go;
 mod haskell;
 mod hcl;
@@ -209,6 +210,13 @@ impl_lang_expando!(CSharp, language_c_sharp, 'µ');
 impl_lang_expando!(Css, language_css, '_');
 // https://github.com/elixir-lang/tree-sitter-elixir/blob/a2861e88a730287a60c11ea9299c033c7d076e30/grammar.js#L245
 impl_lang_expando!(Elixir, language_elixir, 'µ');
+// https://github.com/WhatsApp/tree-sitter-erlang/blob/main/grammar.js
+// In Erlang, `$A` means "the character code of A" (a char literal, e.g. `$a` = 97).
+// tree-sitter parses `$A` as a `char` node, not a variable, so it can't be a metavariable.
+// We use `à` (U+00E0, lowercase), so `$NAME` becomes `àNAME` which is parsed as an atom.
+// This allows metavariables to match in atom positions (function names, module attributes, etc.)
+// and, since ast-grep metavars match any node at the same structural position, variables too.
+impl_lang_expando!(Erlang, language_erlang, 'à');
 // we can use any Unicode code point categorized as "Letter"
 // https://go.dev/ref/spec#letter
 impl_lang_expando!(Go, language_go, 'µ');
@@ -261,6 +269,7 @@ pub enum SupportLang {
   Css,
   Go,
   Elixir,
+  Erlang,
   Haskell,
   Hcl,
   Html,
@@ -286,7 +295,7 @@ impl SupportLang {
   pub const fn all_langs() -> &'static [SupportLang] {
     use SupportLang::*;
     &[
-      Bash, C, Cpp, CSharp, Css, Elixir, Go, Haskell, Hcl, Html, Java, JavaScript, Json, Kotlin,
+      Bash, C, Cpp, CSharp, Css, Elixir, Erlang, Go, Haskell, Hcl, Html, Java, JavaScript, Json, Kotlin,
       Lua, Nix, Php, Python, Ruby, Rust, Scala, Solidity, Swift, Tsx, TypeScript, Yaml,
     ]
   }
@@ -374,6 +383,7 @@ impl_aliases! {
   CSharp => &["cs", "csharp"],
   Css => &["css"],
   Elixir => &["ex", "elixir"],
+  Erlang => &["erl", "erlang"],
   Go => &["go", "golang"],
   Haskell => &["hs", "haskell"],
   Hcl => &["hcl"],
@@ -421,6 +431,7 @@ macro_rules! execute_lang_method {
       S::CSharp => CSharp.$method($($pname,)*),
       S::Css => Css.$method($($pname,)*),
       S::Elixir => Elixir.$method($($pname,)*),
+      S::Erlang => Erlang.$method($($pname,)*),
       S::Go => Go.$method($($pname,)*),
       S::Haskell => Haskell.$method($($pname,)*),
       S::Hcl => Hcl.$method($($pname,)*),
@@ -493,6 +504,7 @@ fn extensions(lang: SupportLang) -> &'static [&'static str] {
     CSharp => &["cs"],
     Css => &["css", "scss"],
     Elixir => &["ex", "exs"],
+    Erlang => &["erl", "hrl"],
     Go => &["go"],
     Haskell => &["hs"],
     Hcl => &["hcl", "nomad", "tf", "tfvars", "workflow"],

--- a/crates/language/src/parsers.rs
+++ b/crates/language/src/parsers.rs
@@ -40,6 +40,9 @@ pub fn language_css() -> TSLanguage {
 pub fn language_elixir() -> TSLanguage {
   conditional_lang!(tree_sitter_elixir, "tree-sitter-elixir")
 }
+pub fn language_erlang() -> TSLanguage {
+  conditional_lang!(tree_sitter_erlang, "tree-sitter-erlang")
+}
 pub fn language_go() -> TSLanguage {
   conditional_lang!(tree_sitter_go, "tree-sitter-go")
 }

--- a/crates/wasm/tests/web.rs
+++ b/crates/wasm/tests/web.rs
@@ -25,6 +25,7 @@ fn custom_lang(name: &str) -> WasmLangInfo {
   let expando_char = match name {
     "python" | "c" | "cpp" | "csharp" | "elixir" | "go" | "haskell" | "kotlin" | "php" | "ruby"
     | "rust" | "swift" => Some('µ'),
+    "erlang" => Some('à'),
     "css" | "nix" => Some('_'),
     "html" => Some('z'),
     _ => None,

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -4,8 +4,8 @@ use ast_grep_core::matcher::{Pattern, PatternBuilder, PatternError};
 use ast_grep_core::tree_sitter::{LanguageExt, TSLanguage};
 use ast_grep_core::Language;
 use ast_grep_language::{
-  Alias, Bash, CSharp, Cpp, Css, Elixir, Go, Haskell, Html, Java, JavaScript, Json, Kotlin, Lua,
-  Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
+  Alias, Bash, CSharp, Cpp, Css, Elixir, Erlang, Go, Haskell, Html, Java, JavaScript, Json,
+  Kotlin, Lua, Php, Python, Ruby, Rust, Scala, Swift, Tsx, TypeScript, Yaml, C,
 };
 use schemars::{json_schema, schema_for, JsonSchema, Schema, SchemaGenerator};
 use serde_json::{to_writer_pretty, Value};
@@ -32,6 +32,7 @@ fn generate_lang_schemas() -> Result<()> {
   generate_lang_schema(Css, "css")?;
   generate_lang_schema(Go, "go")?;
   generate_lang_schema(Elixir, "elixir")?;
+  generate_lang_schema(Erlang, "erlang")?;
   generate_lang_schema(Haskell, "haskell")?;
   generate_lang_schema(Html, "html")?;
   generate_lang_schema(Java, "java")?;


### PR DESCRIPTION
Add support for the [Erlang](https://www.erlang.org/) programming language, using WhatsApp's [tree-sitter-erlang](https://crates.io/crates/tree-sitter-erlang) grammar.

```
cargo test -p ast-grep-language
cargo run -- -p '{ok, $B}' -l erlang /path/to/file.erl
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Erlang language, enabling pattern matching and code transformations on .erl and .hrl files.

* **Tests**
  * Added unit tests covering Erlang matching, non-matching, and replacement scenarios.

* **Chores**
  * Extended schema generation and build/test mappings to include Erlang outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->