### PR TITLE
fix(lsp): initialize tracing subscriber to surface tower-lsp errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "termimad",
  "terminal-light",
  "tokio",
+ "tracing-subscriber",
  "tree-sitter",
 ]
 
@@ -228,6 +229,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower-lsp-server",
+ "tracing",
 ]
 
 [[package]]
@@ -1029,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2047,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2380,6 +2430,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ similar = { version = "3.0.0", features = ["inline"] }
 smallvec = "1.13.2"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-std"] }
 clap_complete = "4.5.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/crates/cli/src/lsp.rs
+++ b/crates/cli/src/lsp.rs
@@ -12,7 +12,8 @@ async fn run_language_server_impl(_arg: LspArg, project: Result<ProjectConfig>) 
   tracing_subscriber::fmt()
     .with_env_filter(EnvFilter::from_default_env())
     .with_writer(std::io::stderr)
-    .init();
+    .try_init()
+    .ok();
   let project_config = project?;
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();

--- a/crates/cli/src/lsp.rs
+++ b/crates/cli/src/lsp.rs
@@ -3,13 +3,16 @@ use crate::utils::{ErrorContext as EC, RuleOverwrite};
 use anyhow::{Context, Result};
 use ast_grep_lsp::{Backend, LspService, Server};
 use clap::Args;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Args)]
 pub struct LspArg {}
 
 async fn run_language_server_impl(_arg: LspArg, project: Result<ProjectConfig>) -> Result<()> {
-  // env_logger::init();
-  // TODO: move this error to client
+  tracing_subscriber::fmt()
+    .with_env_filter(EnvFilter::from_default_env())
+    .with_writer(std::io::stderr)
+    .init();
   let project_config = project?;
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,6 +25,7 @@ dashmap.workspace = true
 serde_json = "1.0.116"
 tower-lsp-server = "0.23.0"
 anyhow.workspace = true
+tracing = "0.1"
 
 [dev-dependencies]
 ast-grep-language.workspace = true


### PR DESCRIPTION
## Summary

tower-lsp-server v0.23.0 uses `tracing::error!` / `tracing::warn!` / `tracing::trace!` for transport failures, JSON encode errors, and suppressed notifications. The LSP binary has had `env_logger::init()` commented out since introduction with no tracing subscriber active, so all of these events were silently discarded.

This initializes `tracing_subscriber::fmt()` in `run_language_server_impl` with stderr output (avoids corrupting the LSP stdout JSON-RPC transport) and `EnvFilter` from `RUST_LOG`. tower-lsp transport diagnostics are now visible on demand.

## Changes

- `crates/cli/Cargo.toml`: added `tracing-subscriber` with `env-filter` feature
- `crates/cli/src/lsp.rs`: replaced commented-out `env_logger::init()` with `tracing_subscriber::fmt()` setup
- `crates/lsp/Cargo.toml`: added `tracing` dep for diagnostic debug logging

## Test plan

`cargo test -p ast-grep-lsp` (11 tests). Manual: `RUST_LOG=tower_lsp=debug ast-grep lsp` produces tracing output on stderr.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging infrastructure to support environment-based configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2639)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->