### PR TITLE
fix(lsp): scan injected languages for diagnostics

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -16,14 +16,15 @@ use ast_grep_core::{
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 use utils::{convert_match_to_diagnostic, diagnostic_to_code_action, Fixes, RewriteData};
 
 pub use tower_lsp_server::{LspService, Server};
 
-pub trait LSPLang: LanguageExt + Eq + Send + Sync + 'static {}
-impl<T> LSPLang for T where T: LanguageExt + Eq + Send + Sync + 'static {}
+pub trait LSPLang: LanguageExt + Eq + Send + Sync + FromStr + 'static {}
+impl<T> LSPLang for T where T: LanguageExt + Eq + Send + Sync + FromStr + 'static {}
 
 type Notes = BTreeMap<(u32, u32, u32, u32), Arc<String>>;
 
@@ -281,27 +282,29 @@ impl<L: LSPLang> Backend<L> {
     let path = self.uri_to_relative_path(uri)?;
 
     let rules = self.rules.read().ok()?;
-    let rule_refs = rules.for_path(&path);
-    if rule_refs.is_empty() {
-      return None;
-    }
-    let unused_suppression_rule =
-      CombinedScan::unused_config(Severity::Hint, rule_refs[0].language.clone());
-    let mut scan = CombinedScan::new(rule_refs);
-    scan.set_unused_suppression_rule(&unused_suppression_rule);
-    let matches = scan.scan(root, false).matches;
     let mut diagnostics = vec![];
     let mut fixes = Fixes::new();
-    for (rule, ms) in matches {
-      let to_diagnostic = |m: NodeMatch<StrDoc<L>>| {
-        let diagnostic = convert_match_to_diagnostic(uri, &m, rule);
-        let rewrite_data = RewriteData::from_node_match(&m, rule);
-        if let Some(r) = rewrite_data {
-          fixes.insert((diagnostic.range, rule.id.clone()), r);
-        }
-        diagnostic
-      };
-      diagnostics.extend(ms.into_iter().map(to_diagnostic));
+    let injections = root.get_injections(|lang| L::from_str(lang).ok());
+    let docs = std::iter::once(root).chain(injections.iter());
+    for injected in docs {
+      let rule_refs = rules.get_rule_from_lang(&path, injected.lang().clone());
+      if rule_refs.is_empty() {
+        continue;
+      }
+      let unused_suppression_rule =
+        CombinedScan::unused_config(Severity::Hint, injected.lang().clone());
+      let mut scan = CombinedScan::new(rule_refs);
+      scan.set_unused_suppression_rule(&unused_suppression_rule);
+      for (rule, matches) in scan.scan(injected, false).matches {
+        diagnostics.extend(matches.into_iter().map(|m: NodeMatch<StrDoc<L>>| {
+          let diagnostic = convert_match_to_diagnostic(uri, &m, rule);
+          let rewrite_data = RewriteData::from_node_match(&m, rule);
+          if let Some(r) = rewrite_data {
+            fixes.insert((diagnostic.range, rule.id.clone()), r);
+          }
+          diagnostic
+        }));
+      }
     }
     Some((diagnostics, fixes))
   }

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -463,6 +463,51 @@ fix: |-
 }
 
 #[tokio::test]
+async fn test_injected_language_diagnostics() {
+  let yamls = r"
+id: no-alert
+language: TypeScript
+message: Avoid alert
+rule:
+  pattern: alert($A)
+fix: |-
+  console.log($A)
+";
+  let mut client = create_lsp_framed(yamls).await;
+
+  let file_uri = "file:///Users/codes/ast-grep-vscode/test.html";
+  let file_content = "<script lang=typescript>alert('Hello, world!')</script>\n";
+  send_did_open_framed(&mut client, file_uri, "html", file_content).await;
+
+  let diagnostics = &wait_for_diagnostics(&mut client)
+    .await
+    .expect("No diagnostics received")
+    .as_array()
+    .expect("Diagnostics should be an array")
+    .to_owned();
+
+  assert_eq!(
+    diagnostics.len(),
+    1,
+    "Expected 1 diagnostic from injected script"
+  );
+  assert_eq!(diagnostics[0]["code"], "no-alert");
+
+  let code_action = request_code_action(&mut client, file_uri, &diagnostics[0]).await;
+  let code_action = code_action.expect("No code action response");
+  let actions = code_action["result"]
+    .as_array()
+    .expect("Result should be an array");
+  assert_eq!(actions.len(), 1, "Expected 1 code action");
+
+  let fixed_text = apply_all_code_actions(file_content, actions);
+  assert_eq!(
+    fixed_text,
+    "<script lang=typescript>console.log('Hello, world!')</script>"
+  );
+}
+
+#[tokio::test]
 async fn test_overlap_line_code_edit() {
   let yamls = r"
 id: use-alert


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now scan multiple injected languages in a document and apply language-specific rules per injected context.

* **Refactor**
  * Public language interface updated to require parse-from-string capability, aligning implementations with the new trait requirement (public API update).

* **Tests**
  * Added test coverage for injected-language diagnostics and code-action fix application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->