### PR TITLE
Report unfixable diagnostics when using scan --update-all

### DIFF
--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -71,9 +71,8 @@ impl InteractivePrinter {
       first_line,
       inner,
     } = highlights;
-    // if ast-grep is called with -U, do not output anything
     if self.accept_all {
-      return Ok(());
+      return self.inner.process(inner);
     }
     utils::run_in_alternate_screen(|| {
       self.inner.process(inner)?;

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -34,6 +34,25 @@ rule:
   pattern: Some($A)
 ";
 
+const FIXABLE_JS_RULE: &str = "
+id: no-var
+message: use let
+severity: warning
+language: JavaScript
+rule:
+  pattern: var $A = $B;
+fix: let $A = $B;
+";
+
+const UNFIXABLE_JS_RULE: &str = "
+id: no-console
+message: no console
+severity: warning
+language: JavaScript
+rule:
+  pattern: console.log($A)
+";
+
 fn setup() -> Result<TempDir> {
   let dir = create_test_files([
     ("sgconfig.yml", CONFIG),
@@ -77,6 +96,34 @@ fn test_sg_rule_off() -> Result<()> {
     .stdout(contains("on-rule"))
     .stdout(contains("off-rule").not());
   drop(dir);
+  Ok(())
+}
+
+#[test]
+fn test_sg_scan_update_all_reports_unfixable_rules() -> Result<()> {
+  let dir = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/no-var.yml", FIXABLE_JS_RULE),
+    ("rules/no-console.yml", UNFIXABLE_JS_RULE),
+    ("test.js", "var x = 1;\nconsole.log(x);\n"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args([
+      "scan",
+      "--update-all",
+      "--color",
+      "never",
+      "--report-style",
+      "short",
+    ])
+    .assert()
+    .success()
+    .stdout(contains("no-console"))
+    .stdout(contains("no-var").not())
+    .stderr(contains("Applied 1 changes"));
+  let updated = std::fs::read_to_string(dir.path().join("test.js"))?;
+  assert_eq!(updated, "let x = 1;\nconsole.log(x);\n");
   Ok(())
 }
 


### PR DESCRIPTION
Problem I saw:
`ast-grep scan --update-all` applies fixable rewrites, but it was also hiding diagnostics from rules that do not have a fix.
In a mixed scan, the fixable rule was applied, but the remaining unfixable warning was not printed.
What I changed:
In accept-all mode, diff payloads still auto-confirm rewrites without printing the interactive diff preview.
Highlight diagnostics now continue through the normal printer, so unfixable findings are still shown after `--update-all` applies the available fixes.
I also added CLI regression coverage with one fixable rule and one unfixable rule. The test checks that the fix is applied, the fixed rule is no longer reported, the unfixable rule is still printed, and stderr reports the applied change.
How I checked it:
I ran:
cargo fmt --all
cargo fmt --all -- --check
focused regression test, 1 test
full scan integration test, 31 tests
git diff --check
Closes #2681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed highlight processing in interactive mode—highlights are now properly forwarded and output instead of being suppressed when using the accept-all option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->