### PR TITLE
fix(lsp): report unused suppressions without rules

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -285,16 +285,9 @@ impl<L: LSPLang> Backend<L> {
     let mut fixes = Fixes::new();
     let injections = root.get_injections(|lang| L::from_str(lang).ok());
     let docs = std::iter::once(root).chain(injections.iter());
-    let doc_and_rules = docs.filter_map(|injected| {
-      let rule_refs = rules.get_rule_from_lang(&path, injected.lang().clone());
-      if rule_refs.is_empty() {
-        None
-      } else {
-        Some((injected, rule_refs))
-      }
-    });
     // iterate over all main doc and injected docs
-    for (injected, rule_refs) in doc_and_rules {
+    for injected in docs {
+      let rule_refs = rules.get_rule_from_lang(&path, injected.lang().clone());
       let unused_suppression_rule =
         CombinedScan::unused_config(Severity::Hint, injected.lang().clone());
       let mut scan = CombinedScan::new(rule_refs);

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -288,6 +288,9 @@ impl<L: LSPLang> Backend<L> {
     // iterate over all main doc and injected docs
     for injected in docs {
       let rule_refs = rules.get_rule_from_lang(&path, injected.lang().clone());
+      if rule_refs.is_empty() && !injected.source().contains("ast-grep-ignore") {
+        continue;
+      }
       let unused_suppression_rule =
         CombinedScan::unused_config(Severity::Hint, injected.lang().clone());
       let mut scan = CombinedScan::new(rule_refs);

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -508,6 +508,38 @@ fix: |-
 }
 
 #[tokio::test]
+async fn test_unused_suppression_in_injected_language_without_rules() {
+  let yamls = r#"
+id: no-inline-style
+language: Html
+message: Avoid inline style
+rule:
+  pattern: <div style=$STYLE>$$$CHILDREN</div>
+"#;
+  let mut client = create_lsp_framed(yamls).await;
+
+  let file_uri = "file:///Users/codes/ast-grep-vscode/test.html";
+  let file_content =
+    "<script lang=typescript>// ast-grep-ignore: no-alert\nconsole.log('Hello, world!')</script>\n";
+  send_did_open_framed(&mut client, file_uri, "html", file_content).await;
+
+  let diagnostics = wait_for_diagnostics(&mut client)
+    .await
+    .expect("No diagnostics received");
+  let diagnostics = diagnostics
+    .as_array()
+    .expect("Diagnostics should be an array")
+    .to_owned();
+
+  assert_eq!(
+    diagnostics.len(),
+    1,
+    "Expected 1 unused-suppression diagnostic from injected script"
+  );
+  assert_eq!(diagnostics[0]["code"], "unused-suppression");
+}
+
+#[tokio::test]
 async fn test_overlap_line_code_edit() {
   let yamls = r"
 id: use-alert


### PR DESCRIPTION
fix #2530

When an injected language has no configured rules, `get_diagnostics` skips that region before it sets up the standalone unused-suppression rule.

This change scans host and injected documents even when their rule set is empty, so unused `ast-grep-ignore` hints still show up for those regions.

Validation:
- cargo fmt --all --check
- cargo test -p ast-grep-lsp
- cargo test
- cargo clippy --all-targets --all-features --workspace --release --locked -- -D clippy::all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected detection of suppression comments in embedded/injected code so unused suppressions are reported even when the embedded language has no configured rules.
* **Tests**
  * Added an automated test to ensure unused suppression warnings are emitted for injected language blocks without rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->