### PR TITLE
fix: trailing ast-grep-ignore on a multi-line statement suppresses it

### DIFF
--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -70,11 +70,19 @@ fn get_suppression_kind(node: &Node<'_, impl Doc>) -> Option<SuppressKind> {
     return None;
   }
   let line = node.start_pos().line();
-  let suppress_next_line = if let Some(prev) = node.prev() {
-    prev.start_pos().line() != line
-  } else {
-    true
-  };
+  // A trailing suppression comment shares a line with the *end* of its preceding
+  // sibling (e.g. the closing `)` of a multi-line statement) and suppresses that
+  // statement; a comment with no code before it on its line suppresses the
+  // following line. We must compare against the previous node's END line, not its
+  // start line: a comment trailing a multi-line statement starts on a later line
+  // than the statement does, so using `start_pos` would misclassify it as a
+  // leading (next-line) comment. `trailing_start` is the suppressed statement's
+  // start line when this is a trailing comment.
+  let trailing_start = node
+    .prev()
+    .filter(|prev| prev.end_pos().line() == line)
+    .map(|prev| prev.start_pos().line());
+  let suppress_next_line = trailing_start.is_none();
   // if the first line is suppressed and the next line is empyt,
   // we suppress the whole file see gh #1541
   if line == 0
@@ -86,7 +94,10 @@ fn get_suppression_kind(node: &Node<'_, impl Doc>) -> Option<SuppressKind> {
   {
     return Some(SuppressKind::File);
   }
-  let key = if suppress_next_line { line + 1 } else { line };
+  // A trailing comment is keyed by its statement's START line because matches are
+  // looked up by their start line (see `line_suppression`); for a multi-line
+  // statement that start line differs from the comment's own line.
+  let key = trailing_start.unwrap_or(line + 1);
   Some(SuppressKind::Line(key))
 }
 
@@ -468,6 +479,19 @@ language: Tsx",
       assert_eq!(matches.1.len(), 2);
       assert_eq!(matches.1[0].text(), "console.log('no ignore')");
       assert_eq!(matches.1[1].text(), "console.log('ignore another')");
+    });
+  }
+
+  #[test]
+  fn test_ignore_multiline_node_same_line() {
+    // A trailing `// ast-grep-ignore` on the LAST line of a multi-line statement
+    // suppresses that statement (there is a preceding AST on the comment's line),
+    // not the following line.
+    let source = "console.log(\n  'multi'\n) // ast-grep-ignore\nconsole.log('after')\n";
+    test_scan(source, |scanned| {
+      let matches = &scanned[0];
+      assert_eq!(matches.1.len(), 1);
+      assert_eq!(matches.1[0].text(), "console.log('after')");
     });
   }
 


### PR DESCRIPTION
> **Disclaimer:** This PR was created with the help of [Claude Code](https://claude.com/claude-code). The root-cause investigation, fix, and regression test were produced with AI assistance and reviewed by me before submitting.

## Motivation

A `// ast-grep-ignore` comment trailing the **last line of a multi-line statement** is mishandled by `ast-grep scan`. The [documented rule](https://ast-grep.github.io/guide/project/severity.html) is:

> "Suppression comments will suppress the next line diagnostic **if and only if there is no preceding ASTs on the same line**."

For a multi-line statement, the statement's closing token *is* a preceding AST on the comment's line, so the comment should suppress that statement. Instead, the classifier compares the previous sibling's **start** line to the comment's line — which is false for a multi-line statement (it starts on an earlier line) — so the comment is misclassified as a standalone "next-line" comment. Two things then go wrong:

1. the multi-line statement is **not** suppressed (the intended suppression is lost), and
2. the **following** line is suppressed instead — silently hiding an unrelated diagnostic.

If `unused-suppression` is enabled, the directive is additionally reported as **unused**, producing a spurious diagnostic. This only affects the linting (`scan`) path, since `run` does not honor suppression comments.

## Example

```js
console.log(
  'multi'
) // ast-grep-ignore
console.log('after')
```

With rule `pattern: console.log($A)`:

- **Before:** `console.log(\n 'multi'\n)` is reported (not suppressed), and `console.log('after')` is wrongly suppressed.
- **After:** the multi-line `console.log(...)` is suppressed; `console.log('after')` is reported.

## Summary

- In `get_suppression_kind`, detect a trailing comment via the previous sibling's **end** line (`prev.end_pos().line() == comment_line`) instead of its start line, so a comment trailing a multi-line statement is correctly classified as trailing.
- Key a trailing suppression by the suppressed statement's **start** line (matches are looked up by their start line in `line_suppression`), so a multi-line match is actually suppressed.
- Behavior is unchanged for single-line statements (start line == end line) — the divergence is confined to the multi-line-trailing case.
- Add regression test `test_ignore_multiline_node_same_line`.

## Test plan

- [x] New test `test_ignore_multiline_node_same_line` fails before the fix and passes after.
- [x] All existing suppression tests pass unchanged (13 `combined` tests green).
- [x] `cargo test -p ast-grep-core -p ast-grep-config` all green.
- [x] `cargo clippy -p ast-grep-config --all-targets` clean; `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suppression comment detection for multi-line statements to ensure trailing suppression directives accurately target the intended code block without affecting subsequent lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->