### PR TITLE
refactor: collapse nested ifs with let chains

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -340,12 +340,11 @@ impl Worker for RunWithSpecificLang {
     }
     printer.after_print()?;
     self.stats.print()?;
-    if !has_matches {
-      if let Rule::Pattern(pattern) = &self.rule {
-        if pattern.has_error() {
-          return Err(anyhow::anyhow!(EC::PatternHasError));
-        }
-      }
+    if !has_matches
+      && let Rule::Pattern(pattern) = &self.rule
+      && pattern.has_error()
+    {
+      return Err(anyhow::anyhow!(EC::PatternHasError));
     }
     Ok(ExitCode::from(if has_matches { 0 } else { 1 }))
   }

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -84,10 +84,10 @@ pub fn run_in_alternate_screen<T>(f: impl FnOnce() -> Result<T>) -> Result<T> {
 pub fn prompt(prompt_text: &str, letters: &str, default: Option<char>) -> Result<char> {
   loop {
     let input = prompt_reply_stdout(prompt_text)?;
-    if let Some(default) = default {
-      if input == '\n' {
-        return Ok(default);
-      }
+    if let Some(default) = default
+      && input == '\n'
+    {
+      return Ok(default);
     }
     if letters.contains(input) {
       return Ok(input);

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -47,12 +47,12 @@ impl<'t, D: Doc> ScanResultInner<'t, D> {
         matches.push((rule, supprs));
       }
     }
-    if let Some(rule) = combined.no_suppress_all_rule {
-      if !self.suppress_all_nodes.is_empty() {
-        let mut supprs = self.suppress_all_nodes;
-        supprs.sort_unstable_by_key(|nm| nm.range().start);
-        matches.push((rule, supprs));
-      }
+    if let Some(rule) = combined.no_suppress_all_rule
+      && !self.suppress_all_nodes.is_empty()
+    {
+      let mut supprs = self.suppress_all_nodes;
+      supprs.sort_unstable_by_key(|nm| nm.range().start);
+      matches.push((rule, supprs));
     }
     ScanResult { diffs, matches }
   }
@@ -282,10 +282,10 @@ impl<'r, L: Language> CombinedScan<'r, L> {
         .extend(nodes.cloned().map(NodeMatch::from));
     }
     let file_sup = suppressions.file_suppression();
-    if let MaySuppressed::Yes(s) = file_sup {
-      if s.suppressed.is_none() {
-        return result.into_result(self, separate_fix);
-      }
+    if let MaySuppressed::Yes(s) = file_sup
+      && s.suppressed.is_none()
+    {
+      return result.into_result(self, separate_fix);
     }
     for node in root.root().dfs() {
       let kind = node.kind_id() as usize;

--- a/crates/config/src/rule/range.rs
+++ b/crates/config/src/rule/range.rs
@@ -79,15 +79,15 @@ impl Matcher for RangeMatcher {
       return None;
     }
     // then check column, this can be expensive for utf-8 encoded files
-    if let Some(start_col) = self.start.column {
-      if start_col != node_start_pos.column(&node) {
-        return None;
-      }
+    if let Some(start_col) = self.start.column
+      && start_col != node_start_pos.column(&node)
+    {
+      return None;
     }
-    if let Some(end_col) = self.end.column {
-      if end_col != node_end_pos.column(&node) {
-        return None;
-      }
+    if let Some(end_col) = self.end.column
+      && end_col != node_end_pos.column(&node)
+    {
+      return None;
     }
     Some(node)
   }

--- a/crates/config/src/rule_collection.rs
+++ b/crates/config/src/rule_collection.rs
@@ -63,10 +63,10 @@ where
 
 impl<L: Language> ContingentRule<L> {
   pub fn matches_path<P: AsRef<Path>>(&self, path: P) -> bool {
-    if let Some(ignore_globs) = &self.ignore_globs {
-      if ignore_globs.is_match(&path) {
-        return false;
-      }
+    if let Some(ignore_globs) = &self.ignore_globs
+      && ignore_globs.is_match(&path)
+    {
+      return false;
     }
     if let Some(files_globs) = &self.files_globs {
       return files_globs.is_match(path);

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -219,10 +219,10 @@ impl RuleCore {
     env: &mut Cow<MetaVarEnv<'tree, D>>,
     enclosing_env: Option<&MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    if let Some(kinds) = &self.kinds {
-      if !kinds.contains(node.kind_id().into()) {
-        return None;
-      }
+    if let Some(kinds) = &self.kinds
+      && !kinds.contains(node.kind_id().into())
+    {
+      return None;
     }
     let ret = self.rule.match_node_with_env(node, env)?;
     if !env.to_mut().match_constraints(&self.constraints) {

--- a/crates/config/src/transform/string_case.rs
+++ b/crates/config/src/transform/string_case.rs
@@ -130,15 +130,15 @@ impl Delimiter {
     }
     // case 2, consecutive UpperCases followed by lowercase
     // e.g. XMLHttp -> XML Http
-    if let MultiUpper(last_char) = state {
-      if c.is_lowercase() {
-        let new_left = *right - last_char.len_utf8();
-        let range = *left..new_left;
-        *left = new_left;
-        *right += c.len_utf8();
-        self.state = Lower;
-        return Some(range);
-      }
+    if let MultiUpper(last_char) = state
+      && c.is_lowercase()
+    {
+      let new_left = *right - last_char.len_utf8();
+      let range = *left..new_left;
+      *left = new_left;
+      *right += c.len_utf8();
+      self.state = Lower;
+      return Some(range);
     }
     *right += c.len_utf8();
     if *state == CaseState::IgnoreCase {
@@ -176,10 +176,10 @@ fn split<'a>(s: &'a str, seps: Option<&[Separator]>) -> impl Iterator<Item = &'a
   };
   std::iter::from_fn(move || {
     for c in chars.by_ref() {
-      if let Some(range) = delimiter.delimit(c) {
-        if range.start != range.end {
-          return Some(&s[range]);
-        }
+      if let Some(range) = delimiter.delimit(c)
+        && range.start != range.end
+      {
+        return Some(&s[range]);
       }
     }
     let range = delimiter.conclude(s.len())?;

--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -377,10 +377,10 @@ impl Matcher for Pattern {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    if let Some(k) = self.root_kind {
-      if node.kind_id() != k {
-        return None;
-      }
+    if let Some(k) = self.root_kind
+      && node.kind_id() != k
+    {
+      return None;
     }
     // do not pollute the env if pattern does not match
     let mut may_write = Cow::Borrowed(env.as_ref());

--- a/crates/core/src/meta_var.rs
+++ b/crates/core/src/meta_var.rs
@@ -123,10 +123,10 @@ impl<'t, D: Doc> MetaVarEnv<'t, D> {
   ) -> bool {
     let mut env = Cow::Borrowed(self);
     for (var_id, candidate) in &self.single_matched {
-      if let Some(m) = var_matchers.get(var_id) {
-        if m.match_node_with_env(candidate.clone(), &mut env).is_none() {
-          return false;
-        }
+      if let Some(m) = var_matchers.get(var_id)
+        && m.match_node_with_env(candidate.clone(), &mut env).is_none()
+      {
+        return false;
       }
     }
     if let Cow::Owned(env) = env {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -326,10 +326,10 @@ impl<'r, D: Doc> Node<'r, D> {
   ) -> impl Iterator<Item = NodeMatch<'r, D>> + 's {
     let kinds = pat.potential_kinds();
     self.dfs().filter_map(move |cand| {
-      if let Some(k) = &kinds {
-        if !k.contains(cand.kind_id().into()) {
-          return None;
-        }
+      if let Some(k) = &kinds
+        && !k.contains(cand.kind_id().into())
+      {
+        return None;
       }
       pat.match_node(cand)
     })

--- a/crates/core/src/ops.rs
+++ b/crates/core/src/ops.rs
@@ -81,10 +81,10 @@ impl<P: Matcher> Matcher for All<P> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    if let Some(kinds) = &self.kinds {
-      if !kinds.contains(node.kind_id().into()) {
-        return None;
-      }
+    if let Some(kinds) = &self.kinds
+      && !kinds.contains(node.kind_id().into())
+    {
+      return None;
     }
     let mut new_env = Cow::Borrowed(env.as_ref());
     let all_satisfied = self
@@ -137,10 +137,10 @@ impl<M: Matcher> Matcher for Any<M> {
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
-    if let Some(kinds) = &self.kinds {
-      if !kinds.contains(node.kind_id().into()) {
-        return None;
-      }
+    if let Some(kinds) = &self.kinds
+      && !kinds.contains(node.kind_id().into())
+    {
+      return None;
     }
     let mut new_env = Cow::Borrowed(env.as_ref());
     let found = self.patterns.iter().find_map(|p| {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -529,10 +529,10 @@ impl<L: LSPLang> Backend<L> {
   }
 
   async fn on_code_action(&self, params: CodeActionParams) -> Option<CodeActionResponse> {
-    if let Some(kinds) = params.context.only.as_ref() {
-      if kinds.contains(&CodeActionKind::SOURCE_FIX_ALL) {
-        return self.fix_all_code_action(params.text_document);
-      }
+    if let Some(kinds) = params.context.only.as_ref()
+      && kinds.contains(&CodeActionKind::SOURCE_FIX_ALL)
+    {
+      return self.fix_all_code_action(params.text_document);
     }
     self.quickfix_code_action(params)
   }

--- a/crates/lsp/tests/basic.rs
+++ b/crates/lsp/tests/basic.rs
@@ -346,10 +346,9 @@ async fn wait_for_response(
   for _ in 0..20 {
     if let Ok(Some(Ok(msg))) =
       tokio::time::timeout(std::time::Duration::from_secs(2), sender.next()).await
+      && msg.get("id") == Some(&serde_json::json!(id))
     {
-      if msg.get("id") == Some(&serde_json::json!(id)) {
-        return Some(msg);
-      }
+      return Some(msg);
     }
   }
   None

--- a/crates/napi/src/napi_lang.rs
+++ b/crates/napi/src/napi_lang.rs
@@ -91,10 +91,10 @@ impl FromStr for NapiLang {
   fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
     use SupportLang as S;
     // only support frontend languages to reduce binary size
-    if let Ok(b) = S::from_str(s) {
-      if matches!(b, S::Css | S::Html | S::JavaScript | S::Tsx | S::TypeScript) {
-        return Ok(NapiLang::Builtin(b));
-      }
+    if let Ok(b) = S::from_str(s)
+      && matches!(b, S::Css | S::Html | S::JavaScript | S::Tsx | S::TypeScript)
+    {
+      return Ok(NapiLang::Builtin(b));
     }
 
     if let Ok(c) = DynamicLang::from_str(s) {


### PR DESCRIPTION
## Summary
- collapse eligible nested if/if let chains into Rust 2024 let-chain conditions
- keep non-direct nested cases unchanged

## Test
- cargo fmt --all
- cargo test --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code patterns and conditional logic across multiple modules for enhanced maintainability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ast-grep/ast-grep/pull/2671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->