### PR TITLE
fix: remove all impl, start from scratch

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -338,6 +338,7 @@ mod test_cli {
   }
 
   #[test]
+  #[ignore = "outline command is not implemented yet, just test arg parsing for now"]
   fn test_outline() {
     ok("outline crates/cli/src --json=stream");
     ok("outline crates/cli/src --json");


### PR DESCRIPTION
re0:ゼロから始めるoutline実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped test for unimplemented outline command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->