### PR TITLE
fix: don't leak metavar bindings across siblings in nthChild ofRule

### DIFF
--- a/crates/config/src/rule/nth_child.rs
+++ b/crates/config/src/rule/nth_child.rs
@@ -223,11 +223,19 @@ impl NthChild {
     let parent = node.parent()?;
     //  only consider named children
     let mut children: Vec<_> = if let Some(rule) = &self.of_rule {
-      // if of_rule is present, only consider children that match the rule
+      // if of_rule is present, only consider children that match the rule.
+      // Probe each sibling against a throwaway clone of the env so a binding
+      // from one sibling cannot leak into the next: otherwise a metavar-bearing
+      // ofRule (e.g. `pattern: $S`) binds the first matching sibling and then
+      // rejects every later sibling via metavar consistency, so the sibling
+      // list is undercounted and the position match silently fails.
       parent
         .children()
         .filter(|n| n.is_named())
-        .filter_map(|child| rule.match_node_with_env(child, env))
+        .filter_map(|child| {
+          let mut probe = Cow::Borrowed(env.as_ref());
+          rule.match_node_with_env(child, &mut probe)
+        })
         .collect()
     } else {
       parent.children().filter(|n| n.is_named()).collect()
@@ -236,9 +244,16 @@ impl NthChild {
     if self.reverse {
       children.reverse()
     }
-    children
+    let index = children
       .iter()
-      .position(|child| child.node_id() == node.node_id())
+      .position(|child| child.node_id() == node.node_id())?;
+    // Commit the *target* node's own ofRule bindings to the real env. ofRule
+    // metavars are part of `defined_vars` and may be referenced in fix /
+    // constraints; only the matched node's bindings are meaningful.
+    if let Some(rule) = &self.of_rule {
+      rule.match_node_with_env(node.clone(), env);
+    }
+    Some(index)
   }
   pub fn defined_vars(&self) -> HashSet<&str> {
     if let Some(rule) = &self.of_rule {
@@ -338,6 +353,18 @@ mod test {
     let i = find_index(Some(Rule::Regex(regex.clone())), false);
     assert_eq!(i, Some(0));
     let i = find_index(Some(Rule::Regex(regex)), true);
+    assert_eq!(i, Some(1));
+  }
+
+  // A metavar-binding ofRule (e.g. `pattern: $S`) must not let bindings leak
+  // from one sibling to the next while counting; otherwise only the first
+  // sibling is counted and the position match silently fails.
+  #[test]
+  fn test_find_of_rule_with_metavar() {
+    use ast_grep_core::Pattern;
+    // every element matches `$S`, so all four siblings must be counted and the
+    // index of node `2` (the 2nd element) must be 1, not lost to a binding leak.
+    let i = find_index(Some(Rule::Pattern(Pattern::new("$S", TS::Tsx))), false);
     assert_eq!(i, Some(1));
   }
 


### PR DESCRIPTION
> **Disclaimer:** This PR was created with the help of [Claude Code](https://claude.com/claude-code). The root-cause investigation, fix, and regression test were produced with AI assistance and reviewed by me before submitting.

## Motivation

`nthChild` with an `ofRule` counts the sibling nodes that match the sub-rule and then checks the target node's position in that filtered list. `NthChild::find_index` threaded the caller's **live** metavariable env into the `ofRule` match for *every* sibling.

When the `ofRule` binds a metavariable (e.g. `pattern: $S`), the first matching sibling commits `$S` into the env; every later sibling is then matched against that same binding and fails metavar-consistency, so it is dropped from the count. The sibling list is undercounted and the position never lines up — the rule silently matches nothing.

A `kind`/`regex` `ofRule` binds nothing and is unaffected, which is exactly why the only existing test (a `regex` `ofRule`) never caught it. Any `ofRule` written as a `pattern` — the common case — is broken and produces false negatives.

This is the same env-leak class as #2670 (a sub-match mutating a shared env across a multi-candidate loop), here in the positional `nthChild` matcher.

## Example

Target:

```js
function f() { a(); b(); c(); }
```

Rule (match the 2nd statement, counting only expression statements):

```yaml
id: nth
language: typescript
rule:
  kind: expression_statement
  regex: '^b'
  nthChild:
    position: 2
    ofRule: { pattern: $S }   # binds $S
```

Before this change the rule matches **nothing**: the `ofRule` binds `$S = a` on the first sibling, then rejects `b();` and `c();`, so only one sibling is counted. Replacing `ofRule` with `{ kind: expression_statement }` (no binding) matches `b();` correctly — confirming the binding is the trigger. After this change, the `pattern` form matches `b();` as expected.

## Summary

- In `NthChild::find_index`, probe each sibling against a throwaway `Cow::Borrowed` clone of the env so a binding from one sibling can't leak into the next.
- After locating the index, commit only the **target** node's own `ofRule` bindings to the real env (`ofRule` metavars are part of `defined_vars` and may be referenced in `fix`/`constraints`).
- Add a regression test (`test_find_of_rule_with_metavar`) with a metavar-binding `ofRule`.

## Test plan

- [x] New regression test `test_find_of_rule_with_metavar` fails before the fix and passes after.
- [x] `cargo test -p ast-grep-core -p ast-grep-config` all green (no regressions).
- [x] `cargo clippy -p ast-grep-config --all-targets` clean; `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug where metavar bindings were leaking across sibling iterations in element matching, causing incorrect results.

* **Tests**
  * Added test coverage to verify metavar bindings behave correctly during sibling matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->