### PR TITLE
Fix typos in comments and grammar in --help text

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -86,7 +86,7 @@ fn is_command(arg: &str, command: &str) -> bool {
 }
 
 fn try_default_run(args: &[String]) -> Result<Option<RunArg>> {
-  // use `run` if there is at lease one pattern arg with no user provided command
+  // use `run` if there is at least one pattern arg with no user provided command
   let is_pattern = args.iter().skip(1).any(|p| is_command(p, "pattern"));
   let is_kind = args.iter().skip(1).any(|p| is_command(p, "kind"));
   let should_use_default_run_command = (is_pattern || is_kind) && args[1].starts_with('-');

--- a/crates/cli/src/new.rs
+++ b/crates/cli/src/new.rs
@@ -27,7 +27,7 @@ pub struct NewArg {
   /// Accept all default options without interactive input during creation.
   ///
   /// You need to provide all required arguments via command line if this flag is true.
-  /// Please see the command description for the what arguments are required.
+  /// Please see the command description for what arguments are required.
   #[arg(short, long, global = true)]
   yes: bool,
 }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -45,12 +45,12 @@ impl ValueEnum for Strictness {
   fn to_possible_value(&self) -> Option<PossibleValue> {
     use MatchStrictness as M;
     Some(match &self.0 {
-      M::Cst => PossibleValue::new("cst").help("Match exact all node"),
-      M::Smart => PossibleValue::new("smart").help("Match all node except source trivial nodes"),
+      M::Cst => PossibleValue::new("cst").help("Match all nodes exactly"),
+      M::Smart => PossibleValue::new("smart").help("Match all nodes except source trivial nodes"),
       M::Ast => PossibleValue::new("ast").help("Match only ast nodes"),
-      M::Relaxed => PossibleValue::new("relaxed").help("Match ast node except comments"),
+      M::Relaxed => PossibleValue::new("relaxed").help("Match ast nodes except comments"),
       M::Signature => {
-        PossibleValue::new("signature").help("Match ast node except comments, without text")
+        PossibleValue::new("signature").help("Match ast nodes except comments, without text")
       }
       M::Template => PossibleValue::new("template")
         .help("Similar to smart but match text only, node kinds are ignored"),


### PR DESCRIPTION
Small grammar/typo fixes (no behavior change):

**Code comments**
- `crates/cli/src/lib.rs` — `at lease one pattern arg` → `at least one pattern arg`.
- `crates/cli/src/new.rs` — `for the what arguments are required` → `for what arguments are required`.

**`--help` text for the `MatchStrictness` values** (`crates/cli/src/run.rs`), which had singular "node"/awkward wording:
- `cst`: `Match exact all node` → `Match all nodes exactly`
- `smart`: `Match all node except source trivial nodes` → `Match all nodes except source trivial nodes`
- `relaxed`: `Match ast node except comments` → `Match ast nodes except comments`
- `signature`: `Match ast node except comments, without text` → `Match ast nodes except comments, without text`

No test/snapshot asserts these strings (`help_test.rs` only checks the output contains `ast-grep`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved help text clarity for the `--yes` flag.
  * Enhanced `--strictness` flag descriptions with refined wording.
  * Corrected inline documentation for default run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->