### PR TITLE
fix: don't leak metavar bindings from ellipsis-end lookahead

### DIFF
--- a/crates/core/src/match_tree/match_node.rs
+++ b/crates/core/src/match_tree/match_node.rs
@@ -151,11 +151,19 @@ fn may_match_ellipsis_impl<'p, 't: 'p, D: Doc>(
     return Some(ControlFlow::Continue);
   }
   loop {
+    // Probe whether the next (non-ellipsis) goal matches the current candidate
+    // to decide where the ellipsis ends. The probe runs against a throwaway
+    // clone of the aggregator so that a failed probe of a metavar-bearing goal
+    // does not leak partial bindings into the real environment. Leaking them
+    // would make a later, genuine bind of the same metavar conflict and fail
+    // (e.g. probing `$P := g()` against `a := 0` binds `$P = a`, then poisons
+    // the real bind `$P = p`).
+    let mut probe = (*agg).clone();
     if matches!(
       match_node_impl(
         goal_children.peek().unwrap(),
         cand_children.peek().unwrap(),
-        agg,
+        &mut probe,
         strictness,
       ),
       MatchOneNode::MatchedBoth

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -10,7 +10,7 @@ use crate::{Doc, Node, Pattern};
 
 use std::borrow::Cow;
 
-trait Aggregator<'t, D: Doc> {
+trait Aggregator<'t, D: Doc>: Clone {
   fn match_terminal(&mut self, node: &Node<'t, D>) -> Option<()>;
   fn match_meta_var(&mut self, var: &MetaVariable, node: &Node<'t, D>) -> Option<()>;
   fn match_ellipsis(
@@ -21,6 +21,7 @@ trait Aggregator<'t, D: Doc> {
   ) -> Option<()>;
 }
 
+#[derive(Clone)]
 struct ComputeEnd(usize);
 
 impl<'t, D: Doc> Aggregator<'t, D> for ComputeEnd {
@@ -335,5 +336,23 @@ mod test {
   #[test]
   fn test_gh_1087() {
     test_match("($P) => $F($P)", "(x) => bar(x)");
+  }
+
+  // A leading `$$$` followed by a metavar-bearing anchored statement must not
+  // leak partial bindings from the ellipsis-end lookahead probe. Here the probe
+  // of `let $P = g()` against the leading `let a = 0` would bind `$P = a` and
+  // then fail on the right-hand side, poisoning the real bind `$P = p`.
+  #[test]
+  fn test_leading_ellipsis_metavar_anchor() {
+    // No trailing `;` after `$$$A`/`$$$B` so they parse as statement-list
+    // ellipses (a bare `$$$A;` would be wrapped in an expression_statement).
+    let env = test_match(
+      "function _() {\n  $$$A\n  let $P = g()\n  let $Q = h()\n  $$$B\n}",
+      "function _() { let a = 0; let p = g(); let q = h(); let b = 1; }",
+    );
+    assert_eq!(env["P"], "p");
+    assert_eq!(env["Q"], "q");
+    assert_eq!(env["A"], "[let a = 0;]");
+    assert_eq!(env["B"], "[let b = 1;]");
   }
 }


### PR DESCRIPTION
> **Disclaimer:** This PR was created with the help of [Claude Code](https://claude.com/claude-code). The root-cause investigation, fix, and regression test were produced with AI assistance and reviewed by me before submitting.

## Motivation

A pattern that starts with a leading `$$$` list metavariable followed by an anchored statement that itself contains a metavariable fails to match code it should match. The statement-list matcher probes the anchored goal against successive candidates to decide where the leading `$$$` ends, but it runs that probe against the **live** metavariable environment. A failed probe of a metavar-bearing goal leaves partial bindings behind, which then conflict with the real bind and abort the match.

Concretely, when probing `$P := g()` against `a := 0`, the matcher binds `$P = a` (the left-hand side matches) and only then fails on the right-hand side (`g()` vs `0`). That stray `$P = a` binding survives into later iterations, so when the loop reaches the genuinely matching `p := g()`, the real bind `$P = p` conflicts with `$P = a` and the whole match fails.

## Example

Target `repro.go`:

```go
package p

func f() {
	a := 0
	p := g()
	q := h()
	b := 0
}
```

Rule:

```yaml
id: ch
language: go
rule:
  pattern:
    selector: block
    context: |-
      func _() {
      	$$$A
      	$P := g()
      	$Q := h()
      	$$$B
      }
```

Before this change `ast-grep scan` reports **0 matches**. After it, the block matches with `$$$A = [a := 0]`, `$P = p`, `$Q = q`, `$$$B = [b := 0]`.

The match succeeds in all of these cases, which helped isolate the trigger:

- the anchored statements use only literals (no metavariables) — never polluted the env, so it already worked;
- there is only one anchored statement, **or** the leading statement can't partially bind the metavar (e.g. it's a call expression, not a `short_var_declaration`);
- the leading statement happens to bind the same name (`p := 0` → `$P = p`, consistent).

The common factor is whether a candidate absorbed by the leading `$$$` partially binds a metavariable of the following anchored goal during the probe.

## Summary

- In `may_match_ellipsis_impl`, run the ellipsis-end lookahead probe against a throwaway clone of the aggregator instead of the live one, so a failed probe can't mutate the real environment. The genuine bind is redone immediately afterward by the normal matching path, so the clone is only used for the end-of-ellipsis decision.
- Add `Clone` as a supertrait of the private `Aggregator` trait and derive `Clone` for `ComputeEnd` to support cloning the aggregator at that one call site (both impls are trivially cloneable).
- Add a regression test (`test_leading_ellipsis_metavar_anchor`) covering a leading `$$$` followed by metavar-bearing anchored statements.

## Test plan

- [x] New regression test `test_leading_ellipsis_metavar_anchor` fails before the fix and passes after.
- [x] `cargo test -p ast-grep-core -p ast-grep-config -p ast-grep` all green (no regressions).
- [x] `cargo clippy -p ast-grep-core` clean.
- [x] Manually verified the original Go repro and all controls (including the real-world `q.Receive(...)` + `if` block codemod) now match with correct captures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern matching probe operations to prevent partial variable bindings from being retained when probes fail, resulting in more predictable and correct matching behavior in complex pattern scenarios.

* **Tests**
  * Added regression test validating the correct handling of anchored patterns with leading metavariables during pattern matching operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->