### PR TITLE
fix(config): trim block comment ignore directives

### DIFF
--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -379,8 +379,14 @@ fn parse_suppression_set(text: &str) -> Option<HashSet<String>> {
     return None;
   }
   let (_, rules) = after.split_once(':')?;
+  let rules = trim_block_comment_end(rules);
   let set = rules.split(',').map(|r| r.trim().to_string()).collect();
   Some(set)
+}
+
+fn trim_block_comment_end(text: &str) -> &str {
+  let text = text.trim();
+  text.strip_suffix("*/").unwrap_or(text).trim()
 }
 
 #[cfg(test)]
@@ -455,6 +461,37 @@ language: Tsx",
       assert_eq!(matches.1[0].text(), "console.log('no ignore')");
       assert_eq!(matches.1[1].text(), "console.log('ignore another')");
     });
+  }
+
+  #[test]
+  fn test_ignore_node_block_comment() {
+    let source = r#"
+    /* ast-grep-ignore: test */
+    console.log('ignore one')
+    console.log('no ignore')
+    console.log('ignore inline') /* ast-grep-ignore: test */
+    console.log('ignore another') /* ast-grep-ignore: not-test */
+    /* ast-grep-ignore: not-test, test */
+    console.log('multiple ignore')
+    "#;
+    test_scan(source, |scanned| {
+      let matches = &scanned[0];
+      assert_eq!(matches.1.len(), 2);
+      assert_eq!(matches.1[0].text(), "console.log('no ignore')");
+      assert_eq!(matches.1[1].text(), "console.log('ignore another')");
+    });
+  }
+
+  #[test]
+  fn test_parse_suppression_set_trims_block_comment_end() {
+    let set = parse_suppression_set("/* ast-grep-ignore: rule-name */").unwrap();
+    assert!(set.contains("rule-name"));
+    assert!(!set.contains("rule-name */"));
+
+    let set = parse_suppression_set("/* ast-grep-ignore: first, second */").unwrap();
+    assert!(set.contains("first"));
+    assert!(set.contains("second"));
+    assert!(!set.contains("second */"));
   }
 
   fn test_scan_unused<F>(source: &str, test_fn: F)


### PR DESCRIPTION
## Summary
- Trim the closing `*/` from block-comment `ast-grep-ignore` rule lists before splitting rule IDs.
- Add regressions for block-comment ignore directives, including the CSS-style `/* ast-grep-ignore: rule-name */` parsing case.

## Testing
- `cargo test -p ast-grep-config test_ignore_node_block_comment`
- `cargo test -p ast-grep-config test_parse_suppression_set_trims_block_comment_end`
- `cargo test -p ast-grep-config`
- `cargo fmt --all -- --check`
- `cargo clippy -p ast-grep-config --all-targets --all-features -- -D clippy::all`
- `git diff --check`

Closes #2644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of suppression directives embedded in block comments to properly extract rule IDs without interference from comment terminators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->