### PR TITLE
feat(npm): publish musl builds of @ast-grep/cli for Alpine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
             os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -85,8 +89,8 @@ jobs:
           out-file-path: artifacts
       - name: Unzip packages
         run: |
-          files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu)
-          target_dir=(darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu)
+          files=(aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-musl)
+          target_dir=(darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu linux-x64-musl linux-arm64-musl)
           length=${#files[@]}
           for (( i=0; i<${length}; i++ ));
           do

--- a/npm/package.json
+++ b/npm/package.json
@@ -36,7 +36,9 @@
     "@ast-grep/cli-darwin-arm64": "0.42.2",
     "@ast-grep/cli-darwin-x64": "0.42.2",
     "@ast-grep/cli-linux-arm64-gnu": "0.42.2",
-    "@ast-grep/cli-linux-x64-gnu": "0.42.2"
+    "@ast-grep/cli-linux-arm64-musl": "0.42.2",
+    "@ast-grep/cli-linux-x64-gnu": "0.42.2",
+    "@ast-grep/cli-linux-x64-musl": "0.42.2"
   },
   "bin": {
     "sg": "sg",

--- a/npm/platforms/linux-arm64-musl/README.md
+++ b/npm/platforms/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@ast-grep/cli-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@ast-grep/cli`

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@ast-grep/cli-linux-arm64-musl",
+  "version": "0.42.2",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "files": [
+    "ast-grep"
+  ],
+  "description": "Search and Rewrite code at large scale using precise AST pattern",
+  "keywords": [
+    "ast",
+    "pattern",
+    "codemod",
+    "search",
+    "rewrite"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": "https://github.com/ast-grep/ast-grep"
+}

--- a/npm/platforms/linux-x64-musl/README.md
+++ b/npm/platforms/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@ast-grep/cli-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@ast-grep/cli`

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@ast-grep/cli-linux-x64-musl",
+  "version": "0.42.2",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "files": [
+    "ast-grep"
+  ],
+  "description": "Search and Rewrite code at large scale using precise AST pattern",
+  "keywords": [
+    "ast",
+    "pattern",
+    "codemod",
+    "search",
+    "rewrite"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": "https://github.com/ast-grep/ast-grep"
+}

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -13,9 +13,9 @@ function detectPackageName() {
       break;
     case "linux": {
       const { MUSL, familySync } = require("detect-libc");
-      if (familySync() === MUSL) return null;
-      if (arch === "arm64") return "@ast-grep/cli-linux-arm64-gnu";
-      if (arch === "x64") return "@ast-grep/cli-linux-x64-gnu";
+      const libc = familySync() === MUSL ? "musl" : "gnu";
+      if (arch === "arm64") return `@ast-grep/cli-linux-arm64-${libc}`;
+      if (arch === "x64") return `@ast-grep/cli-linux-x64-${libc}`;
       break;
     }
     case "win32":


### PR DESCRIPTION
## Why

`npm install -g @ast-grep/cli` fails on Alpine and other musl-based Linux distros:

```
$ docker run --rm node:24-alpine npm i -g @ast-grep/cli
...
Failed to locate @ast-grep/cli native binary.
npm error code 1
```

The bail is intentional in `npm/postinstall.js`:

```js
case "linux": {
  const { MUSL, familySync } = require("detect-libc");
  if (familySync() === MUSL) return null;   // <- exits 1
  ...
}
```

It is correct given today's `optionalDependencies` — only `-gnu` variants are
published — but it leaves musl users with no install path through npm.

`@ast-grep/napi` already publishes both `linux-x64-musl` and `linux-arm64-musl`
(commit 255cfd6f, "feat: support arm64 musl", closing #1227). This PR brings
`@ast-grep/cli` to the same parity.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the `upload-assets` matrix; extend the `release-npm` unzip step with the matching platform dirs. |
| `npm/package.json` | Add `@ast-grep/cli-linux-{x64,arm64}-musl` to `optionalDependencies`. |
| `npm/postinstall.js` | Replace the `return null` musl bail with a branch that selects the `-musl` package when `familySync() === MUSL`. |
| `npm/platforms/linux-{x64,arm64}-musl/` (new) | Platform packages mirroring the existing `-gnu` ones with `"libc": ["musl"]`. |

**7 files changed, +84 / -6.** Purely additive — glibc / Darwin / Windows paths
are unchanged.

The new linux branch in `detectPackageName`:

```js
case "linux": {
  const { MUSL, familySync } = require("detect-libc");
  const libc = familySync() === MUSL ? "musl" : "gnu";
  if (arch === "arm64") return `@ast-grep/cli-linux-arm64-${libc}`;
  if (arch === "x64") return `@ast-grep/cli-linux-x64-${libc}`;
  break;
}
```

## Verification

### 1. The musl binary builds

Cross-compiled `ast-grep` for `aarch64-unknown-linux-musl` inside `rust:alpine`:

```
$ file target/release/ast-grep
ELF 64-bit LSB pie executable, ARM aarch64,
dynamically linked, interpreter /lib/ld-musl-aarch64.so.1
```

The workspace's `.cargo/config.toml` already declares the musl target sections
with `-C target-feature=-crt-static`. `taiki-e/upload-rust-binary-action`
auto-selects `cross` for musl targets and works out of the box on
`ubuntu-22.04` runners.

### 2. End-to-end install on Alpine

Packed the new platform package and the main package, installed both in
`node:24-alpine`, and ran the binary:

```
=== libc family detected ===
musl
=== node_modules/@ast-grep ===
drwxr-xr-x  cli
drwxr-xr-x  cli-linux-arm64-musl
=== ./node_modules/@ast-grep/cli/ast-grep --version ===
ast-grep 0.42.2
=== ./node_modules/@ast-grep/cli/sg --version ===
ast-grep 0.42.2
```

`detect-libc` reports `musl`, postinstall picks
`@ast-grep/cli-linux-arm64-musl`, hardlinks `ast-grep` and `sg` into the main
package, and both invocations print the right version. No `process.exit(1)`,
no fallback shim warning.

### 3. `detectPackageName` resolution table

With `detect-libc` mocked to cover all four branches:

| platform | arch  | family | resolved package                 |
|----------|-------|--------|----------------------------------|
| linux    | x64   | musl   | `@ast-grep/cli-linux-x64-musl`   |
| linux    | arm64 | musl   | `@ast-grep/cli-linux-arm64-musl` |
| linux    | x64   | glibc  | `@ast-grep/cli-linux-x64-gnu`    |
| linux    | arm64 | glibc  | `@ast-grep/cli-linux-arm64-gnu`  |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Linux platform support to include musl-based distributions for both x86_64 and ARM64 architectures.
  * Improved installer to automatically detect and select the correct binary variant for GNU and musl-based Linux systems.

* **Documentation**
  * Added documentation for new Linux musl platform variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->