### PR TITLE
Fix specific-rule suppression in block comments

### DIFF
--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -34,6 +34,16 @@ rule:
   pattern: Some($A)
 ";
 
+const CSS_RULE: &str = "
+id: my-rule
+message: test rule
+severity: warning
+language: Css
+rule:
+  kind: declaration
+  regex: '^border\\s*:\\s*3px\\s+dashed\\b'
+";
+
 fn setup() -> Result<TempDir> {
   let dir = create_test_files([
     ("sgconfig.yml", CONFIG),
@@ -159,6 +169,27 @@ fn test_scan_unused_suppression() -> Result<()> {
     .assert()
     .success()
     .stdout(contains("unused-suppression"));
+  Ok(())
+}
+
+#[test]
+fn test_scan_css_specific_rule_suppression() -> Result<()> {
+  let dir = create_test_files([
+    ("rule.yml", CSS_RULE),
+    (
+      "test.css",
+      ".x {\n  /* ast-grep-ignore: my-rule */\n  border: 3px dashed red;\n}\n\n.y {\n  border: 3px dashed blue;\n}\n",
+    ),
+  ])?;
+  let output = Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan", "-r", "rule.yml", "test.css"])
+    .output()?;
+  assert!(output.status.success());
+  let stdout = String::from_utf8(output.stdout)?;
+  assert_eq!(stdout.matches("my-rule").count(), 1);
+  assert!(!stdout.contains("border: 3px dashed red;"));
+  assert!(stdout.contains("border: 3px dashed blue;"));
   Ok(())
 }
 

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -379,7 +379,11 @@ fn parse_suppression_set(text: &str) -> Option<HashSet<String>> {
     return None;
   }
   let (_, rules) = after.split_once(':')?;
-  let set = rules.split(',').map(|r| r.trim().to_string()).collect();
+  let rules = rules.trim().trim_end_matches("*/").trim();
+  let set = rules
+    .split(',')
+    .map(|r| r.trim().trim_end_matches("*/").trim().to_string())
+    .collect();
   Some(set)
 }
 
@@ -454,6 +458,21 @@ language: Tsx",
       assert_eq!(matches.1.len(), 2);
       assert_eq!(matches.1[0].text(), "console.log('no ignore')");
       assert_eq!(matches.1[1].text(), "console.log('ignore another')");
+    });
+  }
+
+  #[test]
+  fn test_ignore_node_block_comment_specific_rule() {
+    let source = r#"
+    /* ast-grep-ignore: test */
+    console.log('ignored')
+    /* ast-grep-ignore: not-test */
+    console.log('reported')
+    "#;
+    test_scan(source, |scanned| {
+      let matches = &scanned[0];
+      assert_eq!(matches.1.len(), 1);
+      assert_eq!(matches.1[0].text(), "console.log('reported')");
     });
   }
 


### PR DESCRIPTION
Fixes #2644.

## Summary
- trim block comment terminators when parsing `ast-grep-ignore: rule-id` directives
- add a config-layer regression test covering block comment specific-rule suppression
- add a CLI regression test that reproduces the CSS suppression scenario from the bug report

## Testing
- `cargo test -p ast-grep-config combined -- --nocapture`
- `cargo test -p ast-grep --test scan_test -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suppression directive parsing to more robustly handle whitespace normalization and various block comment formats, enhancing the reliability of rule suppression across different code contexts.

* **Tests**
  * Added comprehensive test coverage for CSS-specific rule suppression, verifying that ignore directives correctly suppress matching rules while still reporting diagnostic violations for rules without suppression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->