### PR TITLE
feat(scan.rs): support show diagnostic reports in favor of just errors

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -19,12 +19,12 @@ use crate::print::{
 };
 use crate::utils::RuleOverwrite;
 use crate::utils::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs, filter_file_rule};
+use crate::utils::{DiagnosticCount, DiagnosticSnapshot};
 use crate::utils::{ErrorContext as EC, MaxItemCounter};
 use crate::utils::{FileTrace, ScanTrace};
 use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Args)]
 pub struct ScanArg {
@@ -136,8 +136,7 @@ struct ScanWithConfig {
   no_suppress_all_rule: RuleConfig<SgLang>,
   trace: ScanTrace,
   proj_dir: PathBuf,
-  // TODO: remove this
-  error_count: AtomicUsize,
+  diagnostic_count: DiagnosticCount,
   max_item_counter: Option<MaxItemCounter>,
 }
 impl ScanWithConfig {
@@ -175,7 +174,7 @@ impl ScanWithConfig {
       no_suppress_all_rule,
       trace,
       proj_dir: absolute_proj_dir,
-      error_count: AtomicUsize::new(0),
+      diagnostic_count: DiagnosticCount::default(),
       max_item_counter,
     })
   }
@@ -192,9 +191,9 @@ impl Worker for ScanWithConfig {
     }
     printer.after_print()?;
     self.trace.print()?;
-    let error_count = self.error_count.load(Ordering::Acquire);
-    if error_count > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
+    let diagnostic_snapshot = self.diagnostic_count.snapshot();
+    if diagnostic_snapshot.issue_total() > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticReport(diagnostic_snapshot)))
     } else {
       Ok(ExitCode::SUCCESS)
     }
@@ -245,7 +244,7 @@ impl PathWorker for ScanWithConfig {
     processor: &P::Processor,
   ) -> Result<Vec<P::Processed>> {
     let items = filter_file_rule(path, &self.configs, &self.trace)?;
-    let mut error_count = 0usize;
+    let mut diagnostic_snapshot = DiagnosticSnapshot::default();
     let mut ret = vec![];
     for grep in items {
       let file_content = grep.source();
@@ -283,14 +282,12 @@ impl PathWorker for ScanWithConfig {
           continue;
         }
         let match_count = matches.len();
-        if matches!(rule.severity, Severity::Error) {
-          error_count = error_count.saturating_add(match_count);
-        }
+        diagnostic_snapshot.add(&rule.severity, match_count);
         let processed = match_rule_on_file(path, matches, rule, file_content, processor)?;
         ret.push(processed);
       }
     }
-    self.error_count.fetch_add(error_count, Ordering::AcqRel);
+    self.diagnostic_count.merge(diagnostic_snapshot);
     Ok(ret)
   }
 
@@ -304,8 +301,7 @@ impl PathWorker for ScanWithConfig {
 
 struct ScanStdin {
   rules: Vec<RuleConfig<SgLang>>,
-  // TODO: remove this
-  error_count: AtomicUsize,
+  diagnostic_count: DiagnosticCount,
   max_diagnostics_shown: Option<usize>,
 }
 impl ScanStdin {
@@ -323,7 +319,7 @@ impl ScanStdin {
     };
     Ok(Self {
       rules,
-      error_count: AtomicUsize::new(0),
+      diagnostic_count: DiagnosticCount::default(),
       max_diagnostics_shown: arg.max_results.map(usize::from),
     })
   }
@@ -340,9 +336,9 @@ impl Worker for ScanStdin {
       printer.process(item)?;
     }
     printer.after_print()?;
-    let error_count = self.error_count.load(Ordering::Acquire);
-    if error_count > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
+    let diagnostic_snapshot = self.diagnostic_count.snapshot();
+    if diagnostic_snapshot.issue_total() > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticReport(diagnostic_snapshot)))
     } else {
       Ok(ExitCode::SUCCESS)
     }
@@ -363,13 +359,12 @@ impl StdInWorker for ScanStdin {
     let file_content = grep.source();
     // do not separate_fix rule in stdin mode
     let scanned = combined.scan(&grep, false);
-    let mut error_count = 0usize;
-    let mut diagnostic_count = 0usize;
+    let mut diagnostic_snapshot = DiagnosticSnapshot::default();
     let mut ret = vec![];
     for (rule, matches) in scanned.matches {
       // Truncate matches if max_diagnostics_shown is set
       let matches: Vec<_> = if let Some(max) = self.max_diagnostics_shown {
-        let remaining = max.saturating_sub(diagnostic_count);
+        let remaining = max.saturating_sub(diagnostic_snapshot.total());
         if remaining == 0 {
           break;
         }
@@ -381,14 +376,11 @@ impl StdInWorker for ScanStdin {
         continue;
       }
       let match_count = matches.len();
-      diagnostic_count += match_count;
-      if matches!(rule.severity, Severity::Error) {
-        error_count = error_count.saturating_add(match_count);
-      }
+      diagnostic_snapshot.add(&rule.severity, match_count);
       let processed = match_rule_on_file(path, matches, rule, file_content, processor)?;
       ret.push(processed);
     }
-    self.error_count.fetch_add(error_count, Ordering::AcqRel);
+    self.diagnostic_count.merge(diagnostic_snapshot);
     Ok(ret)
   }
 }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -19,7 +19,7 @@ use crate::print::{
 };
 use crate::utils::RuleOverwrite;
 use crate::utils::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs, filter_file_rule};
-use crate::utils::{DiagnosticCount, DiagnosticSnapshot};
+use crate::utils::{DiagnosticCount, DiagnosticSnapshot, report_warning_summary};
 use crate::utils::{ErrorContext as EC, MaxItemCounter};
 use crate::utils::{FileTrace, ScanTrace};
 use crate::utils::{Items, PathWorker, StdInWorker, Worker};
@@ -191,13 +191,7 @@ impl Worker for ScanWithConfig {
     }
     printer.after_print()?;
     self.trace.print()?;
-    report_warning_summary(self.diagnostic_count.warnings());
-    let error_count = self.diagnostic_count.errors();
-    if error_count > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
-    } else {
-      Ok(ExitCode::SUCCESS)
-    }
+    report_diagnostic_summary(&self.diagnostic_count, self.arg.output.needs_interactive())
   }
 }
 
@@ -304,6 +298,7 @@ struct ScanStdin {
   rules: Vec<RuleConfig<SgLang>>,
   diagnostic_count: DiagnosticCount,
   max_diagnostics_shown: Option<usize>,
+  interactive: bool,
 }
 impl ScanStdin {
   fn try_new(arg: ScanArg) -> Result<Self> {
@@ -322,6 +317,7 @@ impl ScanStdin {
       rules,
       diagnostic_count: DiagnosticCount::default(),
       max_diagnostics_shown: arg.max_results.map(usize::from),
+      interactive: arg.output.needs_interactive(),
     })
   }
 }
@@ -337,13 +333,7 @@ impl Worker for ScanStdin {
       printer.process(item)?;
     }
     printer.after_print()?;
-    report_warning_summary(self.diagnostic_count.warnings());
-    let error_count = self.diagnostic_count.errors();
-    if error_count > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
-    } else {
-      Ok(ExitCode::SUCCESS)
-    }
+    report_diagnostic_summary(&self.diagnostic_count, self.interactive)
   }
 }
 
@@ -362,11 +352,13 @@ impl StdInWorker for ScanStdin {
     // do not separate_fix rule in stdin mode
     let scanned = combined.scan(&grep, false);
     let mut diagnostic_snapshot = DiagnosticSnapshot::default();
+    // count every shown match regardless of severity for truncation
+    let mut shown = 0usize;
     let mut ret = vec![];
     for (rule, matches) in scanned.matches {
       // Truncate matches if max_diagnostics_shown is set
       let matches: Vec<_> = if let Some(max) = self.max_diagnostics_shown {
-        let remaining = max.saturating_sub(diagnostic_snapshot.total());
+        let remaining = max.saturating_sub(shown);
         if remaining == 0 {
           break;
         }
@@ -378,6 +370,7 @@ impl StdInWorker for ScanStdin {
         continue;
       }
       let match_count = matches.len();
+      shown += match_count;
       diagnostic_snapshot.add(&rule.severity, match_count);
       let processed = match_rule_on_file(path, matches, rule, file_content, processor)?;
       ret.push(processed);
@@ -387,11 +380,19 @@ impl StdInWorker for ScanStdin {
   }
 }
 
-fn report_warning_summary(warnings: usize) {
-  if warnings == 0 {
-    return;
+// In interactive/update-all modes fixable diagnostics are resolved as diffs
+// and never counted, so a warning summary would be partial or already fixed.
+// Errors keep their pre-existing exit-code semantics in all modes.
+fn report_diagnostic_summary(count: &DiagnosticCount, interactive: bool) -> Result<ExitCode> {
+  if !interactive {
+    report_warning_summary(count.warnings());
   }
-  eprintln!("Warning: {warnings} warning(s) found in code.");
+  let error_count = count.errors();
+  if error_count > 0 {
+    Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
+  } else {
+    Ok(ExitCode::SUCCESS)
+  }
 }
 
 fn match_rule_diff_on_file<T>(

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -192,7 +192,7 @@ impl Worker for ScanWithConfig {
     printer.after_print()?;
     self.trace.print()?;
     let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    report_warning_summary(diagnostic_snapshot);
+    report_warning_summary(diagnostic_snapshot.warnings);
     if diagnostic_snapshot.errors > 0 {
       Err(anyhow::anyhow!(EC::DiagnosticError(
         diagnostic_snapshot.errors
@@ -340,7 +340,7 @@ impl Worker for ScanStdin {
     }
     printer.after_print()?;
     let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    report_warning_summary(diagnostic_snapshot);
+    report_warning_summary(diagnostic_snapshot.warnings);
     if diagnostic_snapshot.errors > 0 {
       Err(anyhow::anyhow!(EC::DiagnosticError(
         diagnostic_snapshot.errors
@@ -391,15 +391,11 @@ impl StdInWorker for ScanStdin {
   }
 }
 
-fn report_warning_summary(diagnostic_snapshot: DiagnosticSnapshot) {
-  if diagnostic_snapshot.warnings == 0 {
+fn report_warning_summary(warnings: usize) {
+  if warnings == 0 {
     return;
   }
-  let warnings = DiagnosticSnapshot {
-    warnings: diagnostic_snapshot.warnings,
-    ..Default::default()
-  };
-  eprintln!("Warning: {warnings} found in code.");
+  eprintln!("Warning: {warnings} warning(s) found in code.");
 }
 
 fn match_rule_diff_on_file<T>(

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -191,12 +191,10 @@ impl Worker for ScanWithConfig {
     }
     printer.after_print()?;
     self.trace.print()?;
-    let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    report_warning_summary(diagnostic_snapshot.warnings);
-    if diagnostic_snapshot.errors > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(
-        diagnostic_snapshot.errors
-      )))
+    report_warning_summary(self.diagnostic_count.warnings());
+    let error_count = self.diagnostic_count.errors();
+    if error_count > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
     } else {
       Ok(ExitCode::SUCCESS)
     }
@@ -339,12 +337,10 @@ impl Worker for ScanStdin {
       printer.process(item)?;
     }
     printer.after_print()?;
-    let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    report_warning_summary(diagnostic_snapshot.warnings);
-    if diagnostic_snapshot.errors > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticError(
-        diagnostic_snapshot.errors
-      )))
+    report_warning_summary(self.diagnostic_count.warnings());
+    let error_count = self.diagnostic_count.errors();
+    if error_count > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticError(error_count)))
     } else {
       Ok(ExitCode::SUCCESS)
     }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -192,8 +192,11 @@ impl Worker for ScanWithConfig {
     printer.after_print()?;
     self.trace.print()?;
     let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    if diagnostic_snapshot.issue_total() > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticReport(diagnostic_snapshot)))
+    report_warning_summary(diagnostic_snapshot);
+    if diagnostic_snapshot.errors > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticError(
+        diagnostic_snapshot.errors
+      )))
     } else {
       Ok(ExitCode::SUCCESS)
     }
@@ -337,8 +340,11 @@ impl Worker for ScanStdin {
     }
     printer.after_print()?;
     let diagnostic_snapshot = self.diagnostic_count.snapshot();
-    if diagnostic_snapshot.issue_total() > 0 {
-      Err(anyhow::anyhow!(EC::DiagnosticReport(diagnostic_snapshot)))
+    report_warning_summary(diagnostic_snapshot);
+    if diagnostic_snapshot.errors > 0 {
+      Err(anyhow::anyhow!(EC::DiagnosticError(
+        diagnostic_snapshot.errors
+      )))
     } else {
       Ok(ExitCode::SUCCESS)
     }
@@ -384,6 +390,18 @@ impl StdInWorker for ScanStdin {
     Ok(ret)
   }
 }
+
+fn report_warning_summary(diagnostic_snapshot: DiagnosticSnapshot) {
+  if diagnostic_snapshot.warnings == 0 {
+    return;
+  }
+  let warnings = DiagnosticSnapshot {
+    warnings: diagnostic_snapshot.warnings,
+    ..Default::default()
+  };
+  eprintln!("Warning: {warnings} found in code.");
+}
+
 fn match_rule_diff_on_file<T>(
   path: &Path,
   matches: Vec<(&RuleConfig<SgLang>, NodeMatch<StrDoc<SgLang>>)>,

--- a/crates/cli/src/utils/diagnostic_count.rs
+++ b/crates/cli/src/utils/diagnostic_count.rs
@@ -29,28 +29,31 @@ impl DiagnosticSnapshot {
   }
 }
 
+/// Shared counts merged from parallel scan workers.
+/// Only errors and warnings appear in the final summary,
+/// so only they need cross-thread accumulation.
 #[derive(Default)]
 pub struct DiagnosticCount {
   error: AtomicUsize,
   warning: AtomicUsize,
-  info: AtomicUsize,
-  hint: AtomicUsize,
 }
 
 impl DiagnosticCount {
   pub fn merge(&self, local: DiagnosticSnapshot) {
-    self.error.fetch_add(local.errors, Ordering::AcqRel);
-    self.warning.fetch_add(local.warnings, Ordering::AcqRel);
-    self.info.fetch_add(local.infos, Ordering::AcqRel);
-    self.hint.fetch_add(local.hints, Ordering::AcqRel);
+    // most files have no diagnostics, skip the atomic write for them
+    if local.errors > 0 {
+      self.error.fetch_add(local.errors, Ordering::AcqRel);
+    }
+    if local.warnings > 0 {
+      self.warning.fetch_add(local.warnings, Ordering::AcqRel);
+    }
   }
 
-  pub fn snapshot(&self) -> DiagnosticSnapshot {
-    DiagnosticSnapshot {
-      errors: self.error.load(Ordering::Acquire),
-      warnings: self.warning.load(Ordering::Acquire),
-      infos: self.info.load(Ordering::Acquire),
-      hints: self.hint.load(Ordering::Acquire),
-    }
+  pub fn errors(&self) -> usize {
+    self.error.load(Ordering::Acquire)
+  }
+
+  pub fn warnings(&self) -> usize {
+    self.warning.load(Ordering::Acquire)
   }
 }

--- a/crates/cli/src/utils/diagnostic_count.rs
+++ b/crates/cli/src/utils/diagnostic_count.rs
@@ -1,0 +1,68 @@
+use ast_grep_config::Severity;
+use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Default, Clone, Copy, Debug)]
+pub struct DiagnosticSnapshot {
+  pub errors: usize,
+  pub warnings: usize,
+  pub infos: usize,
+  pub hints: usize,
+}
+
+impl DiagnosticSnapshot {
+  pub fn add(&mut self, severity: &Severity, n: usize) {
+    match severity {
+      Severity::Error => self.errors = self.errors.saturating_add(n),
+      Severity::Warning => self.warnings = self.warnings.saturating_add(n),
+      Severity::Info => self.infos = self.infos.saturating_add(n),
+      Severity::Hint => self.hints = self.hints.saturating_add(n),
+      Severity::Off => {}
+    }
+  }
+
+  pub fn total(&self) -> usize {
+    self.errors + self.warnings + self.infos + self.hints
+  }
+
+  pub fn issue_total(&self) -> usize {
+    self.errors + self.warnings
+  }
+}
+
+impl fmt::Display for DiagnosticSnapshot {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let parts: Vec<String> = [(self.errors, "error"), (self.warnings, "warning")]
+      .into_iter()
+      .filter(|(n, _)| *n > 0)
+      .map(|(n, label)| format!("{n} {label}(s)"))
+      .collect();
+    write!(f, "{}", parts.join(", "))
+  }
+}
+
+#[derive(Default)]
+pub struct DiagnosticCount {
+  error: AtomicUsize,
+  warning: AtomicUsize,
+  info: AtomicUsize,
+  hint: AtomicUsize,
+}
+
+impl DiagnosticCount {
+  pub fn merge(&self, local: DiagnosticSnapshot) {
+    self.error.fetch_add(local.errors, Ordering::AcqRel);
+    self.warning.fetch_add(local.warnings, Ordering::AcqRel);
+    self.info.fetch_add(local.infos, Ordering::AcqRel);
+    self.hint.fetch_add(local.hints, Ordering::AcqRel);
+  }
+
+  pub fn snapshot(&self) -> DiagnosticSnapshot {
+    DiagnosticSnapshot {
+      errors: self.error.load(Ordering::Acquire),
+      warnings: self.warning.load(Ordering::Acquire),
+      infos: self.info.load(Ordering::Acquire),
+      hints: self.hint.load(Ordering::Acquire),
+    }
+  }
+}

--- a/crates/cli/src/utils/diagnostic_count.rs
+++ b/crates/cli/src/utils/diagnostic_count.rs
@@ -22,11 +22,15 @@ impl DiagnosticSnapshot {
   }
 
   pub fn total(&self) -> usize {
-    self.errors + self.warnings + self.infos + self.hints
+    self
+      .errors
+      .saturating_add(self.warnings)
+      .saturating_add(self.infos)
+      .saturating_add(self.hints)
   }
 
   pub fn issue_total(&self) -> usize {
-    self.errors + self.warnings
+    self.errors.saturating_add(self.warnings)
   }
 }
 

--- a/crates/cli/src/utils/diagnostic_count.rs
+++ b/crates/cli/src/utils/diagnostic_count.rs
@@ -1,12 +1,12 @@
 use ast_grep_config::Severity;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[derive(Default, Clone, Copy, Debug)]
+/// Per-file diagnostic counts, accumulated locally before one shared merge.
+/// Only errors and warnings appear in the final summary, so only they are tracked.
+#[derive(Default)]
 pub struct DiagnosticSnapshot {
   pub errors: usize,
   pub warnings: usize,
-  pub infos: usize,
-  pub hints: usize,
 }
 
 impl DiagnosticSnapshot {
@@ -14,24 +14,12 @@ impl DiagnosticSnapshot {
     match severity {
       Severity::Error => self.errors = self.errors.saturating_add(n),
       Severity::Warning => self.warnings = self.warnings.saturating_add(n),
-      Severity::Info => self.infos = self.infos.saturating_add(n),
-      Severity::Hint => self.hints = self.hints.saturating_add(n),
-      Severity::Off => {}
+      Severity::Info | Severity::Hint | Severity::Off => {}
     }
-  }
-
-  pub fn total(&self) -> usize {
-    self
-      .errors
-      .saturating_add(self.warnings)
-      .saturating_add(self.infos)
-      .saturating_add(self.hints)
   }
 }
 
 /// Shared counts merged from parallel scan workers.
-/// Only errors and warnings appear in the final summary,
-/// so only they need cross-thread accumulation.
 #[derive(Default)]
 pub struct DiagnosticCount {
   error: AtomicUsize,

--- a/crates/cli/src/utils/diagnostic_count.rs
+++ b/crates/cli/src/utils/diagnostic_count.rs
@@ -1,5 +1,4 @@
 use ast_grep_config::Severity;
-use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Default, Clone, Copy, Debug)]
@@ -27,21 +26,6 @@ impl DiagnosticSnapshot {
       .saturating_add(self.warnings)
       .saturating_add(self.infos)
       .saturating_add(self.hints)
-  }
-
-  pub fn issue_total(&self) -> usize {
-    self.errors.saturating_add(self.warnings)
-  }
-}
-
-impl fmt::Display for DiagnosticSnapshot {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let parts: Vec<String> = [(self.errors, "error"), (self.warnings, "warning")]
-      .into_iter()
-      .filter(|(n, _)| *n > 0)
-      .map(|(n, label)| format!("{n} {label}(s)"))
-      .collect();
-    write!(f, "{}", parts.join(", "))
   }
 }
 

--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -6,6 +6,8 @@ use std::fmt;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use super::DiagnosticSnapshot;
+
 const DOC_SITE_HOST: &str = "https://ast-grep.github.io";
 const PATTERN_GUIDE: Option<&str> = Some("/guide/pattern-syntax.html");
 const ESQUERY_GUIDE: Option<&str> = Some("/reference/rule/esquery.html");
@@ -49,7 +51,7 @@ pub enum ErrorContext {
   PatternHasError,
   // Scan
   DuplicateRuleId(String),
-  DiagnosticError(usize),
+  DiagnosticReport(DiagnosticSnapshot),
   RuleNotSpecified,
   RuleNotFound(String),
   // LSP
@@ -78,7 +80,7 @@ impl ErrorContext {
     use ErrorContext::*;
     // reference: https://mariadb.com/kb/en/operating-system-error-codes/
     match self {
-      DiagnosticError(_) => 1,
+      DiagnosticReport(snapshot) if snapshot.errors > 0 => 1,
       // skip 2 to avoid conflict with clap error code or unexpected error
       ProjectNotExist | LanguageNotSpecified | RuleNotSpecified | RuleNotFound(_) => 3,
       TestFail(_) | TestSnapshotMismatch(_) => 4,
@@ -95,7 +97,7 @@ impl ErrorContext {
       CustomLanguage => 79,
       OpenEditor | StartLanguageServer => 126,
       // soft error
-      PatternHasError | ExitInteractiveEditing => 0,
+      PatternHasError | ExitInteractiveEditing | DiagnosticReport(_) => 0,
     }
   }
 
@@ -204,9 +206,9 @@ impl ErrorMessage {
         "Multiple rule files have the same id. Please add a unique `id` field to each rule.",
         CONFIG_GUIDE,
       ),
-      DiagnosticError(num) => Self::new(
-        format!("{num} error(s) found in code."),
-        "Scan succeeded and found error level diagnostics in the codebase.",
+      DiagnosticReport(snapshot) => Self::new(
+        format!("{snapshot} found in code."),
+        "Scan succeeded and found diagnostics in the codebase.",
         None,
       ),
       ParsePattern => Self::new(

--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -315,6 +315,25 @@ impl ErrorMessage {
   }
 }
 
+/// Print a summary for warning diagnostics found in a scan.
+/// Warnings alone do not fail the scan, so this is not an ErrorContext;
+/// it reuses the soft-error styling to match `DiagnosticError`'s summary.
+pub fn report_warning_summary(warnings: usize) {
+  if warnings == 0 {
+    return;
+  }
+  let style = if std::io::stderr().is_tty() {
+    ErrorStyle::colored()
+  } else {
+    ErrorStyle::default()
+  };
+  let notice = style.warning.paint("Warning:");
+  let message = style
+    .message
+    .paint(format!("{warnings} warning(s) found in code."));
+  eprintln!("{notice} {message}");
+}
+
 pub fn exit_with_error(error: Error) -> Result<ExitCode> {
   if let Some(e) = error.downcast_ref::<clap::Error>() {
     e.exit()

--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -6,8 +6,6 @@ use std::fmt;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use super::DiagnosticSnapshot;
-
 const DOC_SITE_HOST: &str = "https://ast-grep.github.io";
 const PATTERN_GUIDE: Option<&str> = Some("/guide/pattern-syntax.html");
 const ESQUERY_GUIDE: Option<&str> = Some("/reference/rule/esquery.html");
@@ -51,7 +49,7 @@ pub enum ErrorContext {
   PatternHasError,
   // Scan
   DuplicateRuleId(String),
-  DiagnosticReport(DiagnosticSnapshot),
+  DiagnosticError(usize),
   RuleNotSpecified,
   RuleNotFound(String),
   // LSP
@@ -80,7 +78,7 @@ impl ErrorContext {
     use ErrorContext::*;
     // reference: https://mariadb.com/kb/en/operating-system-error-codes/
     match self {
-      DiagnosticReport(snapshot) if snapshot.errors > 0 => 1,
+      DiagnosticError(_) => 1,
       // skip 2 to avoid conflict with clap error code or unexpected error
       ProjectNotExist | LanguageNotSpecified | RuleNotSpecified | RuleNotFound(_) => 3,
       TestFail(_) | TestSnapshotMismatch(_) => 4,
@@ -97,7 +95,7 @@ impl ErrorContext {
       CustomLanguage => 79,
       OpenEditor | StartLanguageServer => 126,
       // soft error
-      PatternHasError | ExitInteractiveEditing | DiagnosticReport(_) => 0,
+      PatternHasError | ExitInteractiveEditing => 0,
     }
   }
 
@@ -206,9 +204,9 @@ impl ErrorMessage {
         "Multiple rule files have the same id. Please add a unique `id` field to each rule.",
         CONFIG_GUIDE,
       ),
-      DiagnosticReport(snapshot) => Self::new(
-        format!("{snapshot} found in code."),
-        "Scan succeeded and found diagnostics in the codebase.",
+      DiagnosticError(num) => Self::new(
+        format!("{num} error(s) found in code."),
+        "Scan succeeded and found error level diagnostics in the codebase.",
         None,
       ),
       ParsePattern => Self::new(

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -1,5 +1,6 @@
 mod args;
 mod debug_query;
+mod diagnostic_count;
 mod error_context;
 mod inspect;
 mod print_diff;
@@ -8,6 +9,7 @@ mod worker;
 
 pub use args::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs};
 pub use debug_query::DebugFormat;
+pub use diagnostic_count::{DiagnosticCount, DiagnosticSnapshot};
 pub use error_context::{ErrorContext, exit_with_error};
 pub use inspect::{FileTrace, Granularity, RuleTrace, RunTrace, ScanTrace};
 pub use print_diff::DiffStyles;

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -10,7 +10,7 @@ mod worker;
 pub use args::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs};
 pub use debug_query::DebugFormat;
 pub use diagnostic_count::{DiagnosticCount, DiagnosticSnapshot};
-pub use error_context::{ErrorContext, exit_with_error};
+pub use error_context::{ErrorContext, exit_with_error, report_warning_summary};
 pub use inspect::{FileTrace, Granularity, RuleTrace, RunTrace, ScanTrace};
 pub use print_diff::DiffStyles;
 pub use rule_overwrite::RuleOverwrite;

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -343,6 +343,99 @@ fn test_severity_override_with_inline_rule_and_stdin() -> Result<()> {
   Ok(())
 }
 
+#[test]
+fn test_scan_reports_warning_diagnostic_summary() -> Result<()> {
+  let dir = setup()?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan"])
+    .assert()
+    .success()
+    .stderr(contains("Warning: 1 warning(s) found in code."));
+  Ok(())
+}
+
+const MULTI_SEVERITY_RULES: &str = "
+id: error-rule
+message: error rule
+severity: error
+language: TypeScript
+rule: { pattern: error($A) }
+---
+id: warning-rule
+message: warning rule
+severity: warning
+language: TypeScript
+rule: { pattern: warning($A) }
+---
+id: info-rule
+message: info rule
+severity: info
+language: TypeScript
+rule: { pattern: info($A) }
+---
+id: hint-rule
+message: hint rule
+severity: hint
+language: TypeScript
+rule: { pattern: hint($A) }
+";
+
+#[test]
+fn test_scan_reports_mixed_diagnostic_summary() -> Result<()> {
+  let dir = create_test_files([
+    ("rule.yml", MULTI_SEVERITY_RULES),
+    ("test.ts", "error(1); warning(2); info(3); hint(4)"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan", "-r", "rule.yml"])
+    .assert()
+    .failure()
+    .stderr(contains("Error: 1 error(s), 1 warning(s) found in code."));
+  Ok(())
+}
+
+const INFO_HINT_RULES: &str = "
+id: info-rule
+message: info rule
+severity: info
+language: TypeScript
+rule: { pattern: info($A) }
+---
+id: hint-rule
+message: hint rule
+severity: hint
+language: TypeScript
+rule: { pattern: hint($A) }
+";
+
+#[test]
+fn test_scan_does_not_report_info_hint_summary() -> Result<()> {
+  let dir = create_test_files([
+    ("rule.yml", INFO_HINT_RULES),
+    ("test.ts", "info(1); hint(2)"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan", "-r", "rule.yml"])
+    .assert()
+    .success()
+    .stderr(contains("found in code.").not());
+  Ok(())
+}
+
+#[test]
+fn test_scan_reports_stdin_diagnostic_summary() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args(["scan", "--stdin", "--inline-rules", RULE1, "--json"])
+    .write_stdin("Some(1); Some(2)")
+    .assert()
+    .success()
+    .stderr(contains("Warning: 2 warning(s) found in code."));
+  Ok(())
+}
+
 const PY_RULE: &str = r"
 id: transform-indent
 language: python

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -397,24 +397,10 @@ fn test_scan_reports_mixed_diagnostic_summary() -> Result<()> {
   Ok(())
 }
 
-const INFO_HINT_RULES: &str = "
-id: info-rule
-message: info rule
-severity: info
-language: TypeScript
-rule: { pattern: info($A) }
----
-id: hint-rule
-message: hint rule
-severity: hint
-language: TypeScript
-rule: { pattern: hint($A) }
-";
-
 #[test]
 fn test_scan_does_not_report_info_hint_summary() -> Result<()> {
   let dir = create_test_files([
-    ("rule.yml", INFO_HINT_RULES),
+    ("rule.yml", MULTI_SEVERITY_RULES),
     ("test.ts", "info(1); hint(2)"),
   ])?;
   Command::new(cargo_bin!())
@@ -422,6 +408,8 @@ fn test_scan_does_not_report_info_hint_summary() -> Result<()> {
     .args(["scan", "-r", "rule.yml"])
     .assert()
     .success()
+    .stdout(contains("info-rule"))
+    .stdout(contains("hint-rule"))
     .stderr(contains("found in code.").not());
   Ok(())
 }
@@ -434,6 +422,54 @@ fn test_scan_reports_stdin_diagnostic_summary() -> Result<()> {
     .assert()
     .success()
     .stderr(contains("Warning: 2 warning(s) found in code."));
+  Ok(())
+}
+
+#[test]
+fn test_scan_stdin_max_results_counts_off_matches() -> Result<()> {
+  // off-severity matches must consume the --max-results budget
+  // even though they are excluded from severity counting.
+  // rule iteration order is randomized, so repeat the scan to
+  // exercise the ordering where the off rule is truncated first
+  let rules = "
+id: off-rule
+severity: off
+language: TypeScript
+rule: { pattern: off($A) }
+---
+id: warn-rule
+message: warn rule
+severity: warning
+language: TypeScript
+rule: { pattern: warn($A) }
+";
+  for _ in 0..8 {
+    let output = Command::new(cargo_bin!())
+      .args(["scan", "--stdin", "--inline-rules", rules, "--json"])
+      .args(["--max-results", "1"])
+      .write_stdin("off(1); warn(1)")
+      .assert()
+      .success()
+      .get_output()
+      .stdout
+      .clone();
+    let json: Value = from_slice(&output)?;
+    let matches = json.as_array().expect("should be array");
+    assert_eq!(matches.len(), 1, "off matches must consume the budget");
+  }
+  Ok(())
+}
+
+#[test]
+fn test_scan_stdin_update_all_omits_summary() -> Result<()> {
+  // fix-application modes should not report just-fixed diagnostics
+  Command::new(cargo_bin!())
+    .args(["scan", "--stdin", "--update-all", "--inline-rules"])
+    .arg(FIXABLE_JS_RULE)
+    .write_stdin("var a = 1;")
+    .assert()
+    .success()
+    .stderr(contains("found in code.").not());
   Ok(())
 }
 

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -392,7 +392,8 @@ fn test_scan_reports_mixed_diagnostic_summary() -> Result<()> {
     .args(["scan", "-r", "rule.yml"])
     .assert()
     .failure()
-    .stderr(contains("Error: 1 error(s), 1 warning(s) found in code."));
+    .stderr(contains("Warning: 1 warning(s) found in code."))
+    .stderr(contains("Error: 1 error(s) found in code."));
   Ok(())
 }
 


### PR DESCRIPTION
Hi team, this is my first contribution to ast-grep. I tried to keep the change small and follow the existing style, but I may have missed some project conventions. Happy to adjust anything as needed. Fixes #2633

## Changes

- Report scan summaries for all issue-level diagnostics, not just errors.
- Include both error and warning counts in the final scan message.
- Keep info/hint diagnostics out of the final issue summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostic summary output with accurate, separate error and warning totals for both file and stdin scanning (including JSON/stdin flows).
* **Bug Fixes**
  * Corrected how diagnostic limits are applied, ensuring reported counts match configured truncation and ignore non-counted severities where appropriate; summary is now omitted in fix-application mode.
* **Tests**
  * Added/expanded CLI integration tests to verify stderr formatting, severity-specific counting, stdout vs stderr behavior, stdin `--json` warning totals, and `--max-results`/`--update-all` summary rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->