### PR TITLE
fix: don't leak metavar bindings from a negated `not` rule

### DIFF
--- a/crates/config/src/rule/relational_rule.rs
+++ b/crates/config/src/rule/relational_rule.rs
@@ -337,6 +337,39 @@ mod test {
     o::All::new(vec![Rule::Pattern(Pattern::new(target, TS::Tsx)), relation])
   }
 
+  // A `not` sub-rule must never export a metavariable binding. When the negated
+  // inner matches some candidate (making the negation fail) the relational
+  // `find_map` keeps probing later candidates with the SAME env; without
+  // rollback in `Not`, the inner's stray binding survives into the eventual
+  // successful match. Here the nearest preceding sibling is a `return $A`
+  // (negated inner matches, would bind A=foo), while a farther sibling lets the
+  // negation succeed, so the match should bind nothing.
+  #[test]
+  fn test_not_in_relation_does_not_leak_env() {
+    use ast_grep_core::ops as o;
+    let follows = Follows {
+      former: Rule::Not(Box::new(o::Not::new(Rule::Pattern(Pattern::new(
+        "return $A",
+        TS::Tsx,
+      ))))),
+      stop_by: StopBy::End,
+    };
+    let grep = TS::Tsx.ast_grep("function f() { bar(); return foo; target; }");
+    let root = grep.root();
+    let target = root
+      .dfs()
+      .find(|n| n.text() == "target;")
+      .expect("find target stmt");
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    let matched = follows.match_node_with_env(target, &mut env);
+    assert!(matched.is_some(), "target follows a non-return statement");
+    let leaked = env.get_match("A").map(|n| n.text().to_string());
+    assert!(
+      leaked.is_none(),
+      "`not` must not leak a binding for $A, got {leaked:?}"
+    );
+  }
+
   #[test]
   fn test_precedes_operator() {
     let precedes = Precedes {

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -301,6 +301,33 @@ mod test {
     rule.get_matcher(env)
   }
 
+  // A `not` sub-rule must not leak a metavariable binding into the match env,
+  // even when reached through a relational rule. Regression for the env-leak
+  // class: the `return $A` sibling makes the negated inner match (binding A),
+  // but `not` succeeds on a different sibling, so $A must remain unbound.
+  #[test]
+  fn test_not_does_not_leak_env_via_yaml() {
+    use ast_grep_core::tree_sitter::LanguageExt;
+    let matcher = get_matcher(
+      r"
+rule:
+  kind: expression_statement
+  regex: '^target'
+  follows:
+    not:
+      pattern: return $A
+    stopBy: end
+",
+    )
+    .expect("rule should compile");
+    let grep = TypeScript::Tsx.ast_grep("function f() { bar(); return foo; target; }");
+    let nm = grep.root().find(&matcher).expect("should match target;");
+    assert!(
+      nm.get_env().get_match("A").is_none(),
+      "`not` must export no binding for $A"
+    );
+  }
+
   #[test]
   fn test_rule_error() {
     let ret = get_matcher(r"rule: {kind: bbb}");

--- a/crates/core/src/ops.rs
+++ b/crates/core/src/ops.rs
@@ -217,9 +217,17 @@ where
     node: Node<'tree, D>,
     env: &mut Cow<MetaVarEnv<'tree, D>>,
   ) -> Option<Node<'tree, D>> {
+    // A `not` rule never contributes bindings: a successful negation means the
+    // inner did NOT match, so there is nothing to bind. Run the inner against a
+    // throwaway clone so that an inner *match* (which makes the negation fail)
+    // cannot leak its partial bindings into the live env. Without this, a `not`
+    // evaluated via a relational rule's `find_map` (which reuses one env across
+    // candidates) can leave a stray binding behind that survives into a later,
+    // successful match. See the env-leak class fixed in PR #2670.
+    let mut probe = Cow::Borrowed(env.as_ref());
     self
       .not
-      .match_node_with_env(node.clone(), env)
+      .match_node_with_env(node.clone(), &mut probe)
       .xor(Some(node))
   }
 }
@@ -382,6 +390,21 @@ mod test {
   fn test_not() {
     let matcher = Not { not: "let a = 1" };
     test_find(&matcher, "const b = 2");
+  }
+
+  // When the negated inner matches (so `Not` fails) it must not leave the
+  // inner's bindings behind in env. A `not` rule never contributes bindings.
+  #[test]
+  fn test_not_does_not_leak_env() {
+    let matcher = Not { not: "let $A = 1" };
+    let code = Root::str("let x = 1", Tsx);
+    let node = code.root().find("let $B = 1").expect("should exist");
+    let node = node.get_node().clone();
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    // inner matches `let x = 1`, so the negation fails …
+    assert!(matcher.match_node_with_env(node, &mut env).is_none());
+    // … and must not have leaked a binding for $A
+    assert!(env.get_match("A").is_none());
   }
 
   #[test]


### PR DESCRIPTION
> **Disclaimer:** This PR was created with the help of [Claude Code](https://claude.com/claude-code). The root-cause investigation, fix, and regression tests were produced with AI assistance and reviewed by me before submitting.

## Motivation

A `not` rule must never contribute metavariable bindings — a successful negation means the inner rule did **not** match, so there is nothing to bind. But `Not::match_node_with_env` passed the **live** metavariable environment straight to its inner rule. When the inner *matches* (which makes the negation fail), it writes its bindings into the env and `Not` returns `None` **without reverting them**.

This is normally masked: `all`/`any` match into a cloned env and discard it when a branch fails, so a leaked binding never escapes. But a **relational rule** (`has`/`inside`/`precedes`/`follows`) evaluates its inner via `find_map` over many candidate nodes, reusing a **single** env with no clone in between. So a binding leaked by an early candidate (one where the negated inner matched) survives into a later, **successful** match and lands in the result env — corrupting any `fix`/`transform`/`constraints` that references the variable.

This is the same env-leak class fixed for the ellipsis-end lookahead probe in #2670, in a different matcher.

## Example

Target:

```js
function f() { bar(); return foo; target; }
```

Rule:

```yaml
id: leak
language: typescript
rule:
  kind: expression_statement
  regex: '^target'
  follows:
    not:
      pattern: return $A
    stopBy: end
```

`follows` walks the preceding siblings nearest-first. The nearest one, `return foo;`, matches the negated `return $A` (binding `$A = foo`), so the negation fails there and the leaked `$A = foo` stays in the env. A farther sibling, `bar();`, is not a `return`, so the negation succeeds and the node matches.

The `not` is meant to bind nothing, yet before this change the match's env contains `$A = foo`. After it, `$A` is correctly unbound.

## Summary

- In `Op::Not::match_node_with_env`, run the negated inner against a throwaway `Cow::Borrowed` clone of the env instead of the live one, so an inner match can never leak partial bindings into the caller's environment.
- Add regression tests at three levels: the `Not` operator directly (`test_not_does_not_leak_env`), through a relational rule (`test_not_in_relation_does_not_leak_env`), and through the YAML rule path (`test_not_does_not_leak_env_via_yaml`).

## Test plan

- [x] All three new regression tests fail before the fix and pass after.
- [x] `cargo test -p ast-grep-core -p ast-grep-config` all green (no regressions).
- [x] `cargo clippy -p ast-grep-core -p ast-grep-config --all-targets` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where negated pattern matches could leak temporary variable bindings into the surrounding match environment; negation now isolates probe bindings so subsequent matches behave correctly.

* **Tests**
  * Added regression tests that verify negated rules do not persist internal bindings across matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->