### PR TITLE
feat(cli): add `ast-grep playground` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "ast-grep-language",
  "ast-grep-lsp",
  "atty",
+ "base64",
  "clap",
  "clap_complete",
  "codespan-reporting",
@@ -121,6 +122,7 @@ dependencies = [
  "dashmap",
  "ignore",
  "inquire",
+ "open",
  "predicates",
  "regex",
  "serde",
@@ -287,6 +289,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -908,6 +916,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1214,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1246,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,8 @@ similar = { version = "3.0.0", features = ["inline"] }
 smallvec = "1.13.2"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-std"] }
 clap_complete = "4.5.2"
+base64 = "0.22"
+open = "5"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -4,7 +4,6 @@ use crate::utils::{ErrorContext as EC, RuleOverwrite, RuleTrace};
 use anyhow::{Context, Result};
 use ast_grep_config::{
   from_str, from_yaml_string, DeserializeEnv, GlobalRules, RuleCollection, RuleConfig,
-  SerializableGlobalRule,
 };
 use ast_grep_language::config_file_type;
 use ignore::WalkBuilder;
@@ -91,10 +90,6 @@ impl ProjectConfig {
     read_directory_yaml(self, global_rules, rule_overwrite)
   }
 
-  pub fn find_util_rule_configs(&self) -> Result<Vec<SerializableGlobalRule<SgLang>>> {
-    find_util_rule_configs(self)
-  }
-
   /// returns a Result of Result.
   /// The inner Result is for configuration not found, or ProjectNotExist
   /// The outer Result is for definitely wrong config.
@@ -136,19 +131,13 @@ fn build_util_walker(base_dir: &Path, util_dirs: &Option<Vec<PathBuf>>) -> Optio
 }
 
 fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
-  let utils = find_util_rule_configs(config)?;
-  let ret = DeserializeEnv::<SgLang>::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
-  Ok(ret)
-}
-
-fn find_util_rule_configs(config: &ProjectConfig) -> Result<Vec<SerializableGlobalRule<SgLang>>> {
   let ProjectConfig {
     project_dir,
     util_dirs,
     ..
   } = config;
   let Some(mut walker) = build_util_walker(project_dir, util_dirs) else {
-    return Ok(vec![]);
+    return Ok(GlobalRules::default());
   };
   let mut utils = vec![];
   let walker = walker.types(config_file_type()).build();
@@ -165,11 +154,13 @@ fn find_util_rule_configs(config: &ProjectConfig) -> Result<Vec<SerializableGlob
     let path = config_file.path();
     let file = read_to_string(path)
       .with_context(|| format!("failed to read util rule file {}", path.display()))?;
-    let new_config: SerializableGlobalRule<SgLang> = from_str(&file)
+    let new_configs = from_str(&file)
       .with_context(|| format!("failed to parse util rule file {}", path.display()))?;
-    utils.push(new_config);
+    utils.push(new_configs);
   }
-  Ok(utils)
+
+  let ret = DeserializeEnv::<SgLang>::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
+  Ok(ret)
 }
 
 fn read_directory_yaml(

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -4,6 +4,7 @@ use crate::utils::{ErrorContext as EC, RuleOverwrite, RuleTrace};
 use anyhow::{Context, Result};
 use ast_grep_config::{
   from_str, from_yaml_string, DeserializeEnv, GlobalRules, RuleCollection, RuleConfig,
+  SerializableGlobalRule,
 };
 use ast_grep_language::config_file_type;
 use ignore::WalkBuilder;
@@ -90,6 +91,10 @@ impl ProjectConfig {
     read_directory_yaml(self, global_rules, rule_overwrite)
   }
 
+  pub fn find_util_rule_configs(&self) -> Result<Vec<SerializableGlobalRule<SgLang>>> {
+    find_util_rule_configs(self)
+  }
+
   /// returns a Result of Result.
   /// The inner Result is for configuration not found, or ProjectNotExist
   /// The outer Result is for definitely wrong config.
@@ -131,13 +136,19 @@ fn build_util_walker(base_dir: &Path, util_dirs: &Option<Vec<PathBuf>>) -> Optio
 }
 
 fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
+  let utils = find_util_rule_configs(config)?;
+  let ret = DeserializeEnv::<SgLang>::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
+  Ok(ret)
+}
+
+fn find_util_rule_configs(config: &ProjectConfig) -> Result<Vec<SerializableGlobalRule<SgLang>>> {
   let ProjectConfig {
     project_dir,
     util_dirs,
     ..
   } = config;
   let Some(mut walker) = build_util_walker(project_dir, util_dirs) else {
-    return Ok(GlobalRules::default());
+    return Ok(vec![]);
   };
   let mut utils = vec![];
   let walker = walker.types(config_file_type()).build();
@@ -152,13 +163,13 @@ fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
       continue;
     }
     let path = config_file.path();
-    let file = read_to_string(path)?;
-    let new_configs = from_str(&file)?;
-    utils.push(new_configs);
+    let file = read_to_string(path)
+      .with_context(|| format!("failed to read util rule file {}", path.display()))?;
+    let new_config: SerializableGlobalRule<SgLang> = from_str(&file)
+      .with_context(|| format!("failed to parse util rule file {}", path.display()))?;
+    utils.push(new_config);
   }
-
-  let ret = DeserializeEnv::<SgLang>::parse_global_utils(utils).context(EC::InvalidGlobalUtils)?;
-  Ok(ret)
+  Ok(utils)
 }
 
 fn read_directory_yaml(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod lang;
 mod lsp;
 mod new;
+mod playground;
 mod print;
 mod run;
 mod scan;
@@ -17,6 +18,7 @@ use completions::{run_shell_completion, CompletionsArg};
 use config::ProjectConfig;
 use lsp::{run_language_server, LspArg};
 use new::{run_create_new, NewArg};
+use playground::{run_playground, PlaygroundArg};
 use run::{run_with_pattern, RunArg};
 use scan::{run_with_config, ScanArg};
 use utils::exit_with_error;
@@ -58,6 +60,8 @@ enum Commands {
   New(NewArg),
   /// Start language server.
   Lsp(LspArg),
+  /// Open a rule and/or file in the ast-grep playground (https://ast-grep.github.io/playground.html).
+  Playground(PlaygroundArg),
   /// Generate shell completion script.
   Completions(CompletionsArg),
   /// Generate rule docs for current configuration. (Not Implemented Yet)
@@ -139,6 +143,7 @@ pub fn main_with_args(args: impl Iterator<Item = String>) -> Result<ExitCode> {
     Commands::Test(arg) => run_test_rule(arg, project),
     Commands::New(arg) => run_create_new(arg, project),
     Commands::Lsp(arg) => run_language_server(arg, project).map(|_| ExitCode::SUCCESS),
+    Commands::Playground(arg) => run_playground(arg, project),
     Commands::Completions(arg) => run_shell_completion::<App>(arg),
     #[cfg(debug_assertions)]
     Commands::Docs => todo!("todo, generate rule docs based on current config"),
@@ -321,5 +326,18 @@ mod test_cli {
     ok("completions fish");
     error("completions not-shell");
     error("completions --shell fish");
+  }
+
+  #[test]
+  fn test_playground() {
+    ok("playground --file a.ts");
+    ok("playground -f a.ts");
+    ok("playground --rule no-console");
+    ok("playground -r no-console");
+    ok("playground --rule-file rule.yml");
+    ok("playground --file a.ts --rule no-console");
+    ok("playground --file a.ts --lang typescript");
+    ok("playground --file a.ts --print");
+    error("playground --rule r --rule-file r.yml");
   }
 }

--- a/crates/cli/src/playground.rs
+++ b/crates/cli/src/playground.rs
@@ -1,0 +1,947 @@
+use std::fs::read_to_string;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use ansi_term::{Color, Style};
+use anyhow::{anyhow, Result};
+use ast_grep_config::{RuleConfig, SerializableGlobalRule};
+use ast_grep_core::Language;
+use ast_grep_language::SupportLang;
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use clap::Args;
+use crossterm::tty::IsTty;
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Mapping, Value};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::config::ProjectConfig;
+use crate::lang::SgLang;
+use crate::utils::RuleOverwrite;
+
+const PLAYGROUND_BASE: &str = "https://ast-grep.github.io/playground.html";
+
+/// `ansi_term` styles applied to the `--print`-less stderr status lines.
+#[derive(Default)]
+struct StatusStyles {
+  info: Style,
+  success: Style,
+  warning: Style,
+}
+
+impl StatusStyles {
+  /// Pick colored styles when stderr is a TTY and `NO_COLOR`/`TERM=dumb`
+  /// aren't set; fall back to plain `Style::default()` otherwise.
+  fn auto() -> Self {
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let dumb = std::env::var_os("TERM")
+      .map(|t| t == "dumb")
+      .unwrap_or(false);
+    if no_color || dumb || !std::io::stderr().is_tty() {
+      Self::default()
+    } else {
+      Self {
+        info: Style::new().dimmed(),
+        success: Style::new().fg(Color::Green),
+        warning: Style::new().fg(Color::Yellow),
+      }
+    }
+  }
+}
+
+/// State shared with the web playground via the URL fragment.
+///
+/// Mirrors the `State` shape declared in
+/// `website/src/components/astGrep/state.ts`; the frontend merges this over
+/// its `defaultState`, so fields we leave empty get filled in.
+#[derive(Serialize, Default, Debug)]
+pub struct PlaygroundState {
+  pub mode: String,
+  pub query: String,
+  pub rewrite: String,
+  pub config: String,
+  pub source: String,
+  pub strictness: String,
+  pub selector: String,
+  pub lang: String,
+}
+
+/// Encode the state as `base64(utf8(json(state)))` and append it to the
+/// playground URL as a fragment. The encoding is bit-compatible with the
+/// frontend's `btoa(unescape(encodeURIComponent(JSON.stringify(state))))`.
+pub fn build_url(state: &PlaygroundState) -> String {
+  let json = serde_json::to_string(state).expect("PlaygroundState is always serializable");
+  let fragment = B64.encode(json.as_bytes());
+  format!("{PLAYGROUND_BASE}#{fragment}")
+}
+
+/// Pick the playground `lang` field, preferring `--lang` > the rule's
+/// `language` > the file's extension. Errors when the resolved language is
+/// not supported by the web playground (Dart / Haskell / Solidity / custom).
+pub(crate) fn resolve_lang(
+  flag: Option<&str>,
+  rule_lang: Option<SgLang>,
+  file: Option<&Path>,
+) -> Result<String> {
+  if let Some(s) = flag {
+    let lang = SgLang::from_str(s).map_err(|_| anyhow!("unsupported --lang value: {s}"))?;
+    return playground_lang_name(lang);
+  }
+  if let Some(lang) = rule_lang {
+    return playground_lang_name(lang);
+  }
+  if let Some(path) = file {
+    if let Some(lang) = SgLang::from_path(path) {
+      return playground_lang_name(lang);
+    }
+  }
+  Err(anyhow!("could not infer language; pass --lang explicitly"))
+}
+
+/// Map an `SgLang` to the lowercase identifier the playground expects, or
+/// error if the language isn't in `SupportedLang` on the web side.
+fn playground_lang_name(lang: SgLang) -> Result<String> {
+  let name: &'static str = match lang {
+    SgLang::Builtin(builtin) => match builtin {
+      SupportLang::Bash => "bash",
+      SupportLang::C => "c",
+      SupportLang::Cpp => "cpp",
+      SupportLang::CSharp => "csharp",
+      SupportLang::Css => "css",
+      SupportLang::Elixir => "elixir",
+      SupportLang::Go => "go",
+      SupportLang::Hcl => "hcl",
+      SupportLang::Html => "html",
+      SupportLang::Java => "java",
+      SupportLang::JavaScript => "javascript",
+      SupportLang::Json => "json",
+      SupportLang::Kotlin => "kotlin",
+      SupportLang::Lua => "lua",
+      SupportLang::Nix => "nix",
+      SupportLang::Php => "php",
+      SupportLang::Python => "python",
+      SupportLang::Ruby => "ruby",
+      SupportLang::Rust => "rust",
+      SupportLang::Scala => "scala",
+      SupportLang::Swift => "swift",
+      SupportLang::Tsx => "tsx",
+      SupportLang::TypeScript => "typescript",
+      SupportLang::Yaml => "yaml",
+      SupportLang::Dart | SupportLang::Haskell | SupportLang::Solidity => {
+        return Err(unsupported_playground_lang(lang));
+      }
+    },
+    SgLang::Custom(_) => return Err(unsupported_playground_lang(lang)),
+  };
+  Ok(name.into())
+}
+
+/// Build the consistent "language X not supported" error used wherever the
+/// playground's `SupportedLang` set is consulted.
+fn unsupported_playground_lang(lang: SgLang) -> anyhow::Error {
+  let name = lang.to_string().to_lowercase();
+  anyhow!("language '{name}' is not supported by the web playground")
+}
+
+/// Read the source file into a string, or return an empty string when no
+/// file was supplied (i.e. user is opening the playground with rule only).
+pub(crate) fn resolve_source(file: Option<&Path>) -> Result<String> {
+  match file {
+    None => Ok(String::new()),
+    Some(path) => read_to_string(path)
+      .map_err(|e| anyhow!("failed to read source file {}: {e}", path.display())),
+  }
+}
+
+/// Result of rule resolution: (YAML text, optional language).
+type ResolvedRule = (String, Option<SgLang>);
+
+/// Resolve `--rule-file` or `--rule <ID>` into the YAML text the playground
+/// should display along with the inferred language. Returns `None` when the
+/// user passed only `--file`.
+pub(crate) fn resolve_rule(
+  rule_id: Option<&str>,
+  rule_file: Option<&Path>,
+  project: Option<&ProjectConfig>,
+) -> Result<Option<ResolvedRule>> {
+  if let Some(path) = rule_file {
+    let yaml = read_to_string(path)
+      .map_err(|e| anyhow!("failed to read rule file {}: {e}", path.display()))?;
+    let lang = infer_rule_file_lang(&yaml)?;
+    return Ok(Some((yaml, lang)));
+  }
+  if let Some(id) = rule_id {
+    let project = project.ok_or_else(|| {
+      anyhow!("--rule '{id}' requires a project config (sgconfig.yml) - not found")
+    })?;
+    let (collection, _trace) = project
+      .find_rules(RuleOverwrite::default())
+      .map_err(|e| anyhow!("failed to load project rules: {e}"))?;
+    let rule = collection
+      .get_rule(id)
+      .ok_or_else(|| anyhow!("rule id '{id}' not found in project config"))?;
+    let mut value = rule_to_yaml_value(rule)?;
+    let mut queue = VecDeque::new();
+    collect_matches(&value, &mut queue);
+    let utils = if queue.is_empty() {
+      Vec::new()
+    } else {
+      project
+        .find_util_rule_configs()
+        .map_err(|e| anyhow!("failed to load project utilities: {e}"))?
+    };
+    inline_project_utils(&mut value, rule.language, &utils, queue)?;
+    let yaml = serde_yaml::to_string(&value)
+      .map_err(|e| anyhow!("failed to serialize rule '{}' to YAML: {e}", rule.id))?;
+    return Ok(Some((yaml, Some(rule.language))));
+  }
+  Ok(None)
+}
+
+/// Extract the `language:` field from each YAML document in `--rule-file`
+/// content without going through the full rule deserializer — which would
+/// otherwise fail when a rule references project utilities not loaded here.
+/// For multi-document YAML the last document's language wins.
+fn infer_rule_file_lang(yaml: &str) -> Result<Option<SgLang>> {
+  let mut lang = None;
+  for doc in serde_yaml::Deserializer::from_str(yaml) {
+    let value =
+      Value::deserialize(doc).map_err(|e| anyhow!("failed to parse rule file YAML: {e}"))?;
+    let Some(map) = value.as_mapping() else {
+      continue;
+    };
+    let key = Value::String("language".into());
+    let Some(value) = map.get(&key) else {
+      continue;
+    };
+    lang = Some(
+      SgLang::deserialize(value.clone())
+        .map_err(|e| anyhow!("failed to parse rule file language: {e}"))?,
+    );
+  }
+  Ok(lang)
+}
+
+/// Serialize a `RuleConfig` to a `serde_yaml::Value`, then drop empty
+/// optional fields so the playground sees a clean rule body.
+fn rule_to_yaml_value(rule: &RuleConfig<SgLang>) -> Result<Value> {
+  let mut value = serde_yaml::to_value(&**rule)
+    .map_err(|e| anyhow!("failed to serialize rule '{}' to YAML: {e}", rule.id))?;
+  strip_serialized_null_fields(&mut value);
+  Ok(value)
+}
+
+/// Recursively drop `key: null` entries from a YAML value, but only for keys
+/// in [`is_serialized_optional_key`]. The contents of `metadata:` are
+/// passed through untouched since it's user-controlled free-form data.
+fn strip_serialized_null_fields(value: &mut Value) {
+  match value {
+    Value::Mapping(map) => {
+      map.retain(|key, value| !(value.is_null() && is_serialized_optional_key(key)));
+      for (key, value) in map.iter_mut() {
+        if key.as_str() != Some("metadata") {
+          strip_serialized_null_fields(value);
+        }
+      }
+    }
+    Value::Sequence(seq) => {
+      for value in seq {
+        strip_serialized_null_fields(value);
+      }
+    }
+    Value::Tagged(tagged) => strip_serialized_null_fields(&mut tagged.value),
+    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+  }
+}
+
+/// `Option<...>` fields on `SerializableRuleConfig` / `SerializableRuleCore`
+/// that should be elided when serialized to `null`. Driven from the schema
+/// in `crates/config/src/rule_config.rs`; keep in sync if a new optional
+/// field is added there.
+fn is_serialized_optional_key(key: &Value) -> bool {
+  matches!(
+    key.as_str(),
+    Some(
+      "constraints"
+        | "field"
+        | "files"
+        | "fix"
+        | "ignores"
+        | "labels"
+        | "metadata"
+        | "note"
+        | "ofRule"
+        | "rewriters"
+        | "selector"
+        | "strictness"
+        | "transform"
+        | "url"
+        | "utils"
+    )
+  )
+}
+
+/// Walk the rule's `matches:` references and inline the targeted project
+/// utilities into a local `utils:` block, so the playground URL is
+/// self-contained. `queue` is the set of util ids reachable from the rule,
+/// pre-collected by [`collect_matches`].
+fn inline_project_utils(
+  rule: &mut Value,
+  rule_lang: SgLang,
+  global_utils: &[SerializableGlobalRule<SgLang>],
+  mut queue: VecDeque<String>,
+) -> Result<()> {
+  let global_utils: HashMap<_, _> = global_utils
+    .iter()
+    .map(|util| (util.id.as_str(), util))
+    .collect();
+
+  let rule_map = rule
+    .as_mapping_mut()
+    .ok_or_else(|| anyhow!("serialized rule must be a YAML mapping"))?;
+  let mut utils = match rule_map.shift_remove("utils") {
+    Some(Value::Mapping(utils)) => utils,
+    Some(Value::Null) | None => Mapping::new(),
+    Some(_) => return Err(anyhow!("serialized rule has invalid `utils` field")),
+  };
+  let local_ids: HashSet<_> = utils
+    .keys()
+    .filter_map(Value::as_str)
+    .map(str::to_string)
+    .collect();
+  let mut included = HashSet::new();
+
+  while let Some(id) = queue.pop_front() {
+    if !included.insert(id.clone()) || local_ids.contains(&id) {
+      continue;
+    }
+    let Some(util) = global_utils.get(id.as_str()) else {
+      continue;
+    };
+    let util_rule = project_util_to_local_util(util, rule_lang)?;
+    collect_matches(&util_rule, &mut queue);
+    utils.insert(Value::String(id), util_rule);
+  }
+
+  if !utils.is_empty() {
+    rule_map.insert(Value::String("utils".into()), Value::Mapping(utils));
+  }
+  Ok(())
+}
+
+/// Convert a project-level global utility into a value suitable for the
+/// playground's local `utils:` block. Rejects utilities that can't be
+/// represented locally (parameterized, language-mismatched, or carrying
+/// constraints / transforms / fix that aren't supported on local utils).
+fn project_util_to_local_util(
+  util: &SerializableGlobalRule<SgLang>,
+  rule_lang: SgLang,
+) -> Result<Value> {
+  if util.language != rule_lang {
+    return Err(anyhow!(
+      "project utility '{}' uses language '{}' but the selected rule uses '{}'",
+      util.id,
+      util.language,
+      rule_lang
+    ));
+  }
+  if util.arguments.as_ref().is_some_and(|args| !args.is_empty()) {
+    return Err(anyhow!(
+      "project utility '{}' is parameterized and cannot be shared with the playground",
+      util.id
+    ));
+  }
+  if util.core.constraints.is_some()
+    || util.core.utils.is_some()
+    || util.core.transform.is_some()
+    || util.core.fix.is_some()
+  {
+    return Err(anyhow!(
+      "project utility '{}' uses fields that cannot be represented as playground local utils",
+      util.id
+    ));
+  }
+  let mut value = serde_yaml::to_value(&util.core.rule).map_err(|e| {
+    anyhow!(
+      "failed to serialize project utility '{}' to YAML: {e}",
+      util.id
+    )
+  })?;
+  strip_serialized_null_fields(&mut value);
+  rename_project_util_metavars(&mut value, rule_lang, &util.id);
+  Ok(value)
+}
+
+/// Project utilities have an independent metavariable scope; playground
+/// local utils share scope with the caller. Rewrite each metavariable in
+/// the inlined util to a per-util prefix so the scopes stay separate.
+fn rename_project_util_metavars(value: &mut Value, rule_lang: SgLang, util_id: &str) {
+  let prefix = project_util_metavar_prefix(util_id);
+  rename_metavars_in_rule(value, rule_lang.meta_var_char(), &prefix);
+}
+
+/// Build the per-util metavariable prefix. Non-alphanumeric characters in
+/// the util id are replaced with `_`; the rest is uppercased. Rule ids are
+/// unique within a project, so prefixes derived from them are too.
+fn project_util_metavar_prefix(util_id: &str) -> String {
+  let mut sanitized = String::new();
+  for ch in util_id.chars() {
+    if ch.is_ascii_alphanumeric() {
+      sanitized.push(ch.to_ascii_uppercase());
+    } else {
+      sanitized.push('_');
+    }
+  }
+  format!("AST_GREP_PLAYGROUND_{sanitized}_")
+}
+
+/// Recurse the rule YAML, rewriting metavariables in every `pattern:`
+/// scalar / `{ context: "..." }` form. Other keys (`constraints`, `fix`,
+/// `transform`) cannot appear here — they are rejected upstream by
+/// [`project_util_to_local_util`].
+fn rename_metavars_in_rule(value: &mut Value, meta_char: char, prefix: &str) {
+  match value {
+    Value::Mapping(map) => {
+      for (key, value) in map {
+        if key.as_str() == Some("pattern") {
+          rename_metavars_in_pattern_value(value, meta_char, prefix);
+        } else {
+          rename_metavars_in_rule(value, meta_char, prefix);
+        }
+      }
+    }
+    Value::Sequence(seq) => {
+      for value in seq {
+        rename_metavars_in_rule(value, meta_char, prefix);
+      }
+    }
+    Value::Tagged(tagged) => rename_metavars_in_rule(&mut tagged.value, meta_char, prefix),
+    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+  }
+}
+
+/// Apply metavariable renaming to whichever shape `pattern:` takes — a
+/// bare string, or a mapping with `{ context: "..." }`.
+fn rename_metavars_in_pattern_value(value: &mut Value, meta_char: char, prefix: &str) {
+  match value {
+    Value::String(pattern) => {
+      *pattern = rename_metavars_in_pattern(pattern, meta_char, prefix);
+    }
+    Value::Mapping(map) => {
+      for (key, value) in map {
+        if key.as_str() == Some("context") {
+          if let Value::String(context) = value {
+            *context = rename_metavars_in_pattern(context, meta_char, prefix);
+          }
+        }
+      }
+    }
+    Value::Tagged(tagged) => rename_metavars_in_pattern_value(&mut tagged.value, meta_char, prefix),
+    Value::Null | Value::Bool(_) | Value::Number(_) | Value::Sequence(_) => {}
+  }
+}
+
+/// Rewrite every `$NAME` / `$$X` / `$$$NAME` inside a pattern by prepending
+/// `prefix` to the name. Anonymous `_`-prefixed forms (`$_`, `$$$_`) and
+/// sigils without a valid name are left unchanged.
+fn rename_metavars_in_pattern(pattern: &str, meta_char: char, prefix: &str) -> String {
+  let chars: Vec<_> = pattern.chars().collect();
+  let mut ret = String::with_capacity(pattern.len() + prefix.len());
+  let mut i = 0;
+  while i < chars.len() {
+    if chars[i] != meta_char {
+      ret.push(chars[i]);
+      i += 1;
+      continue;
+    }
+    if i + 2 < chars.len() && chars[i + 1] == meta_char && chars[i + 2] == meta_char {
+      let name_start = i + 3;
+      let name_end = collect_multi_metavar_name(&chars, name_start);
+      if name_end == name_start {
+        ret.extend(chars[i..name_start].iter());
+      } else {
+        ret.extend(chars[i..name_start].iter());
+        if chars[name_start] == '_' {
+          ret.extend(chars[name_start..name_end].iter());
+        } else {
+          ret.push_str(prefix);
+          ret.extend(chars[name_start..name_end].iter());
+        }
+      }
+      i = name_end;
+      continue;
+    }
+
+    let sigil_end = if i + 1 < chars.len() && chars[i + 1] == meta_char {
+      i + 2
+    } else {
+      i + 1
+    };
+    let name_end = collect_single_metavar_name(&chars, sigil_end);
+    if name_end == sigil_end {
+      ret.extend(chars[i..sigil_end].iter());
+    } else {
+      ret.extend(chars[i..sigil_end].iter());
+      if chars[sigil_end] == '_' {
+        ret.extend(chars[sigil_end..name_end].iter());
+      } else {
+        ret.push_str(prefix);
+        ret.extend(chars[sigil_end..name_end].iter());
+      }
+    }
+    i = name_end;
+  }
+  ret
+}
+
+/// Single-sigil metavar names must start with an uppercase letter or `_`.
+fn collect_single_metavar_name(chars: &[char], start: usize) -> usize {
+  if start >= chars.len() || !is_valid_metavar_first_char(chars[start]) {
+    return start;
+  }
+  collect_metavar_name(chars, start)
+}
+
+/// Triple-sigil (variadic) metavar names allow digits in the first slot too.
+fn collect_multi_metavar_name(chars: &[char], start: usize) -> usize {
+  if start >= chars.len() || !is_valid_metavar_char(chars[start]) {
+    return start;
+  }
+  collect_metavar_name(chars, start)
+}
+
+/// Consume contiguous `[A-Z_0-9]` chars starting at `start`, returning the
+/// exclusive end index.
+fn collect_metavar_name(chars: &[char], start: usize) -> usize {
+  let mut end = start;
+  while end < chars.len() && is_valid_metavar_char(chars[end]) {
+    end += 1;
+  }
+  end
+}
+
+/// Whether `ch` can begin an ast-grep metavariable name.
+fn is_valid_metavar_first_char(ch: char) -> bool {
+  matches!(ch, 'A'..='Z' | '_')
+}
+
+/// Whether `ch` can appear inside an ast-grep metavariable name.
+fn is_valid_metavar_char(ch: char) -> bool {
+  is_valid_metavar_first_char(ch) || ch.is_ascii_digit()
+}
+
+/// Walk the rule YAML and feed every `matches:` reference into `queue` —
+/// either a bare id string or the keys of a `{ utilId: { ... args ... } }`
+/// call form.
+fn collect_matches(value: &Value, queue: &mut VecDeque<String>) {
+  match value {
+    Value::Mapping(map) => {
+      for (key, value) in map {
+        if key.as_str() == Some("matches") {
+          collect_match_ids(value, queue);
+        }
+        collect_matches(value, queue);
+      }
+    }
+    Value::Sequence(seq) => {
+      for value in seq {
+        collect_matches(value, queue);
+      }
+    }
+    Value::Tagged(tagged) => collect_matches(&tagged.value, queue),
+    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+  }
+}
+
+/// Push the ids referenced by a `matches:` value. Sequence values are not a
+/// valid `matches:` shape in ast-grep's schema, so they are skipped.
+fn collect_match_ids(value: &Value, queue: &mut VecDeque<String>) {
+  match value {
+    Value::String(id) => {
+      queue.push_back(id.clone());
+    }
+    Value::Mapping(calls) => {
+      for (callee, args) in calls {
+        if let Some(id) = callee.as_str() {
+          queue.push_back(id.to_string());
+        }
+        collect_matches(args, queue);
+      }
+    }
+    Value::Tagged(tagged) => collect_match_ids(&tagged.value, queue),
+    Value::Null | Value::Bool(_) | Value::Number(_) | Value::Sequence(_) => {}
+  }
+}
+
+/// Arguments accepted by the `ast-grep playground` subcommand.
+#[derive(Args)]
+pub struct PlaygroundArg {
+  /// Source file to load into the playground.
+  #[clap(short, long, value_name = "FILE")]
+  pub file: Option<PathBuf>,
+
+  /// Rule ID to look up in the project config and load into the playground.
+  #[clap(short, long, value_name = "ID", conflicts_with = "rule_file")]
+  pub rule: Option<String>,
+
+  /// Read rule YAML from a path (alternative to --rule).
+  #[clap(long, value_name = "PATH")]
+  pub rule_file: Option<PathBuf>,
+
+  /// Language override. Inferred from --file extension or rule's language otherwise.
+  #[clap(short, long, value_name = "LANG")]
+  pub lang: Option<String>,
+
+  /// Print the URL only; do not open the browser.
+  #[clap(long)]
+  pub print: bool,
+}
+
+/// Entry point for `ast-grep playground`: resolve the requested rule and/or
+/// source, build the playground URL, then either open it in the user's
+/// default browser or print it (when `--print` is set, or as a fallback
+/// when opening the browser fails).
+pub fn run_playground(arg: PlaygroundArg, project: Result<ProjectConfig>) -> Result<ExitCode> {
+  if arg.file.is_none() && arg.rule.is_none() && arg.rule_file.is_none() {
+    return Err(anyhow!(
+      "nothing to share - pass --file and/or --rule (or --rule-file)"
+    ));
+  }
+
+  let project_ref = project.as_ref().ok();
+
+  let (config_yaml, rule_lang) =
+    match resolve_rule(arg.rule.as_deref(), arg.rule_file.as_deref(), project_ref)? {
+      Some((yaml, lang)) => (yaml, lang),
+      None => (String::new(), None),
+    };
+
+  let source = resolve_source(arg.file.as_deref())?;
+  let lang = resolve_lang(arg.lang.as_deref(), rule_lang, arg.file.as_deref())?;
+
+  let mode = if config_yaml.is_empty() {
+    "Patch"
+  } else {
+    "Config"
+  };
+  let state = PlaygroundState {
+    mode: mode.into(),
+    lang,
+    source,
+    config: config_yaml,
+    ..PlaygroundState::default()
+  };
+  let url = build_url(&state);
+
+  if arg.print {
+    println!("{url}");
+    return Ok(ExitCode::SUCCESS);
+  }
+
+  let styles = StatusStyles::auto();
+  eprintln!(
+    "{}",
+    styles.info.paint("Opening playground in your browser...")
+  );
+  match open::that(&url) {
+    Ok(()) => {
+      eprintln!("{}", styles.success.paint("Playground opened in browser."));
+    }
+    Err(e) => {
+      eprintln!(
+        "{} {e}",
+        styles
+          .warning
+          .paint("Could not open the browser automatically:"),
+      );
+      eprintln!("Open this URL manually:");
+      println!("{url}");
+    }
+  }
+
+  Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use ast_grep_config::{from_yaml_string, GlobalRules};
+  use std::path::Path;
+  use std::str::FromStr;
+
+  fn serialize_rule_yaml(rule: &RuleConfig<SgLang>) -> String {
+    let value = rule_to_yaml_value(rule).expect("rule serializes");
+    serde_yaml::to_string(&value).expect("yaml serializes")
+  }
+
+  fn decode_state(url: &str) -> serde_json::Value {
+    let frag = url.split_once('#').expect("url has fragment").1;
+    let bytes = B64.decode(frag).expect("valid base64");
+    serde_json::from_slice(&bytes).expect("valid json")
+  }
+
+  #[test]
+  fn build_url_encodes_state_round_trip() {
+    let state = PlaygroundState {
+      mode: "Config".into(),
+      lang: "typescript".into(),
+      source: "console.log(1)".into(),
+      config: "rule:\n  pattern: console.log($A)\n".into(),
+      ..PlaygroundState::default()
+    };
+    let url = build_url(&state);
+    assert!(url.starts_with("https://ast-grep.github.io/playground.html#"));
+    let decoded = decode_state(&url);
+    assert_eq!(decoded["mode"], "Config");
+    assert_eq!(decoded["lang"], "typescript");
+    assert_eq!(decoded["source"], "console.log(1)");
+    assert_eq!(decoded["config"], "rule:\n  pattern: console.log($A)\n");
+    assert_eq!(decoded["query"], "");
+    assert_eq!(decoded["rewrite"], "");
+    assert_eq!(decoded["strictness"], "");
+    assert_eq!(decoded["selector"], "");
+  }
+
+  #[test]
+  fn build_url_handles_unicode_source() {
+    let state = PlaygroundState {
+      mode: "Patch".into(),
+      lang: "javascript".into(),
+      source: "// 你好 🦀".into(),
+      ..PlaygroundState::default()
+    };
+    let url = build_url(&state);
+    let decoded = decode_state(&url);
+    assert_eq!(decoded["source"], "// 你好 🦀");
+  }
+
+  #[test]
+  fn resolve_lang_prefers_explicit_flag() {
+    let got = resolve_lang(
+      Some("typescript"),
+      Some(SgLang::from_str("rust").unwrap()),
+      Some(Path::new("foo.js")),
+    )
+    .unwrap();
+    assert_eq!(got, "typescript");
+  }
+
+  #[test]
+  fn resolve_lang_falls_back_to_rule_language() {
+    let got = resolve_lang(
+      None,
+      Some(SgLang::from_str("rust").unwrap()),
+      Some(Path::new("foo.js")),
+    )
+    .unwrap();
+    assert_eq!(got, "rust");
+  }
+
+  #[test]
+  fn resolve_lang_falls_back_to_file_extension() {
+    let got = resolve_lang(None, None, Some(Path::new("foo.tsx"))).unwrap();
+    assert_eq!(got, "tsx");
+  }
+
+  #[test]
+  fn resolve_lang_errors_when_nothing_known() {
+    let err = resolve_lang(None, None, None).unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("--lang"));
+  }
+
+  #[test]
+  fn resolve_lang_normalises_explicit_alias_to_lowercase() {
+    let got = resolve_lang(Some("JS"), None, None).unwrap();
+    assert_eq!(got, "javascript");
+  }
+
+  #[test]
+  fn resolve_lang_rejects_playground_unsupported_lang() {
+    let cases: &[(&str, Option<&str>, Option<&Path>)] = &[
+      ("explicit flag", Some("dart"), None),
+      ("file extension", None, Some(Path::new("main.dart"))),
+    ];
+    for (desc, flag, file) in cases {
+      let err = resolve_lang(*flag, None, *file).unwrap_err();
+      let msg = err.to_string();
+      assert!(msg.contains("dart"), "{desc}: {msg}");
+      assert!(msg.contains("playground"), "{desc}: {msg}");
+    }
+  }
+
+  #[test]
+  fn resolve_source_reads_file_contents() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "let x = 1;").unwrap();
+    let got = resolve_source(Some(tmp.path())).unwrap();
+    assert_eq!(got, "let x = 1;");
+  }
+
+  #[test]
+  fn resolve_source_returns_empty_when_no_file() {
+    let got = resolve_source(None).unwrap();
+    assert_eq!(got, "");
+  }
+
+  #[test]
+  fn resolve_source_errors_on_missing_file() {
+    let err = resolve_source(Some(Path::new("/definitely/nonexistent/path"))).unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("read"));
+  }
+
+  #[test]
+  fn resolve_rule_returns_none_when_no_input() {
+    let got = resolve_rule(None, None, None).unwrap();
+    assert!(got.is_none());
+  }
+
+  #[test]
+  fn resolve_rule_reads_rule_file_verbatim() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let yaml = "id: test\nlanguage: javascript\nrule:\n  pattern: foo($A)\n";
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let (text, lang) = resolve_rule(None, Some(tmp.path()), None).unwrap().unwrap();
+    assert_eq!(text, yaml);
+    assert_eq!(lang.unwrap(), SgLang::from_str("javascript").unwrap());
+  }
+
+  #[test]
+  fn resolve_rule_reads_rule_file_language_without_validating_global_utils() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let yaml = "id: test\nlanguage: javascript\nrule:\n  matches: project-util\n";
+    std::fs::write(tmp.path(), yaml).unwrap();
+
+    let (text, lang) = resolve_rule(None, Some(tmp.path()), None).unwrap().unwrap();
+
+    assert_eq!(text, yaml);
+    assert_eq!(lang.unwrap(), SgLang::from_str("javascript").unwrap());
+  }
+
+  #[test]
+  fn resolve_rule_includes_project_utilities_as_local_utils() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(temp.path().join("rules")).unwrap();
+    std::fs::create_dir(temp.path().join("utils")).unwrap();
+    std::fs::write(
+      temp.path().join("utils/num.yml"),
+      "id: num\nlanguage: javascript\nrule:\n  kind: number\n",
+    )
+    .unwrap();
+    std::fs::write(
+      temp.path().join("rules/use-num.yml"),
+      "id: use-num\nlanguage: javascript\nrule:\n  matches: num\n",
+    )
+    .unwrap();
+    let project = ProjectConfig {
+      project_dir: temp.path().to_path_buf(),
+      rule_dirs: vec![PathBuf::from("rules")],
+      test_configs: None,
+      util_dirs: Some(vec![PathBuf::from("utils")]),
+    };
+
+    let (text, lang) = resolve_rule(Some("use-num"), None, Some(&project))
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(lang.unwrap(), SgLang::from_str("javascript").unwrap());
+    assert!(text.contains("utils:"));
+    assert!(text.contains("num:"));
+    assert!(text.contains("kind: number"));
+    from_yaml_string::<SgLang>(&text, &GlobalRules::default()).expect("shared YAML parses alone");
+  }
+
+  #[test]
+  fn resolve_rule_preserves_project_util_metavar_scope_when_inlined() {
+    use ast_grep_core::tree_sitter::LanguageExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(temp.path().join("rules")).unwrap();
+    std::fs::create_dir(temp.path().join("utils")).unwrap();
+    std::fs::write(
+      temp.path().join("utils/is-bar.yml"),
+      "id: is-bar\nlanguage: javascript\nrule:\n  pattern: bar($A)\n",
+    )
+    .unwrap();
+    std::fs::write(
+      temp.path().join("rules/use-bar.yml"),
+      r#"id: use-bar
+language: javascript
+rule:
+  all:
+    - pattern: foo($A)
+    - has:
+        stopBy: end
+        matches: is-bar
+"#,
+    )
+    .unwrap();
+    let project = ProjectConfig {
+      project_dir: temp.path().to_path_buf(),
+      rule_dirs: vec![PathBuf::from("rules")],
+      test_configs: None,
+      util_dirs: Some(vec![PathBuf::from("utils")]),
+    };
+
+    let (text, _lang) = resolve_rule(Some("use-bar"), None, Some(&project))
+      .unwrap()
+      .unwrap();
+    let config = from_yaml_string::<SgLang>(&text, &GlobalRules::default())
+      .expect("shared YAML parses alone")
+      .pop()
+      .unwrap();
+    let grep = config.language.ast_grep("foo(bar(1))");
+
+    assert!(
+      grep.root().find(&config.matcher).is_some(),
+      "generated YAML should match like a project global utility:\n{text}"
+    );
+  }
+
+  #[test]
+  fn resolve_rule_errors_when_id_missing_and_no_project() {
+    let err = resolve_rule(Some("does-not-exist"), None, None).unwrap_err();
+    assert!(err.to_string().contains("does-not-exist"));
+  }
+
+  fn parse_single_rule(yaml: &str) -> RuleConfig<SgLang> {
+    from_yaml_string::<SgLang>(yaml, &GlobalRules::default())
+      .expect("parses")
+      .pop()
+      .expect("has one rule")
+  }
+
+  #[test]
+  fn serialize_rule_yaml_strips_null_lines() {
+    let rule = parse_single_rule("id: t\nlanguage: javascript\nrule:\n  pattern: foo\n");
+    let out = serialize_rule_yaml(&rule);
+    assert!(
+      !out.contains(": null"),
+      "stripped output should not contain ': null': {out}"
+    );
+    assert!(out.contains("id: t"));
+    assert!(out.contains("pattern: foo"));
+  }
+
+  #[test]
+  fn serialize_rule_yaml_preserves_null_like_lines_in_scalars() {
+    let rule = parse_single_rule(
+      "id: t\nlanguage: javascript\nnote: |\n  foo: null\nrule:\n  pattern: foo\n",
+    );
+    let out = serialize_rule_yaml(&rule);
+    assert!(out.contains("foo: null"), "scalar line was dropped: {out}");
+  }
+
+  #[test]
+  fn run_playground_errors_when_no_input() {
+    let arg = PlaygroundArg {
+      file: None,
+      rule: None,
+      rule_file: None,
+      lang: None,
+      print: true,
+    };
+    let err = run_playground(arg, Err(anyhow!("no project"))).unwrap_err();
+    assert!(err.to_string().contains("nothing to share"));
+  }
+}

--- a/crates/cli/src/playground.rs
+++ b/crates/cli/src/playground.rs
@@ -5,16 +5,15 @@ use std::str::FromStr;
 
 use ansi_term::{Color, Style};
 use anyhow::{anyhow, Result};
-use ast_grep_config::{RuleConfig, SerializableGlobalRule};
-use ast_grep_core::Language;
+use ast_grep_config::RuleConfig;
 use ast_grep_language::SupportLang;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use clap::Args;
 use crossterm::tty::IsTty;
 use serde::{Deserialize, Serialize};
-use serde_yaml::{Mapping, Value};
-use std::collections::{HashMap, HashSet, VecDeque};
+use serde_yaml::Value;
+use std::collections::HashSet;
 
 use crate::config::ProjectConfig;
 use crate::lang::SgLang;
@@ -181,17 +180,8 @@ pub(crate) fn resolve_rule(
     let rule = collection
       .get_rule(id)
       .ok_or_else(|| anyhow!("rule id '{id}' not found in project config"))?;
-    let mut value = rule_to_yaml_value(rule)?;
-    let mut queue = VecDeque::new();
-    collect_matches(&value, &mut queue);
-    let utils = if queue.is_empty() {
-      Vec::new()
-    } else {
-      project
-        .find_util_rule_configs()
-        .map_err(|e| anyhow!("failed to load project utilities: {e}"))?
-    };
-    inline_project_utils(&mut value, rule.language, &utils, queue)?;
+    let value = rule_to_yaml_value(rule)?;
+    ensure_rule_self_contained(&value, &rule.id)?;
     let yaml = serde_yaml::to_string(&value)
       .map_err(|e| anyhow!("failed to serialize rule '{}' to YAML: {e}", rule.id))?;
     return Ok(Some((yaml, Some(rule.language))));
@@ -282,294 +272,91 @@ fn is_serialized_optional_key(key: &Value) -> bool {
   )
 }
 
-/// Walk the rule's `matches:` references and inline the targeted project
-/// utilities into a local `utils:` block, so the playground URL is
-/// self-contained. `queue` is the set of util ids reachable from the rule,
-/// pre-collected by [`collect_matches`].
-fn inline_project_utils(
-  rule: &mut Value,
-  rule_lang: SgLang,
-  global_utils: &[SerializableGlobalRule<SgLang>],
-  mut queue: VecDeque<String>,
-) -> Result<()> {
-  let global_utils: HashMap<_, _> = global_utils
-    .iter()
-    .map(|util| (util.id.as_str(), util))
+/// Project-level utility rules are not serialized into playground URLs.
+/// Project rules must therefore be self-contained: every `matches:` reference
+/// needs a same-file local `utils:` entry.
+fn ensure_rule_self_contained(rule: &Value, rule_id: &str) -> Result<()> {
+  let local_utils = local_util_ids(rule)?;
+  let mut refs = Vec::new();
+  collect_match_refs(rule, &mut refs);
+
+  let mut seen = HashSet::new();
+  let external: Vec<_> = refs
+    .into_iter()
+    .filter(|id| !local_utils.contains(id))
+    .filter(|id| seen.insert(id.clone()))
     .collect();
 
-  let rule_map = rule
-    .as_mapping_mut()
+  if external.is_empty() {
+    return Ok(());
+  }
+
+  Err(anyhow!(
+    "rule '{}' references project utilities ({}) which cannot be shared with the playground; use a self-contained rule file or inline them as local utils",
+    rule_id,
+    external.join(", ")
+  ))
+}
+
+fn local_util_ids(rule: &Value) -> Result<HashSet<String>> {
+  let rule = rule
+    .as_mapping()
     .ok_or_else(|| anyhow!("serialized rule must be a YAML mapping"))?;
-  let mut utils = match rule_map.shift_remove("utils") {
-    Some(Value::Mapping(utils)) => utils,
-    Some(Value::Null) | None => Mapping::new(),
-    Some(_) => return Err(anyhow!("serialized rule has invalid `utils` field")),
+  let Some(utils) = rule.get(&Value::String("utils".into())) else {
+    return Ok(HashSet::new());
   };
-  let local_ids: HashSet<_> = utils
-    .keys()
-    .filter_map(Value::as_str)
-    .map(str::to_string)
-    .collect();
-  let mut included = HashSet::new();
-
-  while let Some(id) = queue.pop_front() {
-    if !included.insert(id.clone()) || local_ids.contains(&id) {
-      continue;
-    }
-    let Some(util) = global_utils.get(id.as_str()) else {
-      continue;
-    };
-    let util_rule = project_util_to_local_util(util, rule_lang)?;
-    collect_matches(&util_rule, &mut queue);
-    utils.insert(Value::String(id), util_rule);
-  }
-
-  if !utils.is_empty() {
-    rule_map.insert(Value::String("utils".into()), Value::Mapping(utils));
-  }
-  Ok(())
-}
-
-/// Convert a project-level global utility into a value suitable for the
-/// playground's local `utils:` block. Rejects utilities that can't be
-/// represented locally (parameterized, language-mismatched, or carrying
-/// constraints / transforms / fix that aren't supported on local utils).
-fn project_util_to_local_util(
-  util: &SerializableGlobalRule<SgLang>,
-  rule_lang: SgLang,
-) -> Result<Value> {
-  if util.language != rule_lang {
-    return Err(anyhow!(
-      "project utility '{}' uses language '{}' but the selected rule uses '{}'",
-      util.id,
-      util.language,
-      rule_lang
-    ));
-  }
-  if util.arguments.as_ref().is_some_and(|args| !args.is_empty()) {
-    return Err(anyhow!(
-      "project utility '{}' is parameterized and cannot be shared with the playground",
-      util.id
-    ));
-  }
-  if util.core.constraints.is_some()
-    || util.core.utils.is_some()
-    || util.core.transform.is_some()
-    || util.core.fix.is_some()
-  {
-    return Err(anyhow!(
-      "project utility '{}' uses fields that cannot be represented as playground local utils",
-      util.id
-    ));
-  }
-  let mut value = serde_yaml::to_value(&util.core.rule).map_err(|e| {
-    anyhow!(
-      "failed to serialize project utility '{}' to YAML: {e}",
-      util.id
-    )
-  })?;
-  strip_serialized_null_fields(&mut value);
-  rename_project_util_metavars(&mut value, rule_lang, &util.id);
-  Ok(value)
-}
-
-/// Project utilities have an independent metavariable scope; playground
-/// local utils share scope with the caller. Rewrite each metavariable in
-/// the inlined util to a per-util prefix so the scopes stay separate.
-fn rename_project_util_metavars(value: &mut Value, rule_lang: SgLang, util_id: &str) {
-  let prefix = project_util_metavar_prefix(util_id);
-  rename_metavars_in_rule(value, rule_lang.meta_var_char(), &prefix);
-}
-
-/// Build the per-util metavariable prefix. Non-alphanumeric characters in
-/// the util id are replaced with `_`; the rest is uppercased. Rule ids are
-/// unique within a project, so prefixes derived from them are too.
-fn project_util_metavar_prefix(util_id: &str) -> String {
-  let mut sanitized = String::new();
-  for ch in util_id.chars() {
-    if ch.is_ascii_alphanumeric() {
-      sanitized.push(ch.to_ascii_uppercase());
-    } else {
-      sanitized.push('_');
-    }
-  }
-  format!("AST_GREP_PLAYGROUND_{sanitized}_")
-}
-
-/// Recurse the rule YAML, rewriting metavariables in every `pattern:`
-/// scalar / `{ context: "..." }` form. Other keys (`constraints`, `fix`,
-/// `transform`) cannot appear here — they are rejected upstream by
-/// [`project_util_to_local_util`].
-fn rename_metavars_in_rule(value: &mut Value, meta_char: char, prefix: &str) {
-  match value {
-    Value::Mapping(map) => {
-      for (key, value) in map {
-        if key.as_str() == Some("pattern") {
-          rename_metavars_in_pattern_value(value, meta_char, prefix);
-        } else {
-          rename_metavars_in_rule(value, meta_char, prefix);
-        }
-      }
-    }
-    Value::Sequence(seq) => {
-      for value in seq {
-        rename_metavars_in_rule(value, meta_char, prefix);
-      }
-    }
-    Value::Tagged(tagged) => rename_metavars_in_rule(&mut tagged.value, meta_char, prefix),
-    Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+  match utils {
+    Value::Mapping(utils) => Ok(utils
+      .keys()
+      .filter_map(Value::as_str)
+      .map(str::to_string)
+      .collect()),
+    Value::Null => Ok(HashSet::new()),
+    _ => Err(anyhow!("serialized rule has invalid `utils` field")),
   }
 }
 
-/// Apply metavariable renaming to whichever shape `pattern:` takes — a
-/// bare string, or a mapping with `{ context: "..." }`.
-fn rename_metavars_in_pattern_value(value: &mut Value, meta_char: char, prefix: &str) {
-  match value {
-    Value::String(pattern) => {
-      *pattern = rename_metavars_in_pattern(pattern, meta_char, prefix);
-    }
-    Value::Mapping(map) => {
-      for (key, value) in map {
-        if key.as_str() == Some("context") {
-          if let Value::String(context) = value {
-            *context = rename_metavars_in_pattern(context, meta_char, prefix);
-          }
-        }
-      }
-    }
-    Value::Tagged(tagged) => rename_metavars_in_pattern_value(&mut tagged.value, meta_char, prefix),
-    Value::Null | Value::Bool(_) | Value::Number(_) | Value::Sequence(_) => {}
-  }
-}
-
-/// Rewrite every `$NAME` / `$$X` / `$$$NAME` inside a pattern by prepending
-/// `prefix` to the name. Anonymous `_`-prefixed forms (`$_`, `$$$_`) and
-/// sigils without a valid name are left unchanged.
-fn rename_metavars_in_pattern(pattern: &str, meta_char: char, prefix: &str) -> String {
-  let chars: Vec<_> = pattern.chars().collect();
-  let mut ret = String::with_capacity(pattern.len() + prefix.len());
-  let mut i = 0;
-  while i < chars.len() {
-    if chars[i] != meta_char {
-      ret.push(chars[i]);
-      i += 1;
-      continue;
-    }
-    if i + 2 < chars.len() && chars[i + 1] == meta_char && chars[i + 2] == meta_char {
-      let name_start = i + 3;
-      let name_end = collect_multi_metavar_name(&chars, name_start);
-      if name_end == name_start {
-        ret.extend(chars[i..name_start].iter());
-      } else {
-        ret.extend(chars[i..name_start].iter());
-        if chars[name_start] == '_' {
-          ret.extend(chars[name_start..name_end].iter());
-        } else {
-          ret.push_str(prefix);
-          ret.extend(chars[name_start..name_end].iter());
-        }
-      }
-      i = name_end;
-      continue;
-    }
-
-    let sigil_end = if i + 1 < chars.len() && chars[i + 1] == meta_char {
-      i + 2
-    } else {
-      i + 1
-    };
-    let name_end = collect_single_metavar_name(&chars, sigil_end);
-    if name_end == sigil_end {
-      ret.extend(chars[i..sigil_end].iter());
-    } else {
-      ret.extend(chars[i..sigil_end].iter());
-      if chars[sigil_end] == '_' {
-        ret.extend(chars[sigil_end..name_end].iter());
-      } else {
-        ret.push_str(prefix);
-        ret.extend(chars[sigil_end..name_end].iter());
-      }
-    }
-    i = name_end;
-  }
-  ret
-}
-
-/// Single-sigil metavar names must start with an uppercase letter or `_`.
-fn collect_single_metavar_name(chars: &[char], start: usize) -> usize {
-  if start >= chars.len() || !is_valid_metavar_first_char(chars[start]) {
-    return start;
-  }
-  collect_metavar_name(chars, start)
-}
-
-/// Triple-sigil (variadic) metavar names allow digits in the first slot too.
-fn collect_multi_metavar_name(chars: &[char], start: usize) -> usize {
-  if start >= chars.len() || !is_valid_metavar_char(chars[start]) {
-    return start;
-  }
-  collect_metavar_name(chars, start)
-}
-
-/// Consume contiguous `[A-Z_0-9]` chars starting at `start`, returning the
-/// exclusive end index.
-fn collect_metavar_name(chars: &[char], start: usize) -> usize {
-  let mut end = start;
-  while end < chars.len() && is_valid_metavar_char(chars[end]) {
-    end += 1;
-  }
-  end
-}
-
-/// Whether `ch` can begin an ast-grep metavariable name.
-fn is_valid_metavar_first_char(ch: char) -> bool {
-  matches!(ch, 'A'..='Z' | '_')
-}
-
-/// Whether `ch` can appear inside an ast-grep metavariable name.
-fn is_valid_metavar_char(ch: char) -> bool {
-  is_valid_metavar_first_char(ch) || ch.is_ascii_digit()
-}
-
-/// Walk the rule YAML and feed every `matches:` reference into `queue` —
-/// either a bare id string or the keys of a `{ utilId: { ... args ... } }`
-/// call form.
-fn collect_matches(value: &Value, queue: &mut VecDeque<String>) {
+/// Walk the rule YAML and collect every `matches:` reference: either a bare
+/// id string or the keys of a `{ utilId: { ... args ... } }` call form.
+fn collect_match_refs(value: &Value, refs: &mut Vec<String>) {
   match value {
     Value::Mapping(map) => {
       for (key, value) in map {
         if key.as_str() == Some("matches") {
-          collect_match_ids(value, queue);
+          collect_match_ids(value, refs);
+          continue;
         }
-        collect_matches(value, queue);
+        if key.as_str() == Some("metadata") {
+          continue;
+        }
+        collect_match_refs(value, refs);
       }
     }
     Value::Sequence(seq) => {
       for value in seq {
-        collect_matches(value, queue);
+        collect_match_refs(value, refs);
       }
     }
-    Value::Tagged(tagged) => collect_matches(&tagged.value, queue),
+    Value::Tagged(tagged) => collect_match_refs(&tagged.value, refs),
     Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
   }
 }
 
 /// Push the ids referenced by a `matches:` value. Sequence values are not a
 /// valid `matches:` shape in ast-grep's schema, so they are skipped.
-fn collect_match_ids(value: &Value, queue: &mut VecDeque<String>) {
+fn collect_match_ids(value: &Value, refs: &mut Vec<String>) {
   match value {
     Value::String(id) => {
-      queue.push_back(id.clone());
+      refs.push(id.clone());
     }
     Value::Mapping(calls) => {
-      for (callee, args) in calls {
+      for (callee, _args) in calls {
         if let Some(id) = callee.as_str() {
-          queue.push_back(id.to_string());
+          refs.push(id.to_string());
         }
-        collect_matches(args, queue);
       }
     }
-    Value::Tagged(tagged) => collect_match_ids(&tagged.value, queue),
+    Value::Tagged(tagged) => collect_match_ids(&tagged.value, refs),
     Value::Null | Value::Bool(_) | Value::Number(_) | Value::Sequence(_) => {}
   }
 }
@@ -819,7 +606,34 @@ mod tests {
   }
 
   #[test]
-  fn resolve_rule_includes_project_utilities_as_local_utils() {
+  fn resolve_rule_keeps_local_utils_self_contained() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(temp.path().join("rules")).unwrap();
+    std::fs::write(
+      temp.path().join("rules/use-num.yml"),
+      "id: use-num\nlanguage: javascript\nrule:\n  matches: num\nutils:\n  num:\n    kind: number\n",
+    )
+    .unwrap();
+    let project = ProjectConfig {
+      project_dir: temp.path().to_path_buf(),
+      rule_dirs: vec![PathBuf::from("rules")],
+      test_configs: None,
+      util_dirs: None,
+    };
+
+    let (text, lang) = resolve_rule(Some("use-num"), None, Some(&project))
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(lang.unwrap(), SgLang::from_str("javascript").unwrap());
+    assert!(text.contains("utils:"));
+    assert!(text.contains("num:"));
+    assert!(text.contains("kind: number"));
+    from_yaml_string::<SgLang>(&text, &GlobalRules::default()).expect("shared YAML parses alone");
+  }
+
+  #[test]
+  fn resolve_rule_errors_on_project_util_reference() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::create_dir(temp.path().join("rules")).unwrap();
     std::fs::create_dir(temp.path().join("utils")).unwrap();
@@ -840,62 +654,10 @@ mod tests {
       util_dirs: Some(vec![PathBuf::from("utils")]),
     };
 
-    let (text, lang) = resolve_rule(Some("use-num"), None, Some(&project))
-      .unwrap()
-      .unwrap();
-
-    assert_eq!(lang.unwrap(), SgLang::from_str("javascript").unwrap());
-    assert!(text.contains("utils:"));
-    assert!(text.contains("num:"));
-    assert!(text.contains("kind: number"));
-    from_yaml_string::<SgLang>(&text, &GlobalRules::default()).expect("shared YAML parses alone");
-  }
-
-  #[test]
-  fn resolve_rule_preserves_project_util_metavar_scope_when_inlined() {
-    use ast_grep_core::tree_sitter::LanguageExt;
-
-    let temp = tempfile::tempdir().unwrap();
-    std::fs::create_dir(temp.path().join("rules")).unwrap();
-    std::fs::create_dir(temp.path().join("utils")).unwrap();
-    std::fs::write(
-      temp.path().join("utils/is-bar.yml"),
-      "id: is-bar\nlanguage: javascript\nrule:\n  pattern: bar($A)\n",
-    )
-    .unwrap();
-    std::fs::write(
-      temp.path().join("rules/use-bar.yml"),
-      r#"id: use-bar
-language: javascript
-rule:
-  all:
-    - pattern: foo($A)
-    - has:
-        stopBy: end
-        matches: is-bar
-"#,
-    )
-    .unwrap();
-    let project = ProjectConfig {
-      project_dir: temp.path().to_path_buf(),
-      rule_dirs: vec![PathBuf::from("rules")],
-      test_configs: None,
-      util_dirs: Some(vec![PathBuf::from("utils")]),
-    };
-
-    let (text, _lang) = resolve_rule(Some("use-bar"), None, Some(&project))
-      .unwrap()
-      .unwrap();
-    let config = from_yaml_string::<SgLang>(&text, &GlobalRules::default())
-      .expect("shared YAML parses alone")
-      .pop()
-      .unwrap();
-    let grep = config.language.ast_grep("foo(bar(1))");
-
-    assert!(
-      grep.root().find(&config.matcher).is_some(),
-      "generated YAML should match like a project global utility:\n{text}"
-    );
+    let err = resolve_rule(Some("use-num"), None, Some(&project)).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("project utilities"), "{msg}");
+    assert!(msg.contains("num"), "{msg}");
   }
 
   #[test]

--- a/crates/cli/tests/playground_test.rs
+++ b/crates/cli/tests/playground_test.rs
@@ -1,0 +1,111 @@
+use assert_cmd::Command;
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+fn sg() -> Command {
+  Command::cargo_bin("ast-grep").expect("ast-grep binary exists")
+}
+
+fn extract_state_json(stdout: &str) -> serde_json::Value {
+  let url = stdout
+    .lines()
+    .find(|l| l.starts_with("https://ast-grep.github.io/playground.html#"))
+    .expect("stdout contains the playground URL");
+  let frag = url.split_once('#').unwrap().1;
+  let bytes = B64.decode(frag).expect("valid base64");
+  serde_json::from_slice(&bytes).expect("valid json")
+}
+
+#[test]
+fn playground_with_only_file_prints_url() {
+  let dir = TempDir::new().unwrap();
+  let file = dir.path().join("hello.ts");
+  std::fs::write(&file, "const x: number = 1;\n").unwrap();
+
+  let assert = sg()
+    .args(["playground", "--file"])
+    .arg(&file)
+    .arg("--print")
+    .assert()
+    .success()
+    .stdout(contains("https://ast-grep.github.io/playground.html#"));
+
+  let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+  let state = extract_state_json(&stdout);
+  assert_eq!(state["mode"], "Patch");
+  assert_eq!(state["lang"], "typescript");
+  assert_eq!(state["source"], "const x: number = 1;\n");
+  assert_eq!(state["config"], "");
+}
+
+#[test]
+fn playground_with_rule_file_loads_yaml() {
+  let dir = TempDir::new().unwrap();
+  let rule_path = dir.path().join("rule.yml");
+  let yaml = "id: no-console\nlanguage: typescript\nrule:\n  pattern: console.log($A)\n";
+  std::fs::write(&rule_path, yaml).unwrap();
+
+  let assert = sg()
+    .args(["playground", "--rule-file"])
+    .arg(&rule_path)
+    .arg("--print")
+    .assert()
+    .success();
+
+  let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+  let state = extract_state_json(&stdout);
+  assert_eq!(state["mode"], "Config");
+  assert_eq!(state["lang"], "typescript");
+  assert_eq!(state["source"], "");
+  assert_eq!(state["config"], yaml);
+}
+
+#[test]
+fn playground_with_rule_id_in_project() {
+  let dir = TempDir::new().unwrap();
+  std::fs::create_dir_all(dir.path().join("rules")).unwrap();
+  std::fs::write(dir.path().join("sgconfig.yml"), "ruleDirs:\n  - rules\n").unwrap();
+  let rule_yaml = "id: no-console\nlanguage: typescript\nrule:\n  pattern: console.log($A)\n";
+  std::fs::write(dir.path().join("rules/no-console.yml"), rule_yaml).unwrap();
+
+  let assert = sg()
+    .current_dir(dir.path())
+    .args(["playground", "--rule", "no-console", "--print"])
+    .assert()
+    .success();
+
+  let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+  let state = extract_state_json(&stdout);
+  assert_eq!(state["mode"], "Config");
+  assert_eq!(state["lang"], "typescript");
+  assert!(state["config"]
+    .as_str()
+    .unwrap()
+    .contains("console.log($A)"));
+}
+
+#[test]
+fn playground_no_inputs_errors() {
+  sg()
+    .args(["playground", "--print"])
+    .assert()
+    .failure()
+    .stderr(contains("nothing to share"));
+}
+
+#[test]
+fn playground_rule_and_rule_file_are_exclusive() {
+  let dir = TempDir::new().unwrap();
+  let path = dir.path().join("r.yml");
+  std::fs::write(&path, "id: r\nlanguage: javascript\nrule:\n  pattern: x\n").unwrap();
+
+  sg()
+    .args(["playground", "--rule", "r", "--rule-file"])
+    .arg(&path)
+    .args(["--print"])
+    .assert()
+    .failure()
+    .stderr(contains("cannot be used with"));
+}


### PR DESCRIPTION
## Summary

Adds a top-level `ast-grep playground` subcommand that opens a rule and/or source file in the [web playground](https://ast-grep.github.io/playground.html) with state preloaded via a base64-encoded URL fragment.

Refs #2000.

## Usage

```sh
ast-grep playground --file path/to/source.ts
ast-grep playground --rule no-console
ast-grep playground --rule-file ./my-rule.yml
ast-grep playground --file a.ts --rule no-console
ast-grep playground --file a.ts --print      # print URL only, no browser open
```

## Behaviour

- Encoding matches the playground frontend's `btoa(unescape(encodeURIComponent(JSON.stringify(state))))` byte-for-byte (see `website/src/utils.ts`), so the URL is bit-compatible with what the playground produces from its own UI.
- `--rule <ID>` walks the project's `sgconfig.yml`, looks up the rule, and inlines any reachable global utilities into the shared rule's `utils:` block so the URL is self-contained and parses standalone via `from_yaml_string`. Parameterised utilities, language mismatches, and utilities using `constraints` / `transform` / `fix` are reported as errors.
- Inlined project utilities have their metavariables renamed to `AST_GREP_PLAYGROUND_<UTIL_ID>_<NAME>` so an inlined util's `$A` does not collide with the caller's `$A`. Variadic (`$$$X`) and anonymous (`$_`, `$$$_`) forms are preserved.
- Default flow opens the URL in the user's default browser and stays quiet on success; on failure it falls back to printing the URL on stdout. `--print` skips the browser and writes only the URL to stdout (script-friendly).
- Status messages on stderr respect `NO_COLOR` / `TERM=dumb` / TTY detection, mirroring `env_allows_color` in `crates/cli/src/print/colored_print/styles.rs`.
- Refuses to share rules/files in languages not supported by the web playground (Dart / Haskell / Solidity / custom languages) rather than silently letting the frontend fall back to JavaScript.
- Empty optional fields are stripped from the serialised rule YAML via a structural `serde_yaml::Value` walk, so block scalars containing the literal text `foo: null` survive.

New dependencies: `open = "5"` (default-browser launcher) and `base64 = "0.22"`.

Exposes `ProjectConfig::find_util_rule_configs()` to share the intermediate `Vec<SerializableGlobalRule<SgLang>>` with the existing `find_util_rules`; otherwise no public-API churn.

## Test plan

- [x] `cargo test -p ast-grep --lib playground::tests` — 20 unit tests covering URL encoding (incl. unicode source), language resolution priority, source/rule resolution, null-line stripping, project-util inlining, and metavar scope preservation
- [x] `cargo test -p ast-grep --test playground_test` — 5 integration tests via `assert_cmd` covering `--file`, `--rule-file`, `--rule <id>` with a fixture `sgconfig.yml`, `--rule` vs `--rule-file` mutual exclusion, and the "nothing to share" error
- [x] `cargo test -p ast-grep` — full crate test suite passes
- [x] `cargo clippy -p ast-grep --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p ast-grep` — clean
- [x] Manual smoke: `cargo run -- playground --file <some-source>` opens the browser to the playground with the source preloaded; `--rule <id>` from inside a project config loads the rule in Config mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New playground subcommand to generate a shareable playground URL from rules, configs, or source files; can open the playground in your browser or print the URL.
  * Language inference for shared state (flag, rule metadata, or file extension).

* **Behavior Changes**
  * Shared rule YAML must be self-contained for sharing; project utility references are rejected.

* **Bug Fixes**
  * Clearer errors when reading/parsing rule files, for conflicting options, unsupported languages, and "nothing to share".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->