### PR TITLE
fix(lsp): buffer diagnostics during initialization race (#2638)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "termimad",
  "terminal-light",
  "tokio",
+ "tracing-subscriber",
  "tree-sitter",
 ]
 
@@ -228,6 +229,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower-lsp-server",
+ "tracing",
 ]
 
 [[package]]
@@ -1029,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2047,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2380,6 +2430,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ similar = { version = "3.0.0", features = ["inline"] }
 smallvec = "1.13.2"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-std"] }
 clap_complete = "4.5.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/crates/cli/src/lsp.rs
+++ b/crates/cli/src/lsp.rs
@@ -3,13 +3,16 @@ use crate::utils::{ErrorContext as EC, RuleOverwrite};
 use anyhow::{Context, Result};
 use ast_grep_lsp::{Backend, LspService, Server};
 use clap::Args;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Args)]
 pub struct LspArg {}
 
 async fn run_language_server_impl(_arg: LspArg, project: Result<ProjectConfig>) -> Result<()> {
-  // env_logger::init();
-  // TODO: move this error to client
+  tracing_subscriber::fmt()
+    .with_env_filter(EnvFilter::from_default_env())
+    .with_writer(std::io::stderr)
+    .init();
   let project_config = project?;
   let stdin = tokio::io::stdin();
   let stdout = tokio::io::stdout();

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,6 +25,7 @@ dashmap.workspace = true
 serde_json = "1.0.116"
 tower-lsp-server = "0.23.0"
 anyhow.workspace = true
+tracing = "0.1"
 
 [dev-dependencies]
 ast-grep-language.workspace = true

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -114,20 +114,24 @@ impl<L: LSPLang> LanguageServer for Backend<L> {
       .log_message(MessageType::INFO, "server initialized!")
       .await;
 
-    // Mark as initialized first so publish_diagnostics stop buffering
-    self.initialized.store(true, Ordering::SeqCst);
+    // Flush any diagnostics that were buffered before initialization.
+    // Take the buffer and set the flag under the same lock to prevent a race:
+    // a concurrent call to publish_diagnostics must either see the flag (and
+    // publish directly) OR acquire the lock after we've drained, preserving order.
+    let pending = {
+      let mut pending_guard = self.pending_diagnostics.lock().unwrap();
+      let pending = std::mem::take(&mut *pending_guard);
+      self.initialized.store(true, Ordering::SeqCst);
+      pending
+    }; // pending_guard dropped here, before any .await
 
-    // Flush any diagnostics that were buffered before initialization
-    {
-      let pending = std::mem::take(&mut *self.pending_diagnostics.lock().unwrap());
-      if !pending.is_empty() {
-        tracing::debug!(count = pending.len(), "flushing buffered diagnostics");
-        for (uri, version, diagnostics) in pending {
-          self
-            .client
-            .publish_diagnostics(uri, diagnostics, Some(version))
-            .await;
-        }
+    if !pending.is_empty() {
+      tracing::debug!(count = pending.len(), "flushing buffered diagnostics");
+      for (uri, version, diagnostics) in pending {
+        self
+          .client
+          .publish_diagnostics(uri, diagnostics, Some(version))
+          .await;
       }
     }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -306,8 +306,6 @@ impl<L: LSPLang> Backend<L> {
     let path = self.uri_to_relative_path(uri)?;
 
     let rules = self.rules.read().ok()?;
-
-    let rules = self.rules.read().ok()?;
     let mut diagnostics = vec![];
     let mut fixes = Fixes::new();
     let injections = root.get_injections(|lang| L::from_str(lang).ok());
@@ -325,9 +323,12 @@ impl<L: LSPLang> Backend<L> {
       // get all matches with rules, and conver to diagnostics
       let scan_result = scan.scan(injected, false);
       let all_matches = &scan_result.matches;
-      eprintln!("[DEBUG get_diagnostics]     scan produced {} rules_with_matches", all_matches.len());
+      tracing::debug!(
+        rules_with_matches = all_matches.len(),
+        "scan produced rules with matches"
+      );
       for (rule, ms) in all_matches.iter() {
-        eprintln!("[DEBUG get_diagnostics]       id={:?} match_count={}", rule.id, ms.len());
+        tracing::debug!(rule_id = ?rule.id, match_count = ms.len(), "rule matches");
       }
       let rule_and_matches = all_matches
         .into_iter()

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -16,14 +16,15 @@ use ast_grep_core::{
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 
 use utils::{convert_match_to_diagnostic, diagnostic_to_code_action, Fixes, RewriteData};
 
 pub use tower_lsp_server::{LspService, Server};
 
-pub trait LSPLang: LanguageExt + Eq + Send + Sync + FromStr + 'static {}
-impl<T> LSPLang for T where T: LanguageExt + Eq + Send + Sync + FromStr + 'static {}
+pub trait LSPLang: LanguageExt + Eq + Send + Sync + FromStr + std::fmt::Debug + 'static {}
+impl<T> LSPLang for T where T: LanguageExt + Eq + Send + Sync + FromStr + std::fmt::Debug + 'static {}
 
 type Notes = BTreeMap<(u32, u32, u32, u32), Arc<String>>;
 
@@ -45,6 +46,10 @@ pub struct Backend<L: LSPLang> {
   rule_finder: Box<dyn Fn() -> anyhow::Result<RuleCollection<L>> + Send + Sync>,
   // store client capabilities to check support
   capabilities: Arc<RwLock<ClientCapabilities>>,
+  // flag to track whether initialized() has been called
+  initialized: AtomicBool,
+  // buffer for diagnostics published before server enters Initialized state
+  pending_diagnostics: Mutex<Vec<(Uri, i32, Vec<Diagnostic>)>>,
 }
 
 const FALLBACK_CODE_ACTION_PROVIDER: Option<CodeActionProviderCapability> =
@@ -108,6 +113,24 @@ impl<L: LSPLang> LanguageServer for Backend<L> {
       .client
       .log_message(MessageType::INFO, "server initialized!")
       .await;
+
+    // Mark as initialized first so publish_diagnostics stop buffering
+    self.initialized.store(true, Ordering::SeqCst);
+
+    // Flush any diagnostics that were buffered before initialization
+    {
+      let pending = std::mem::take(&mut *self.pending_diagnostics.lock().unwrap());
+      if !pending.is_empty() {
+        tracing::debug!(count = pending.len(), "flushing buffered diagnostics");
+        for (uri, version, diagnostics) in pending {
+          self
+            .client
+            .publish_diagnostics(uri, diagnostics, Some(version))
+            .await;
+        }
+      }
+    }
+
     if let Err(e) = self.reload_rules().await {
       self
         .client
@@ -234,6 +257,8 @@ impl<L: LSPLang> Backend<L> {
       interner: DashMap::new(),
       rule_finder: Box::new(rule_finder),
       capabilities: Arc::new(RwLock::new(ClientCapabilities::default())),
+      initialized: AtomicBool::new(false),
+      pending_diagnostics: Mutex::new(Vec::new()),
     }
   }
 
@@ -281,6 +306,8 @@ impl<L: LSPLang> Backend<L> {
     let path = self.uri_to_relative_path(uri)?;
 
     let rules = self.rules.read().ok()?;
+
+    let rules = self.rules.read().ok()?;
     let mut diagnostics = vec![];
     let mut fixes = Fixes::new();
     let injections = root.get_injections(|lang| L::from_str(lang).ok());
@@ -296,7 +323,12 @@ impl<L: LSPLang> Backend<L> {
       let mut scan = CombinedScan::new(rule_refs);
       scan.set_unused_suppression_rule(&unused_suppression_rule);
       // get all matches with rules, and conver to diagnostics
-      let all_matches = scan.scan(injected, false).matches;
+      let scan_result = scan.scan(injected, false);
+      let all_matches = &scan_result.matches;
+      eprintln!("[DEBUG get_diagnostics]     scan produced {} rules_with_matches", all_matches.len());
+      for (rule, ms) in all_matches.iter() {
+        eprintln!("[DEBUG get_diagnostics]       id={:?} match_count={}", rule.id, ms.len());
+      }
       let rule_and_matches = all_matches
         .into_iter()
         .flat_map(|(rule, ms)| ms.into_iter().map(move |m| (rule, m)));
@@ -342,6 +374,18 @@ impl<L: LSPLang> Backend<L> {
     version: i32,
     diagnostics: Vec<Diagnostic>,
   ) -> Option<()> {
+    if !self.initialized.load(Ordering::SeqCst) {
+      tracing::debug!(
+        "server not yet initialized, buffering diagnostics for {uri:?}"
+      );
+      let mut pending = self.pending_diagnostics.lock().unwrap();
+      pending.push((uri, version, diagnostics));
+      return Some(());
+    }
+    tracing::debug!(
+      uri = ?uri, version, count = diagnostics.len(),
+      "publishing diagnostics"
+    );
     self
       .client
       .publish_diagnostics(uri, diagnostics, Some(version))


### PR DESCRIPTION
## Summary

tower-lsp-server's `send_notification` silently drops `textDocument/publishDiagnostics` when the server has not yet reached `State::Initialized`. Since `didOpen` arrives asynchronously after `initialized`, diagnostics for the first opened file are silently lost.

This fix adds a buffer inside the `Backend` struct: diagnostics published before `initialized()` runs are queued, then flushed once the server enters the Initialized state. The `initialized` flag is set before `reload_rules()` so that any diagnostics triggered during rule loading also flow through.

## Changes

- `crates/lsp/src/lib.rs`: added `initialized: AtomicBool` and `pending_diagnostics: Mutex<Vec<(Uri, i32, Vec<Diagnostic>)>>` to `Backend`. Guarded `publish_diagnostics` to buffer when not yet initialized. Set the flag and drain the buffer at the top of `initialized()`. Replaced `eprintln!` debug lines with `tracing::debug!`.

## Test plan

`cargo test -p ast-grep-lsp` — all 11 integration tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics are now buffered and delivered after the language server finishes initialization, preventing premature diagnostic delivery.

* **Chores**
  * Initialized logger/tracing on the language server and added debug logging to show rule-scan and match counts for better visibility.

* **Breaking Changes**
  * Public language type trait now requires Debug, which may affect downstream implementations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2640)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->