### PR TITLE
Outline first builtin rule

### DIFF
--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -66,6 +66,11 @@ isExported   Top-level item belongs to the file/module public surface.
 isPublic     Member is syntactically public/externally usable.
 ```
 
+This model is deliberately simple. It uses a small set of boolean flags for outline
+display instead of a large semantic taxonomy. That keeps the data model general across
+languages, keeps rendering decisions easy to reason about, and keeps rule-based
+extraction practical for built-in and custom languages.
+
 Flags are independent. For example, Rust `pub use internal_mod as api;` is one item
 with both `isImport` and `isExported`. `outline` does not recursively dump arbitrary
 AST nodes or build a normalized relationship graph; source-like signatures preserve

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -51,10 +51,12 @@ container lookup, related-code discovery, or structural diffs.
 | Role | Outline placement: `item` for top-level items and `member` for direct children. |
 | Import flag | `isImport`, true when a top-level item is a dependency edge. |
 | Export flag | `isExported`, true when a top-level item belongs to the file/module public surface. |
+| Public member flag | `isPublic`, true when a member is syntactically public/externally usable according to language-specific outline rules. |
 | Symbol type | Outline category, such as `class`, `function`, or `struct`. Values are compatible with LSP `SymbolKind` names. |
 | AST kind | The underlying tree-sitter node kind, such as `class_declaration` or `function_item`. |
-| Anchor | A top-level item selected for output after `--items`, `--match`, and `--type` filtering. |
-| Member | A direct structural child of an anchor, such as a field, method, constructor, enum variant, or direct namespace/module declaration. |
+| Name | The visible item or member name in the current file, such as a local binding name or exported name. |
+| Alias | The renamed-from symbol when source syntax exposes a different visible name; absent when it would duplicate `name` or `target`. |
+| Member | A direct structural child of a top-level item, such as a field, method, constructor, enum variant, or direct namespace/module declaration. |
 | Range | Full AST node range for the entry. |
 | Member digest | Grouped member names rendered on one compact line, such as `method: parse, recover`. |
 
@@ -69,6 +71,9 @@ Default behavior:
 ```sh
 sg outline <path>
 ```
+
+When no path is provided and `--stdin` is not used, `outline` searches the current
+directory, matching ast-grep's existing input behavior.
 
 The default output depends on whether the input is a file or a directory:
 
@@ -97,6 +102,7 @@ Users can override either default explicitly with `--items` and `--view`.
                           Select top-level items. Default: auto.
 --type <TYPE[,TYPE...]>   LSP-compatible symbol type filter.
 --match <REGEX>          Regex over useful top-level item fields.
+--pub-members             Display only public members.
 --view <auto|names|signatures|digest|expanded>
                           Control text presentation. Default: auto.
 ```
@@ -129,7 +135,9 @@ isImport      Dependency/import edge.
 isExported    Public/exported surface item.
 ```
 
-`--items` selects top-level items before type/name filtering:
+`--items` selects top-level items before type/name filtering. It does not filter by
+symbol type; constants, variables, types, and functions are included whenever the
+active rule catalog extracts them.
 
 ```text
 --items auto          file or directory default
@@ -138,12 +146,18 @@ directory default     exports
 --items structure     top-level items where isImport is false
 --items exports       top-level items where isExported is true
 --items imports       top-level items where isImport is true
---items all           all top-level items, including imports and export-only items
+--items all           all top-level items, including imports, re-exports, and
+                      explicit export declarations without local structure
 ```
 
 When `--items` is omitted, it behaves as `--items auto` and chooses the file or
 directory default from the public CLI contract. Mixed file and directory input uses the
 directory default.
+
+`isExported` is syntax-only in this command. It can come from explicit export syntax
+(`export`, `pub use`) or language public-surface syntax that a built-in outline rule can
+recognize locally (`pub`, exported Go names). It does not follow re-export chains or
+resolve module visibility across files.
 
 Examples:
 
@@ -159,15 +173,17 @@ sg outline src --items all
 `--match <REGEX>` and `--type <TYPE[,TYPE...]>` filter the current item
 selection. Neither option is repeatable.
 
-`--match` is deliberately not a custom DSL. It is a regular expression, like
-ripgrep's pattern argument, applied only to useful top-level item fields:
+`--match` is deliberately not a custom DSL. It is a Rust-regex regular expression,
+case-sensitive by default. Invalid regexes are CLI errors. The regex is applied only
+to useful top-level item fields:
 
-- normal items: symbol name, source line, signature, and container name.
-- import items: imported target, binding name, alias, and source line.
-- exported items: exported name, target, alias, source line, and container name.
+- structure items: symbol name, signature, and first source line.
+- import items: imported target, binding name, alias, signature, and first source line.
+- export edge items: exported name, target, alias, signature, and first source line.
 
-`--type` is a comma-separated OR filter over top-level item symbol types. It never
-matches or filters members:
+`--type` is a comma-separated OR filter over top-level item symbol types. Accepted
+values are the lower-camel `symbolType` names used in JSON, such as `class`,
+`enumMember`, and `typeParameter`. It never matches or filters members:
 
 ```text
 --type class,function       keep class or function items
@@ -199,7 +215,7 @@ arbitrary nested blocks.
 
 ```text
 auto        Choose `names` for directory input and `digest` for file/stdin input.
-names       One block per file: one digest line per top-level symbol type.
+names       One block per file: one grouped name line per top-level symbol type.
 signatures  One block per file: one source/signature line per top-level symbol.
 digest      `signatures` plus compact direct member name digests. File default.
 expanded    `signatures` plus one source/signature line per direct member.
@@ -230,6 +246,29 @@ sg outline src/parser.ts --match Parser --view expanded
 sg outline src/checker.ts --match checkTypeRelatedTo --view expanded
 ```
 
+### Member Publicness
+
+Member publicness is intentionally simpler than a full visibility model. Members can
+carry `isPublic: true` when language-specific syntax says the member is part of the
+usable surface of its parent. Private members use `isPublic: false` when the extractor
+can determine that. Languages or rules without this knowledge may leave `isPublic`
+absent.
+
+By default, member views display all extracted members. `digest` should list public
+members first inside each member symbol type group when `isPublic` is known, then list
+the remaining members. Each bucket keeps source order.
+
+`--pub-members` narrows displayed members in `digest` and `expanded` views:
+
+```text
+default         show all extracted members.
+--pub-members   show only members where isPublic is true.
+```
+
+Members with absent `isPublic` are kept by default and removed by `--pub-members`.
+`expanded` should keep source order; when `--pub-members` is present, it filters
+members without reordering the survivors.
+
 ### Ordering
 
 There is no standalone grouping option. Ordering and grouping are determined by
@@ -238,13 +277,15 @@ There is no standalone grouping option. Ordering and grouping are determined by
 ```text
 names       group top-level item names by symbol type
 signatures  show top-level items in source order
-digest      show top-level items in source order; group member names by symbol type
+digest      show top-level items in source order; group member names by symbol type,
+            with public names first when known
 expanded    show top-level items and members in source order
 ```
 
 The extracted outline model itself preserves source order within each file. Grouped text
-views should keep symbol type groups in a stable presentation order, and keep names
-inside each group in source order.
+views should keep symbol type groups in a stable presentation order. `names` keeps
+names inside each group in source order. `digest` keeps member names in source order
+inside the public and non-public buckets.
 
 Agents or scripts that need a different grouping strategy should use `--json` and
 post-process the structured entries. Text views stay opinionated and optimized for
@@ -263,6 +304,9 @@ default          text
 
 Interactive agents should usually use text. They should request `--json` only when they
 need to transform, extract, join, or programmatically compare outline entries.
+
+`--view` affects text output only. JSON output always emits the selected structured
+model after `--items`, `--match`, `--type`, and `--pub-members` filtering.
 
 ## Output Contract
 
@@ -315,7 +359,14 @@ class:
 73:   recover(...)
 ```
 
-Empty direct file input should be explicit:
+Empty output behavior:
+
+- Direct file and stdin input print an explicit file block when no selected item remains.
+- Directory walks suppress files with no selected items.
+- If a directory or mixed-input invocation selects nothing overall, print one
+  command-level `nothing found` message.
+
+Direct file example:
 
 ```text
 src/empty.ts
@@ -325,7 +376,7 @@ nothing found
 ### JSON Output
 
 `--json` returns grouped file output. `--json=stream` returns one independently useful
-entry per line.
+entry per line. JSON ranges use one-based line and column numbers, matching text output.
 
 Streamed entry shape:
 
@@ -345,7 +396,7 @@ Streamed entry shape:
     },
     "container": null,
     "signature": "enum Commands",
-    "memberDigest": "variant: Run, Scan, Test, New"
+    "astKind": "enum_item"
   }
 }
 ```
@@ -368,14 +419,19 @@ Grouped file shape:
         "end": { "line": 98, "column": 2, "byte": 2500 }
       },
       "signature": "export class Parser",
-      "memberDigest": "method: parse, recover",
       "astKind": "class_declaration",
       "members": [
         {
           "name": "parse",
           "symbolType": "method",
           "role": "member",
-          "visibility": "public"
+          "isPublic": true,
+          "range": {
+            "start": { "line": 44, "column": 3, "byte": 1300 },
+            "end": { "line": 72, "column": 4, "byte": 1900 }
+          },
+          "signature": "parse(...)",
+          "astKind": "method_definition"
         }
       ]
     }
@@ -390,8 +446,8 @@ Important properties:
 - `symbolType` uses LSP `SymbolKind` names serialized as lower camel case.
 - `role` is always `item` or `member`.
 - `isImport` and `isExported` are present on top-level items.
-- `visibility` is optional and only meaningful for members.
-- `memberDigest` is present when `--view digest` has grouped direct members.
+- `isPublic` is optional and only meaningful for members; it is absent or null for
+  top-level items.
 - `container` is present in stream output for parent-symbol metadata.
 
 ## Agent Examples
@@ -501,15 +557,6 @@ pub enum OutlineRole {
   Item,
   Member,
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum MemberVisibility {
-  Public,
-  Protected,
-  Private,
-  Internal,
-}
 ```
 
 Grouped item:
@@ -523,7 +570,6 @@ pub struct OutlineItem {
   pub is_exported: bool,
   pub range: Range,
   pub signature: Option<String>,
-  pub member_digest: Option<String>,
   pub detail: Option<String>,
   pub target: Option<String>,
   pub alias: Option<String>,
@@ -535,7 +581,7 @@ pub struct OutlineMember {
   pub name: Option<String>,
   pub symbol_type: SymbolType,
   pub role: OutlineRole,
-  pub visibility: Option<MemberVisibility>,
+  pub is_public: Option<bool>,
   pub range: Range,
   pub signature: Option<String>,
   pub detail: Option<String>,
@@ -564,10 +610,9 @@ pub struct OutlineFlatSymbol {
   pub role: OutlineRole,
   pub is_import: Option<bool>,
   pub is_exported: Option<bool>,
-  pub visibility: Option<MemberVisibility>,
+  pub is_public: Option<bool>,
   pub range: Range,
   pub signature: Option<String>,
-  pub member_digest: Option<String>,
   pub detail: Option<String>,
   pub target: Option<String>,
   pub alias: Option<String>,
@@ -585,7 +630,7 @@ pub struct OutlineContainer {
 ### Item Flags
 
 `role` is outline placement: `item` for top-level items and `member` for direct children.
-Import and export semantics are represented with item flags. Visibility is member-only.
+Import and export semantics are represented with item flags. Publicness is member-only.
 
 ```rust
 pub struct Foo {}
@@ -618,13 +663,12 @@ This is both an import/dependency edge and an export edge:
   "role": "item",
   "isImport": true,
   "isExported": true,
-  "target": "internal_mod",
-  "alias": "api"
+  "target": "internal_mod"
 }
 ```
 
 Language accessibility syntax can affect extraction-time metadata, especially member
-visibility and whether a top-level item receives `isExported`.
+`isPublic` and whether a top-level item receives `isExported`.
 
 ### Symbol Mapping
 
@@ -661,8 +705,8 @@ The CLI contract depends on a data-driven extraction layer, but the rule catalog
 schema and language-expansion strategy are documented separately in
 [outline-rule-extraction.md](outline-rule-extraction.md). In short, ast-grep rules
 select candidate syntax, and outline-specific extraction derives names, signatures,
-entry/member placement, visibility, import/export flags, targets, aliases, and direct
-members from those matches.
+entry/member placement, member publicness, import/export flags, targets, aliases, and
+direct members from those matches.
 
 ## Runtime And Exit Codes
 
@@ -715,15 +759,15 @@ streamed entries.
 Likely contract:
 
 ```text
---limit <N>    Maximum selected top-level anchors to emit.
+--limit <N>    Maximum selected top-level items to emit.
 ```
 
 Possible semantics:
 
-- Count selected top-level anchors after `--items`, `--type`, and `--match`.
+- Count selected top-level items after `--items`, `--type`, and `--match`.
 - Do not count member names in `--view digest`.
 - Do not count member rows in `--view expanded`.
-- Do not split a selected anchor from its direct members.
+- Do not split a selected top-level item from its direct members.
 - Apply in deterministic file/path/source order.
 
 Leave this out until there is evidence that agents or users need the guardrail
@@ -804,8 +848,5 @@ sg outline <changed-files> --items exports
 
 ## Open Questions
 
-- Should `--items structure` include top-level constants and variables by default, or
-  should the default output prefer named type/function declarations only?
-- Which language-specific accessibility rules should assign `isExported`?
 - Should unsupported languages be silent by default or emit warnings when not writing
   JSON?

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -18,7 +18,7 @@ navigation questions:
 - What members belong to this class, struct, enum, interface, function, or module?
 
 The command should stay narrow. It extracts one structural model per file, then projects
-that model with role filters, name/type filters, and member presentation options. It
+that model with item selection, name/type filters, and member presentation options. It
 should not grow separate subcommands for import lookup, export lookup, symbol lookup,
 container lookup, related-code discovery, or structural diffs.
 
@@ -32,7 +32,7 @@ container lookup, related-code discovery, or structural diffs.
 - Use `SymbolType` as ast-grep's outline category model, with values compatible with
   LSP `SymbolKind` names.
 - Use concise text as the default output for interactive use.
-- Support `--json` for scripts and agents that need structured records.
+- Support `--json` for scripts and agents that need structured entries.
 
 ## Non-Goals
 
@@ -47,13 +47,15 @@ container lookup, related-code discovery, or structural diffs.
 
 | Term | Meaning |
 | --- | --- |
-| Record | One extracted outline fact: name, symbol type, roles, range, signature, and optional children. |
-| Role | A facet that explains which question a record answers: `definition`, `import`, or `export`. Roles are not mutually exclusive. |
+| Entry | One extracted outline fact: name, symbol type, placement role, range, signature, flags, and optional members. |
+| Role | Outline placement: `item` for top-level items and `member` for direct children. |
+| Import flag | `isImport`, true when a top-level item is a dependency edge. |
+| Export flag | `isExported`, true when a top-level item belongs to the file/module public surface. |
 | Symbol type | Outline category, such as `class`, `function`, or `struct`. Values are compatible with LSP `SymbolKind` names. |
 | AST kind | The underlying tree-sitter node kind, such as `class_declaration` or `function_item`. |
-| Anchor | A selected top-level record after `--role`, `--type`, and `--match` filters. Member output is attached to anchors. |
+| Anchor | A top-level item selected for output after `--items`, `--match`, and `--type` filtering. |
 | Member | A direct structural child of an anchor, such as a field, method, constructor, enum variant, or direct namespace/module declaration. |
-| Range | Full AST node range for the record. |
+| Range | Full AST node range for the entry. |
 | Member digest | Grouped member names rendered on one compact line, such as `method: parse, recover`. |
 
 ## Public CLI Contract
@@ -71,19 +73,19 @@ sg outline <path>
 The default output depends on whether the input is a file or a directory:
 
 ```text
-stdin                         --role auto --view auto  =>  --role definition --role export --view digest
-all explicit inputs are files --role auto --view auto  =>  --role definition --role export --view digest
-any directory input present   --role auto --view auto  =>  --role export --view names
+stdin                         --items auto --view auto  =>  --items structure --view digest
+all explicit inputs are files --items auto --view auto  =>  --items structure --view digest
+any directory input present   --items auto --view auto  =>  --items exports --view names
 ```
 
 A file outline is for inspecting one file's internal structure, so it shows local
-definitions and exported records with compact direct member names. A directory outline is
-for scanning project structure, so it shows only exported surface names by default.
+top-level structure excluding imports, with compact direct member names. A directory outline is
+for scanning project structure, so it shows only exported surface items by default.
 If files and directories are mixed in one invocation, `auto` resolves command-wide to the
 directory default. Per-path defaults would make the same file render differently
 depending on how it was reached.
 
-Users can override either default explicitly with `--role` and `--view`.
+Users can override either default explicitly with `--items` and `--view`.
 
 ### Core Options
 
@@ -91,10 +93,10 @@ Users can override either default explicitly with `--role` and `--view`.
 --json[=<pretty|compact|stream>]
                           Output structured JSON. Follows ast-grep's existing
                           `--json` flag shape.
---role <auto|definition|import|export|any[,..]>
-                          Select records by role. Repeatable. Default: auto.
+--items <auto|structure|exports|imports|all>
+                          Select top-level items. Default: auto.
 --type <TYPE[,TYPE...]>   LSP-compatible symbol type filter.
---match <REGEX>          Regex over role-relevant fields. Repeatable.
+--match <REGEX>          Regex over useful top-level item fields.
 --view <auto|names|signatures|digest|expanded>
                           Control text presentation. Default: auto.
 ```
@@ -118,75 +120,72 @@ The current design intentionally does not include `--limit`. See
 
 ## CLI Semantics
 
-### Role Selection
+### Item Selection
 
-Every record has one or more roles:
-
-```text
-definition    Local declaration or implementation.
-import        Dependency edge.
-export        Public/exported surface.
-```
-
-`--role` filters records by role membership:
+An item is the top-level placement role. Items can carry flags:
 
 ```text
---role auto                          file or directory default
-file default                         local definitions or exported records
-directory default                    exported/public records
---role definition                    local definitions
---role import                        imports and dependency edges
---role export                        exported/public records
---role definition,export             exported records implemented locally
---role import,export                 exports forwarded from another module
---role definition --role import      local definitions or imports
---role any                           no role filtering
+isImport      Dependency/import edge.
+isExported    Public/exported surface item.
 ```
 
-Comma-separated roles inside one `--role` are ANDed because roles are facets on one
-record. Repeated `--role` flags are ORed. `auto` and `any` are selector modes, not
-record roles, and should not be combined with other role filters. When `--role` is
-omitted, it behaves as `--role auto` and chooses the file or directory default from the
-public CLI contract. Mixed file and directory input uses the directory default.
+`--items` selects top-level items before type/name filtering:
+
+```text
+--items auto          file or directory default
+file default          structure
+directory default     exports
+--items structure     top-level items where isImport is false
+--items exports       top-level items where isExported is true
+--items imports       top-level items where isImport is true
+--items all           all top-level items, including imports and export-only items
+```
+
+When `--items` is omitted, it behaves as `--items auto` and chooses the file or
+directory default from the public CLI contract. Mixed file and directory input uses the
+directory default.
 
 Examples:
 
 ```sh
 sg outline src
-sg outline src --role import
-sg outline src --role export
-sg outline src --role definition,export
-sg outline src --role import,export
-sg outline src --role definition --role import
+sg outline src --items imports
+sg outline src --items exports
+sg outline src --items all
 ```
 
 ### Match And Type Filters
 
-`--match <REGEX>` and `--type <TYPE>` select anchors inside the current role selection.
+`--match <REGEX>` and `--type <TYPE[,TYPE...]>` filter the current item
+selection. Neither option is repeatable.
 
-`--match` is deliberately not a custom DSL. It is a regular expression, like ripgrep's
-pattern argument, applied to useful fields:
+`--match` is deliberately not a custom DSL. It is a regular expression, like
+ripgrep's pattern argument, applied only to useful top-level item fields:
 
-- definitions: symbol name, source line, signature, and container name.
-- imports: imported target, binding name, alias, and source line.
-- exports: exported name, re-export target, alias, source line, and container name.
+- normal items: symbol name, source line, signature, and container name.
+- import items: imported target, binding name, alias, and source line.
+- exported items: exported name, target, alias, source line, and container name.
 
-Filter composition:
+`--type` is a comma-separated OR filter over top-level item symbol types. It never
+matches or filters members:
 
 ```text
---type values separated by comma     OR
-repeated --match                     OR
-different filter types               AND
+--type class,function       keep class or function items
+--type method,field         keep no top-level items, because methods and fields
+                            are not top-level item types
+--match Parser --type class
+                            keep Parser class items
 ```
 
-Members attached by `--view digest` or `--view expanded` do not need to match the
-filters. They are preserved because they explain the matched anchor.
+When `--match` and `--type` are both present, `--match` first selects
+top-level items, then `--type` filters those top-level items. Neither option matches
+members. Once a top-level item survives, member output is controlled only by `--view`.
 
 Examples:
 
 ```sh
 sg outline crates --type struct,enum,interface
-sg outline crates --role export --match 'Config|Rule|Scan|Verify'
+sg outline crates --items exports --match 'Config|Rule|Scan|Verify'
 sg outline src/parser.ts --match Parser --type class --view expanded
 ```
 
@@ -231,6 +230,26 @@ sg outline src/parser.ts --match Parser --view expanded
 sg outline src/checker.ts --match checkTypeRelatedTo --view expanded
 ```
 
+### Ordering
+
+There is no standalone grouping option. Ordering and grouping are determined by
+`--view`, because each view answers a different reading task:
+
+```text
+names       group top-level item names by symbol type
+signatures  show top-level items in source order
+digest      show top-level items in source order; group member names by symbol type
+expanded    show top-level items and members in source order
+```
+
+The extracted outline model itself preserves source order within each file. Grouped text
+views should keep symbol type groups in a stable presentation order, and keep names
+inside each group in source order.
+
+Agents or scripts that need a different grouping strategy should use `--json` and
+post-process the structured entries. Text views stay opinionated and optimized for
+interactive reading.
+
 ### Output Mode
 
 Text is the default output.
@@ -239,18 +258,18 @@ Text is the default output.
 default          text
 --json           pretty-printed JSON
 --json=compact   compact JSON
---json=stream    newline-delimited records
+--json=stream    newline-delimited entries
 ```
 
 Interactive agents should usually use text. They should request `--json` only when they
-need to transform, extract, join, or programmatically compare outline records.
+need to transform, extract, join, or programmatically compare outline entries.
 
 ## Output Contract
 
 ### Text Output
 
 Text output should prefer compact file/symbol digests, source lines, or names over raw
-metadata. It should not print role labels by default.
+metadata. It should not print `role`, `isImport`, or `isExported` labels by default.
 
 With `--view names`:
 
@@ -306,9 +325,9 @@ nothing found
 ### JSON Output
 
 `--json` returns grouped file output. `--json=stream` returns one independently useful
-record per line.
+entry per line.
 
-Streamed record shape:
+Streamed entry shape:
 
 ```json
 {
@@ -317,7 +336,9 @@ Streamed record shape:
   "symbol": {
     "name": "Commands",
     "symbolType": "enum",
-    "roles": ["definition"],
+    "role": "item",
+    "isImport": false,
+    "isExported": false,
     "range": {
       "start": { "line": 49, "column": 1, "byte": 1200 },
       "end": { "line": 68, "column": 2, "byte": 1700 }
@@ -339,7 +360,9 @@ Grouped file shape:
     {
       "name": "Parser",
       "symbolType": "class",
-      "roles": ["definition", "export"],
+      "role": "item",
+      "isImport": false,
+      "isExported": true,
       "range": {
         "start": { "line": 40, "column": 1, "byte": 1200 },
         "end": { "line": 98, "column": 2, "byte": 2500 }
@@ -347,11 +370,12 @@ Grouped file shape:
       "signature": "export class Parser",
       "memberDigest": "method: parse, recover",
       "astKind": "class_declaration",
-      "children": [
+      "members": [
         {
           "name": "parse",
           "symbolType": "method",
-          "roles": ["definition"]
+          "role": "member",
+          "visibility": "public"
         }
       ]
     }
@@ -364,7 +388,9 @@ Important properties:
 - `path` is always present.
 - `range` is always present, so an agent can open a precise slice.
 - `symbolType` uses LSP `SymbolKind` names serialized as lower camel case.
-- `roles` is a non-empty array.
+- `role` is always `item` or `member`.
+- `isImport` and `isExported` are present on top-level items.
+- `visibility` is optional and only meaningful for members.
 - `memberDigest` is present when `--view digest` has grouped direct members.
 - `container` is present in stream output for parent-symbol metadata.
 
@@ -374,8 +400,8 @@ Important properties:
 
 ```sh
 sg outline crates/cli/src/scan.rs
-sg outline crates/cli/src/scan.rs --role import
-sg outline crates/cli/src/scan.rs --role export
+sg outline crates/cli/src/scan.rs --items imports
+sg outline crates/cli/src/scan.rs --items exports
 ```
 
 This gives a table of contents, dependencies, and public entry points before the agent
@@ -386,7 +412,7 @@ reads implementation details.
 ```sh
 sg outline crates/cli/src --type enum,struct,function
 sg outline crates/cli/src/lib.rs --match Commands --type enum --view expanded
-sg outline crates/cli/src --role export --match 'Arg|run_'
+sg outline crates/cli/src --items exports --match 'Arg|run_'
 ```
 
 This finds command enums, argument structs, run functions, and public API surfaces
@@ -395,8 +421,8 @@ without reading every CLI file.
 ### Trace Dependency Direction
 
 ```sh
-sg outline crates --role import --match ast-grep-config
-sg outline crates/cli/src --role import --match ast-grep-core
+sg outline crates --items imports --match ast-grep-config
+sg outline crates/cli/src --items imports --match ast-grep-core
 ```
 
 This identifies files that depend on a module or package. The agent can then decide
@@ -410,14 +436,14 @@ sg outline crates/core/src/node.rs --match Node --type struct --view expanded
 ```
 
 This lists direct members without reading the whole parent body. `--type` disambiguates
-same-name symbols.
+the top-level item type; `--view expanded` controls member output.
 
 ### Inspect Changed Files After Editing
 
 ```sh
 git diff --name-only HEAD
 sg outline <changed-files>
-sg outline <changed-files> --role export
+sg outline <changed-files> --items exports
 ```
 
 Git remains the source of truth for what changed. `outline` summarizes the current
@@ -429,8 +455,8 @@ structure and public surface of those changed files.
 sg outline crates --json=stream
 ```
 
-This is the machine-readable mode for ranking candidates by path, symbol type, name, roles, and
-container. It is not the default interactive-agent mode.
+This is the machine-readable mode for ranking candidates by path, symbol type, name,
+item flags, and container. It is not the default interactive-agent mode.
 
 ## Data Model
 
@@ -440,42 +466,49 @@ Use ast-grep `SymbolType` names in output. The values are compatible with LSP
 ```rust
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[repr(u8)]
 pub enum SymbolType {
-  File = 1,
-  Module = 2,
-  Namespace = 3,
-  Package = 4,
-  Class = 5,
-  Method = 6,
-  Property = 7,
-  Field = 8,
-  Constructor = 9,
-  Enum = 10,
-  Interface = 11,
-  Function = 12,
-  Variable = 13,
-  Constant = 14,
-  String = 15,
-  Number = 16,
-  Boolean = 17,
-  Array = 18,
-  Object = 19,
-  Key = 20,
-  Null = 21,
-  EnumMember = 22,
-  Struct = 23,
-  Event = 24,
-  Operator = 25,
-  TypeParameter = 26,
+  File,
+  Module,
+  Namespace,
+  Package,
+  Class,
+  Method,
+  Property,
+  Field,
+  Constructor,
+  Enum,
+  Interface,
+  Function,
+  Variable,
+  Constant,
+  String,
+  Number,
+  Boolean,
+  Array,
+  Object,
+  Key,
+  Null,
+  EnumMember,
+  Struct,
+  Event,
+  Operator,
+  TypeParameter,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum SymbolRole {
-  Definition,
-  Import,
-  Export,
+pub enum OutlineRole {
+  Item,
+  Member,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MemberVisibility {
+  Public,
+  Protected,
+  Private,
+  Internal,
 }
 ```
 
@@ -485,7 +518,9 @@ Grouped item:
 pub struct OutlineItem {
   pub name: Option<String>,
   pub symbol_type: SymbolType,
-  pub roles: Vec<SymbolRole>,
+  pub role: OutlineRole,
+  pub is_import: bool,
+  pub is_exported: bool,
   pub range: Range,
   pub signature: Option<String>,
   pub member_digest: Option<String>,
@@ -493,7 +528,18 @@ pub struct OutlineItem {
   pub target: Option<String>,
   pub alias: Option<String>,
   pub ast_kind: String,
-  pub children: Vec<OutlineItem>,
+  pub members: Vec<OutlineMember>,
+}
+
+pub struct OutlineMember {
+  pub name: Option<String>,
+  pub symbol_type: SymbolType,
+  pub role: OutlineRole,
+  pub visibility: Option<MemberVisibility>,
+  pub range: Range,
+  pub signature: Option<String>,
+  pub detail: Option<String>,
+  pub ast_kind: String,
 }
 
 pub struct OutlineFile {
@@ -503,10 +549,10 @@ pub struct OutlineFile {
 }
 ```
 
-Streamed record:
+Streamed entry:
 
 ```rust
-pub struct OutlineRecord {
+pub struct OutlineEntry {
   pub path: PathBuf,
   pub language: SgLang,
   pub symbol: OutlineFlatSymbol,
@@ -515,7 +561,10 @@ pub struct OutlineRecord {
 pub struct OutlineFlatSymbol {
   pub name: Option<String>,
   pub symbol_type: SymbolType,
-  pub roles: Vec<SymbolRole>,
+  pub role: OutlineRole,
+  pub is_import: Option<bool>,
+  pub is_exported: Option<bool>,
+  pub visibility: Option<MemberVisibility>,
   pub range: Range,
   pub signature: Option<String>,
   pub member_digest: Option<String>,
@@ -533,22 +582,24 @@ pub struct OutlineContainer {
 }
 ```
 
-### Roles Are Facets
+### Item Flags
 
-Roles are facets, not mutually exclusive categories. One source construct can answer
-more than one question.
+`role` is outline placement: `item` for top-level items and `member` for direct children.
+Import and export semantics are represented with item flags. Visibility is member-only.
 
 ```rust
 pub struct Foo {}
 ```
 
-This is one record:
+This is one entry:
 
 ```json
 {
   "name": "Foo",
   "symbolType": "struct",
-  "roles": ["definition", "export"]
+  "role": "item",
+  "isImport": false,
+  "isExported": true
 }
 ```
 
@@ -564,23 +615,22 @@ This is both an import/dependency edge and an export edge:
 {
   "name": "api",
   "symbolType": "module",
-  "roles": ["import", "export"],
+  "role": "item",
+  "isImport": true,
+  "isExported": true,
   "target": "internal_mod",
   "alias": "api"
 }
 ```
 
-Language accessibility syntax should be used only to decide whether a record receives
-the `export` role. Rust `pub`, Go capitalized names, Java `public` top-level
-declarations, and Swift `public`/`open` declarations can map to
-`roles: ["definition", "export"]` when they are part of the file/module API surface.
-Do not expose a separate visibility axis in the CLI.
+Language accessibility syntax can affect extraction-time metadata, especially member
+visibility and whether a top-level item receives `isExported`.
 
 ### Symbol Mapping
 
 Do not introduce custom symbol types for imports or exports. Map source constructs to
-existing LSP symbol kinds and use `roles`, `target`, and `alias` metadata to preserve
-import/export meaning.
+existing LSP symbol kinds and use `isImport`, `isExported`, `target`, and `alias`
+metadata to preserve import/export meaning.
 
 | Source construct | `symbolType` |
 | --- | --- |
@@ -605,149 +655,14 @@ import/export meaning.
 | Operator overload | `Operator` |
 | Type parameter or generic parameter | `TypeParameter` |
 
-## Extraction Strategy
+## Extraction Rules
 
-Extraction must be data-driven. The command should not have Rust match arms such as
-"if language is Rust, match `function_item`". Built-in support is a bundled extractor
-catalog. User and custom-language support is additional extractor YAML loaded by
-`--outline-rules`.
-
-An extractor is an ast-grep rule-core object plus outline metadata:
-
-```yaml
-extractors:
-  - id: rust-function
-    language: Rust
-    kind: function
-    roles: [definition]
-    addRoles:
-      export: textPrefix:pub
-    name: field:name
-    rule: { kind: function_item }
-
-  - id: rust-pub-use
-    language: Rust
-    kind: module
-    roles: [import, export]
-    name: text
-    target: text
-    rule:
-      all:
-        - kind: use_declaration
-        - regex: '^\s*pub\s+use\b'
-
-  - id: ts-re-export
-    language: TypeScript
-    kind: module
-    roles: [import, export]
-    name: text
-    target: text
-    rule:
-      all:
-        - kind: export_statement
-        - regex: '^\s*export\s+(\{|\*|type\s+\{)'
-```
-
-The `rule`, `constraints`, `utils`, and `transform` fields are the same rule-core fields
-ast-grep already uses. Outline does not invent a second query language.
-
-Extractor fields:
-
-```text
-id          Stable extractor id for diagnostics.
-language    Any `SgLang`: built-in language or registered custom language.
-kind        SymbolType in extractor YAML. Serialized as public `symbolType`.
-roles       Non-empty list containing definition, import, and/or export.
-addRoles    Optional conditional roles to add when a source predicate matches.
-name        How to resolve the display name.
-target      Optional module/package/path target for import/export edges.
-alias       Optional local alias for import/export edges.
-rule        ast-grep rule object. Required.
-```
-
-Supported `name` values:
-
-```text
-NAME          Use metavariable `$NAME` captured by the ast-grep rule.
-$NAME         Same as `NAME`.
-field:name    Use the matched node's tree-sitter field named `name`.
-text          Use the matched node text, normalized for imports/exports.
-auto          Best-effort fallback for built-ins.
-```
-
-Supported `addRoles` predicates:
-
-```text
-nameUppercase
-textPrefix:<PREFIX>
-textPrefixAny:<A>,<B>
-notTextPrefixAny:<A>,<B>
-ancestorKind:<NODE_KIND>
-auto
-```
-
-`addRoles` is role-oriented. It should answer "should this source construct also have
-the export, import, or definition role?" rather than exposing language visibility as a
-separate concept.
-
-Extractor flow:
-
-1. Parse source with `SgLang::ast_grep`.
-2. Load bundled extractors unless `--no-default-outline-rules` is set.
-3. Load user extractor files from `--outline-rules`.
-4. Keep extractors whose `language` matches the file language.
-5. Compile each extractor's rule through `SerializableRuleCore::get_matcher`.
-6. Run every matcher against the parsed AST.
-7. Use the matched node as `range`.
-8. Resolve `name` from configured metavariable, field, text, or fallback.
-9. Set symbol type, roles, target, and alias, then apply conditional `addRoles`.
-10. Sort items by start byte.
-11. Deduplicate overlapping matches by range, symbol type, and name. Merge roles instead of
-    emitting duplicate records.
-12. Nest structural members by range containment or language-specific membership rules.
-13. Apply role selection, anchor filters, and member presentation before printing.
-
-## Language And Custom Language Support
-
-Language expansion is an extractor-catalog problem, not a CLI-code problem.
-
-Built-in extractors should ship for common languages such as Rust, TypeScript, TSX,
-JavaScript, Python, and Go. Adding another built-in language should mean adding
-extractor entries and tests, not changing the extraction algorithm.
-
-Custom languages work the same way:
-
-1. Register the custom parser in `sgconfig.yml` through ast-grep's existing
-   `customLanguages` support.
-2. Write one or more outline extractor entries with `language: <custom-language-name>`.
-3. Run outline with `--outline-rules <FILE>`.
-
-Example:
-
-```yaml
-extractors:
-  - id: mylang-def
-    language: mylang
-    kind: function
-    roles: [definition]
-    name: NAME
-    rule:
-      pattern: def $NAME($$$ARGS) $$$BODY
-```
-
-```sh
-sg outline src --outline-rules mylang-outline.yml
-```
-
-To completely replace bundled behavior:
-
-```sh
-sg outline src \
-  --no-default-outline-rules \
-  --outline-rules project-outline.yml
-```
-
-Unsupported languages should return an empty outline and a successful exit status.
+The CLI contract depends on a data-driven extraction layer, but the rule catalog
+schema and language-expansion strategy are documented separately in
+[outline-rule-extraction.md](outline-rule-extraction.md). In short, ast-grep rules
+select candidate syntax, and outline-specific extraction derives names, signatures,
+entry/member placement, visibility, import/export flags, targets, aliases, and direct
+members from those matches.
 
 ## Runtime And Exit Codes
 
@@ -759,16 +674,16 @@ Path mode:
 1. Build a walk with `InputArgs`.
 2. Infer language with `SgLang::from_path(path)` unless `--lang` is provided.
 3. Read source with the same file-size safeguards used by `run` and `scan`.
-4. Extract outline items.
-5. Apply role selection and filters.
-6. Print text, grouped JSON, or streamed records.
+4. Extract outline entries.
+5. Apply item selection and filters.
+6. Print text, grouped JSON, or streamed entries.
 
 Stdin mode:
 
 1. Require `--lang`.
 2. Read stdin into a string.
 3. Parse with the provided language.
-4. Extract outline items.
+4. Extract outline entries.
 5. Use `STDIN` as the path.
 
 Exit codes:
@@ -788,14 +703,14 @@ composition when they need presentation-level truncation:
 
 ```sh
 sg outline crates/cli/src | head -n 120
-sg outline crates/cli/src --role export | head -n 80
+sg outline crates/cli/src --items exports | head -n 80
 sg outline crates/cli/src --json=stream | jq 'select(.symbol.symbolType == "function")'
 ```
 
 A future built-in limit may still be valuable as a safety guard against accidentally
-emitting a large subtree. If added, it should not be described as "maximum records or
-tree items" because that is ambiguous across text views, pretty JSON, compact JSON, and
-streamed JSON records.
+emitting a large subtree. If added, it should not be described as "maximum entries or
+tree nodes" because that is ambiguous across text views, pretty JSON, compact JSON, and
+streamed entries.
 
 Likely contract:
 
@@ -805,7 +720,7 @@ Likely contract:
 
 Possible semantics:
 
-- Count selected top-level anchors after `--role`, `--type`, and `--match`.
+- Count selected top-level anchors after `--items`, `--type`, and `--match`.
 - Do not count member names in `--view digest`.
 - Do not count member rows in `--view expanded`.
 - Do not split a selected anchor from its direct members.
@@ -833,7 +748,7 @@ sg outline find crates --match RunArg
 ```
 
 Decision: do not include it. A useful `find` must be comprehensive across top-level
-definitions, direct members, imports, exports, and containers. A partial version looks
+items, direct members, imports, exports, and containers. A partial version looks
 precise while silently missing important cases. Use `rg` and then `sg outline` on
 candidate files or subtrees.
 
@@ -865,7 +780,7 @@ sg outline related crates/cli/src/run.rs --symbol RunArg
 
 Decision: do not include it. The name promises semantic help that local syntax outline
 cannot reliably provide: references, module resolution, call graph edges, inheritance,
-test mapping, and re-export resolution. Use `--role import`, `--role export`,
+test mapping, and re-export resolution. Use `--items imports`, `--items exports`,
 `--match <REGEX> --view expanded`, `rg`, and normal path discovery instead.
 
 ### `diff`
@@ -875,7 +790,7 @@ Intent: answer "did this edit change structure or public API?"
 Example shape:
 
 ```sh
-sg outline diff --base main --role export
+sg outline diff --base main --items exports
 ```
 
 Decision: do not include it. Generic structural diff is hard to explain and easy to
@@ -884,13 +799,13 @@ misuse. Use git for changed files and outline for the current structure:
 ```sh
 git diff --name-only HEAD
 sg outline <changed-files>
-sg outline <changed-files> --role export
+sg outline <changed-files> --items exports
 ```
 
 ## Open Questions
 
-- Should `--role definition` include top-level constants and variables by default, or
+- Should `--items structure` include top-level constants and variables by default, or
   should the default output prefer named type/function declarations only?
-- Which language-specific accessibility rules should assign the `export` role?
+- Which language-specific accessibility rules should assign `isExported`?
 - Should unsupported languages be silent by default or emit warnings when not writing
   JSON?

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -43,22 +43,46 @@ container lookup, related-code discovery, or structural diffs.
 - Import/export semantics may be approximate when syntax alone cannot express a
   language's full module system.
 
-## Glossary
+## Conceptual Model
+
+`outline` extracts **entries** from each parsed file and projects them into text or
+JSON. A `struct Foo`, `class Parser`, `function parse()`, `import ...`, or class
+method can each become an entry. An entry is one structural fact with a name, role,
+`SymbolType`, source range, first-line signature, AST kind, and optional metadata.
+
+There are two roles:
+
+```text
+item     Top-level file/module structure: declarations, imports, and explicit exports.
+member   Direct child structure under an item: fields, methods, constructors, variants,
+         and similar members.
+```
+
+Items can carry import/export flags. Members can carry publicness:
+
+```text
+isImport     Top-level item is a dependency/import edge.
+isExported   Top-level item belongs to the file/module public surface.
+isPublic     Member is syntactically public/externally usable.
+```
+
+Flags are independent. For example, Rust `pub use internal_mod as api;` is one item
+with both `isImport` and `isExported`. `outline` does not recursively dump arbitrary
+AST nodes or build a normalized relationship graph; source-like signatures preserve
+syntax such as `extends`, `implements`, Rust `impl`, and protocol conformance.
+
+Important terms:
 
 | Term | Meaning |
 | --- | --- |
-| Entry | One extracted outline fact: name, symbol type, placement role, range, signature, flags, and optional members. |
-| Role | Outline placement: `item` for top-level items and `member` for direct children. |
-| Import flag | `isImport`, true when a top-level item is a dependency edge. |
-| Export flag | `isExported`, true when a top-level item belongs to the file/module public surface. |
-| Public member flag | `isPublic`, true when a member is syntactically public/externally usable according to language-specific outline rules. |
-| Symbol type | Outline category, such as `class`, `function`, or `struct`. Values are compatible with LSP `SymbolKind` names. |
-| AST kind | The underlying tree-sitter node kind, such as `class_declaration` or `function_item`. |
+| Role | Entry placement: `item` or `member`. |
+| Item | Top-level entry for file/module structure, including declarations, imports, and explicit exports. |
+| Member | Direct child entry under an item, such as a field, method, constructor, variant, or namespace/module child. |
+| SymbolType | Outline category, such as `class`, `function`, or `struct`. Values are compatible with LSP `SymbolKind` names. |
 | Name | The visible item or member name in the current file, such as a local binding name or exported name. |
 | Alias | The renamed-from symbol when source syntax exposes a different visible name; absent when it would duplicate `name` or `target`. |
-| Member | A direct structural child of a top-level item, such as a field, method, constructor, enum variant, or direct namespace/module declaration. |
 | Range | Full AST node range for the entry. |
-| Member digest | Grouped member names rendered on one compact line, such as `method: parse, recover`. |
+| AST kind | The underlying tree-sitter node kind, such as `class_declaration` or `function_item`. |
 
 ## Public CLI Contract
 
@@ -84,8 +108,9 @@ any directory input present   --items auto --view auto  =>  --items exports --vi
 ```
 
 A file outline is for inspecting one file's internal structure, so it shows local
-top-level structure excluding imports, with compact direct member names. A directory outline is
-for scanning project structure, so it shows only exported surface items by default.
+top-level structure excluding imports, with compact direct member names. A directory
+outline is for scanning project structure, so it shows only exported surface items by
+default.
 If files and directories are mixed in one invocation, `auto` resolves command-wide to the
 directory default. Per-path defaults would make the same file render differently
 depending on how it was reached.
@@ -127,13 +152,6 @@ The current design intentionally does not include `--limit`. See
 ## CLI Semantics
 
 ### Item Selection
-
-An item is the top-level placement role. Items can carry flags:
-
-```text
-isImport      Dependency/import edge.
-isExported    Public/exported surface item.
-```
 
 `--items` selects top-level items before type/name filtering. It does not filter by
 symbol type; constants, variables, types, and functions are included whenever the
@@ -206,10 +224,6 @@ sg outline src/parser.ts --match Parser --type class --view expanded
 ```
 
 ### View Presentation
-
-`outline` is a file-level structure command, not a generic AST-depth command. It exposes
-top-level declarations and their direct structural members. It does not recursively dump
-arbitrary nested blocks.
 
 `--view` controls the text projection:
 

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -210,247 +210,43 @@ stable.
 Future versions can improve signature extraction without changing the basic
 outline entry model. See [Future: Rich Signatures](#future-rich-signatures).
 
-## Extraction Model
+## Output Model Summary
 
-`sg outline` should produce one file-level structure model made of outline entries.
-The model has one placement role and two top-level flags:
-
-```text
-role          Placement in the outline: `item` or `member`.
-isImport      True when a top-level item is a dependency edge.
-isExported    True when a top-level item belongs to the file/module surface.
-```
-
-Outline does not use separate `definition`, `import`, and `export` roles. Imports
-and exports are flags on top-level items because one source construct can be both an
-import edge and an exported surface item. Most outline questions are projections over
-top-level items:
+The command contract, CLI filters, JSON shape, and text views are defined in
+[outline-command.md](outline-command.md). The extraction layer only needs to produce
+that model before CLI filtering and rendering:
 
 ```text
---items exports       top-level items where isExported is true.
---items structure     top-level items where isImport is false.
---items imports       top-level items where isImport is true.
---items all           every top-level item, including imports and re-exports.
---view expanded       selected top-level items plus direct member entries.
+role        item or member.
+name        visible item/member name.
+symbolType  LSP-compatible outline category.
+range       full source range of the matched syntax.
+signature   first non-empty source line of the matched syntax.
+astKind     tree-sitter node kind of the matched syntax.
 ```
 
-These are output entries, not necessarily three separate rule types. The rule
-catalog should describe how to find candidate syntax. The extraction runtime
-should derive common metadata from the matched node where possible.
+Top-level `item` entries can additionally carry `isImport`, `isExported`, `target`,
+and `alias`. Direct `member` entries can additionally carry `isPublic`.
 
-### Top-Level Items
+These fields are output facts, not necessarily separate extractor types. For example,
+`pub use internal_mod as api;` is one top-level item with both `isImport` and
+`isExported`; `pub struct Foo {}` is one top-level item with `isExported`.
 
-A top-level item represents source structure at file/module scope. It can be a
-declaration, an import edge, or explicit export-surface syntax.
+### Source Organization Boundary
 
-Examples:
+The extractor should preserve source organization instead of normalizing code into a
+semantic graph. Relationship-bearing syntax stays in signatures and ordinary entries:
 
-- `struct Foo {}`
-- `pub struct Foo {}`
-- `use crate::parser::Parser;`
-- `pub use internal_mod as api;`
-- `function parseRule() {}`
-- `export function parseRule() {}`
-- `export { foo as bar } from "./foo";`
-- `export * from "./api";`
-- `class Parser {}`
-- `class Parser extends Base implements Visitor {}`
-- `interface MockServer {}`
-- `type Result<T> = ...`
-- `impl Foo for A {}`
+- `class A extends Base implements C {}` is a class entry whose signature keeps the
+  relationship syntax.
+- `impl Foo for A {}` is its own item with direct member entries; its methods are not
+  regrouped onto `A`.
 
-Required fields:
-
-```text
-role          `item`.
-name          Display name.
-symbolType    LSP-compatible outline category.
-isImport      Boolean flag; defaults to false.
-isExported    Boolean flag; defaults to false.
-range         Full AST node range.
-signature     First non-empty source line of the matched item/member node.
-astKind       Tree-sitter node kind of the matched node.
-members       Direct structural members.
-```
-
-Optional fields:
-
-```text
-target        Source module/path/package when syntax provides one.
-alias         Renamed-from symbol when syntax exposes a different visible name.
-detail        Small language-specific detail that belongs beside the signature.
-```
-
-The JSON snippets below omit false boolean fields for readability. The public CLI
-JSON contract fills `isImport` and `isExported` with `false` on top-level items.
-
-Examples:
-
-```rust
-struct Foo {}
-pub struct Bar {}
-use crate::parser::Parser;
-pub use internal_mod as api;
-```
-
-```json
-{ "role": "item", "name": "Foo", "symbolType": "struct" }
-{ "role": "item", "name": "Bar", "symbolType": "struct", "isExported": true }
-{ "role": "item", "name": "Parser", "symbolType": "module", "isImport": true, "target": "crate::parser::Parser" }
-{ "role": "item", "name": "api", "symbolType": "module", "isImport": true, "isExported": true, "target": "internal_mod" }
-```
-
-```ts
-const foo = 1;
-export { foo };
-export { api as publicApi } from "./api";
-```
-
-```json
-{ "role": "item", "name": "foo", "symbolType": "constant" }
-{ "role": "item", "name": "foo", "symbolType": "module", "isExported": true }
-{ "role": "item", "name": "publicApi", "symbolType": "module", "isImport": true, "isExported": true, "target": "./api", "alias": "api" }
-```
-
-Do not extract inheritance or implementation relationships into a separate
-normalized field. Relationship-bearing syntax should be represented faithfully by
-ordinary entries and signatures:
-
-- `class A extends Base implements C {}` is a class entry whose signature keeps
-  `extends Base implements C`.
-- `impl Foo for A {}` is its own implementation entry with its own signature and
-  direct member entries.
-
-This preserves the source code's organization. If a language nests members
-inside a class, struct, enum, namespace, or module, outline should show that
-nested layout. If a language keeps related declarations flat, such as Rust
-`impl` blocks next to type declarations, outline should keep that flat layout
-rather than regrouping it into a semantic type view.
-
-### Member Entries
-
-A member entry is a direct structural child of a top-level item.
-
-Examples:
-
-- struct fields.
-- class fields and properties.
-- methods and constructors.
-- enum variants.
-- interface, trait, protocol, and type members.
-- methods inside Rust `impl` blocks, attached to the `impl` entry rather than
-  regrouped onto the target type.
-- named JavaScript/TypeScript function declarations directly inside a function
-  body, when those locals are used as file-structure helpers.
-
-Members have the same basic shape as declarations, but usually only need:
-
-```text
-role: member
-name
-symbolType
-isPublic      Optional member-only publicness flag.
-range
-signature
-astKind
-```
-
-The initial model should avoid arbitrary recursive nesting. `sg outline` is a
-file-structure command. It should expose top-level declarations and their direct
-members, not every nested block, closure, local variable, or expression.
-
-Import/export flags do not affect member entries. Publicness does not affect
-top-level items. A member can have `isPublic`; a top-level item can have
-`isImport` and/or `isExported`.
-
-## Role, Import/Export Flags, And Member Publicness
-
-`role`, `isImport`, `isExported`, and `isPublic` answer different questions:
-
-```text
-role          Where this entry appears in the outline: `item` or `member`.
-isImport      Whether a top-level item is a dependency edge.
-isExported    Whether a top-level item is part of the public/module surface.
-isPublic      Whether a member is part of its parent's syntactic public surface.
-```
-
-`isPublic` is only emitted for member entries. It is deliberately not a full
-visibility enum:
-
-```text
-true         public/externally usable according to the language rule.
-false        private/not public according to the language rule.
-absent       unknown, unsupported, or not meaningful for this member/language.
-```
-
-Examples:
-
-```rust
-struct Foo {}
-```
-
-Plain top-level item:
-
-```json
-{
-  "role": "item",
-  "name": "Foo",
-  "symbolType": "struct"
-}
-```
-
-```rust
-pub struct Foo {}
-```
-
-Exported top-level item:
-
-```json
-{
-  "role": "item",
-  "name": "Foo",
-  "symbolType": "struct",
-  "isExported": true
-}
-```
-
-```rust
-impl Foo {
-  pub fn new() -> Self {}
-  fn helper(&self) {}
-}
-```
-
-Members need publicness even when the parent is not exported:
-
-```json
-{
-  "role": "item",
-  "name": "Foo",
-  "symbolType": "struct",
-  "members": [
-    {
-      "role": "member",
-      "name": "new",
-      "symbolType": "method",
-      "isPublic": true
-    },
-    {
-      "role": "member",
-      "name": "helper",
-      "symbolType": "method",
-      "isPublic": false
-    }
-  ]
-}
-```
-
-This split keeps the output axes independent:
-
-- `role` controls placement.
-- `isImport` controls dependency-oriented views.
-- `isExported` controls public surface views.
-- `isPublic` controls member display/filtering.
+Members are direct structural children of top-level items: fields, methods,
+constructors, enum variants, trait/interface/type members, module/namespace
+declarations, and the JS/TS function-body helper declarations described in the command
+doc. The initial model should not recursively expose arbitrary nested blocks, closures,
+local variables, or expressions.
 
 ## Extraction Strategy
 

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -64,7 +64,547 @@ The extractor does not need to solve semantic code intelligence:
   `static`, `abstract`, or language-specific modifiers. Use normal ast-grep
   rules for those queries.
 
-## Investigation Summary
+## Output Model Summary
+
+The command contract, CLI filters, JSON shape, and text views are defined in
+[outline-command.md](outline-command.md). The extraction layer only needs to produce
+that model before CLI filtering and rendering:
+
+```text
+role        item or member.
+name        visible item/member name.
+symbolType  LSP-compatible outline category.
+range       full source range of the matched syntax.
+signature   first non-empty source line of the matched syntax.
+astKind     tree-sitter node kind of the matched syntax.
+```
+
+Top-level `item` entries can additionally carry `isImport`, `isExported`, `target`,
+and `alias`. Direct `member` entries can additionally carry `isPublic`.
+
+These fields are output facts, not necessarily separate extractor types. For example,
+`pub use internal_mod as api;` is one top-level item with both `isImport` and
+`isExported`; `pub struct Foo {}` is one top-level item with `isExported`.
+
+### Preserve Syntactic Organization
+
+This section defines what the extractor should treat as parent/child structure.
+`outline` should mirror how code is nested or kept flat in the source file, not
+regroup declarations into a semantic view.
+
+Two rules follow from this.
+
+Flat source layout stays flat. `impl Foo for A {}` is its own item, and Go receiver
+methods stay top-level method/function items unless the syntax nests them.
+
+Members are direct syntactic children of the item that contains them. A class can have
+field, method, and constructor members; a module, namespace, enum, or Rust `impl` can
+have direct child declarations as members.
+
+The initial model should not recursively expose arbitrary nested blocks, closures,
+local variables, expressions, or semantic "related code" that is not organized as a
+direct child in the source.
+
+## Extraction Strategy
+
+Extraction must be data-driven. The command should not have Rust match arms such
+as "if language is Rust, match `function_item`". Built-in support is a bundled
+extractor catalog. User and custom-language support is additional extractor YAML
+loaded by `--outline-rules`.
+
+### Rule File Format
+
+An outline rule file is a stream of YAML documents. Each document is one
+extractor. This keeps built-in and custom rules appendable, copyable, and close
+to ast-grep's existing rule-file style:
+
+```yaml
+id: rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: $VIS struct $NAME { $$$BODY }
+name: $NAME
+isExported:
+  has:
+    regex: '^pub\b'
+---
+id: rust-impl-method
+language: Rust
+role: member
+symbolType: method
+rule:
+  pattern: $VIS fn $NAME($$$PARAMS) { $$$BODY }
+name: $NAME
+isPublic:
+  has:
+    regex: '^pub\b'
+```
+
+`rule`, `constraints`, `utils`, and `transform` are the same ast-grep rule-core
+fields used by existing ast-grep YAML. Outline adds only metadata and output
+field mapping.
+
+### Extractor Schema
+
+Each extractor document has this shape:
+
+```text
+id          Stable extractor id for diagnostics.
+language    Any `SgLang`: built-in language or registered custom language.
+role        Output role: `item` or `member`.
+symbolType  Output symbol type.
+rule        ast-grep rule object that selects the candidate node.
+constraints ast-grep constraints for metavariables.
+utils       ast-grep local utility rules.
+transform   ast-grep transformations and rewriters.
+name        Output name from a metavar/template. Required.
+signature   Optional output signature from a metavar/template.
+target      Optional import/export target from a metavar/template.
+alias       Optional renamed-from symbol from a metavar/template.
+detail      Optional small display detail from a metavar/template.
+isImport    Boolean or predicate for top-level import/dependency items.
+isExported  Boolean or predicate for top-level public/module-surface items.
+isPublic    Boolean or predicate for member publicness.
+```
+
+`role`, `symbolType`, and `name` are required. `signature` is optional; when
+omitted, the extractor uses the first non-empty line of the matched node as the
+signature. `target`, `alias`, `detail`, `isImport`, `isExported`, and
+`isPublic` are omitted unless the extractor can derive them.
+
+### Text Field Extraction
+
+Text field extraction should reuse ast-grep metavariables, transformations, and
+template replacement.
+
+```yaml
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  pattern: function $NAME($$$PARAMS) { $$$BODY }
+name: $NAME
+signature: function $NAME($$$PARAMS)
+```
+
+Transforms can feed text fields:
+
+```yaml
+id: rust-raw-ident-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: struct $RAW_NAME { $$$BODY }
+transform:
+  NAME:
+    replace:
+      source: $RAW_NAME
+      replace: '^r#'
+      by: ''
+name: $NAME
+```
+
+Text field values are interpreted like ast-grep template strings:
+
+```text
+$NAME        captured metavariable text.
+$CLEAN_NAME  transformed metavariable text.
+literal text mixed with $VARS.
+```
+
+The initial supported text fields should stay small: `name`, `signature`,
+`target`, `alias`, and `detail`. Arbitrary custom fields are a non-goal.
+
+### Signature Field
+
+Signatures let an agent understand a declaration without reading the body. They
+should be source-like, not semantically reconstructed.
+
+An extractor can set `signature` with a template:
+
+```yaml
+name: $NAME
+signature: function $NAME($$$PARAMS)
+```
+
+When `signature` is omitted, the extractor uses the simplest useful fallback:
+
+1. Take the matched item/member node's source text.
+2. Use the first non-empty line.
+3. Trim leading and trailing whitespace.
+4. Render that line as the signature.
+
+This fallback is intentionally imperfect for multiline declarations, but it is
+predictable, syntax-only, cheap, and easy to test. Future versions can improve
+signature extraction without changing the basic outline entry model. See
+[Future: Rich Signatures](#future-rich-signatures).
+
+### Boolean Derivation
+
+Boolean derivation fields can be literal booleans or ast-grep rule predicates
+evaluated against the matched candidate node. Normal ast-grep relational rules
+such as `has` and `inside` keep their usual meaning relative to that candidate.
+
+```text
+boolean omitted by extractor       output field is absent
+boolean present and rule matches   output field is true
+boolean present and rule misses    output field is false
+boolean set to true                output field is true
+boolean set to false               output field is false
+```
+
+The rule catalog should prefer one extractor plus boolean derivation over
+duplicated exported/non-exported extractors. For example, `struct Foo {}` and
+`pub struct Foo {}` should use one struct extractor with `isExported`, not two
+mostly identical extractors.
+
+### Examples
+
+Rust struct:
+
+```yaml
+id: rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: $VIS struct $NAME { $$$BODY }
+name: $NAME
+isExported:
+  has:
+    regex: '^pub\b'
+```
+
+This handles both entries without duplicating the selector:
+
+```rust
+struct Foo {}
+pub struct Bar {}
+```
+
+```json
+{ "role": "item", "name": "Foo" }
+{ "role": "item", "name": "Bar", "isExported": true }
+```
+
+Rust import/re-export:
+
+```yaml
+id: rust-use
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: $VIS use $TARGET;
+transform:
+  NAME:
+    replace:
+      source: $TARGET
+      replace: '^.*::'
+      by: ''
+name: $NAME
+target: $TARGET
+isImport: true
+isExported:
+  has:
+    regex: '^pub\b'
+```
+
+This keeps ordinary imports and public imports in one extractor:
+
+```rust
+use crate::parser::Parser;
+pub use internal_mod as api;
+```
+
+```json
+{ "role": "item", "name": "Parser", "isImport": true, "target": "crate::parser::Parser" }
+{ "role": "item", "name": "api", "isImport": true, "isExported": true, "target": "internal_mod" }
+```
+
+Rust member publicness:
+
+```yaml
+id: rust-field
+language: Rust
+role: member
+symbolType: field
+rule:
+  pattern: $VIS $NAME: $TYPE
+name: $NAME
+signature: $VIS $NAME: $TYPE
+isPublic:
+  has:
+    regex: '^pub\b'
+```
+
+TypeScript class/export class:
+
+```yaml
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  any:
+    - pattern: class $NAME { $$$BODY }
+    - pattern: export class $NAME { $$$BODY }
+name: $NAME
+isExported:
+  any:
+    - regex: '^export\b'
+    - inside:
+        kind: export_statement
+```
+
+This keeps one class extractor for both forms:
+
+```ts
+class Foo {}
+export class Bar {}
+```
+
+```json
+{ "role": "item", "name": "Foo" }
+{ "role": "item", "name": "Bar", "isExported": true }
+```
+
+Import and explicit export-list syntax are also top-level items with flags:
+
+```ts
+const foo = 1;
+export { foo };
+export { api as publicApi } from "./api";
+export * from "./all";
+```
+
+The local `const foo` is a normal item. The `export { foo }` item has
+`isExported: true`. The `export { api as publicApi } from "./api"` and
+`export * from "./all"` items have both `isImport: true` and `isExported: true`
+with `target` and `alias` metadata when syntax provides it.
+
+## What To Avoid
+
+### Avoid Export-Specific Duplicated Item Rules
+
+Bad direction:
+
+```yaml
+id: rust-struct
+role: item
+rule:
+  pattern: struct $NAME { $$$BODY }
+name: $NAME
+---
+id: rust-exported-struct
+role: item
+isExported: true
+rule:
+  pattern: pub struct $NAME { $$$BODY }
+name: $NAME
+```
+
+This duplicates the core definition rule and gets worse for every language,
+construct, and export variation.
+
+### Avoid A Large New Mini-Language
+
+The outline rule format should not become a second query language with many
+custom expression types. ast-grep already has rule syntax. Outline-specific
+metadata should stay small and purpose-built.
+
+Prefer a small set of extraction helpers that are hard to express as ast-grep
+rules:
+
+- get the first source line from the matched node as a signature.
+- attach direct member entries by syntax containment.
+- normalize import/export target and alias.
+
+### Avoid IDE-Only Symbols
+
+An IDE outline model with only `kind`, `name`, and selection range is not enough
+for agent use. Agents need signatures, line ranges, import/export flags, and
+members so they can decide whether to read the source body.
+
+### Avoid Semantic Promises In The Extractor
+
+The extraction layer should not claim to answer:
+
+- "Where is this symbol referenced?"
+- "What code is related to this symbol?"
+- "What is the full transitive public API?"
+- "Which implementation will runtime dispatch call?"
+
+Those require reference resolution, type resolution, or cross-file module
+resolution. They can be future layers, but they should not be hidden inside the
+basic file extractor.
+
+### Avoid Normalized Relationship Fields
+
+Do not add first-class fields such as `extends`, `implements`, `baseTypes`,
+`protocols`, or `implementedFor` to the outline entry model.
+
+Intent: make navigation easier by normalizing relationship syntax across
+languages.
+
+Decision: reject this for outline extraction. Relationship syntax is highly
+language-specific, and normalizing it makes the extractor more complicated while
+still being less faithful than the source. It also creates unclear membership
+semantics. For Rust, `struct A {}` and `impl Foo for A {}` are two syntactic
+entries, and the `impl` block can have its own direct members. For TypeScript,
+`class A extends Base implements C {}` is already understandable when preserved
+in the class signature. Keeping the syntactic shape also respects whether the
+source author chose a nested or flat organization.
+
+Agents that need to inspect relationship syntax can search for the relevant
+construct directly with ast-grep rules, or read the signature/body of the
+matched entry. Outline should expose the syntax, not normalize a cross-language
+relationship graph.
+
+### Avoid Custom Metadata Extraction
+
+Do not let outline rules define arbitrary output fields such as `async`,
+`override`, `static`, `abstract`, `decorators`, or language-specific modifier
+sets.
+
+Intent: make outline a general structural metadata extractor.
+
+Decision: reject this for outline extraction. These questions are better served
+by ordinary ast-grep rules because the user can express the exact syntax they
+care about:
+
+```sh
+sg run --pattern 'async $METHOD($$$ARGS) { $$$BODY }' src
+sg run --pattern 'override $METHOD($$$ARGS) { $$$BODY }' src
+```
+
+Outline should stay focused on file structure: items, import/export flags,
+names, ranges, first-line signatures, direct members, member publicness, and
+source organization.
+
+## Proposed Extraction Pipeline
+
+1. Parse the source file with ast-grep's language parser.
+2. Select applicable extractor definitions by language.
+3. Compile and run each extractor's ast-grep `rule` against the parsed AST.
+4. For each match, produce a candidate entry:
+   - source range from matched node.
+   - AST kind from matched node.
+   - symbol type from extractor metadata.
+   - outline placement from `role`.
+   - name from `name`.
+   - signature from `signature`, or the first non-empty line of the matched node.
+   - target/alias from `target` and `alias` when applicable.
+5. Derive boolean values from syntax:
+   - import syntax can set `isImport`.
+   - top-level export syntax or language public-surface syntax can set `isExported`.
+   - member syntax can set `isPublic`.
+6. Deduplicate entries by range, symbol type, name, and edge target.
+7. Merge duplicate top-level items by range, symbol type, name, target, and
+   alias, preserving `isImport` and `isExported`.
+8. Attach direct members by syntax containment and derive member publicness where
+   the language exposes it.
+9. Sort entries in source order.
+10. Pass the file model to CLI filtering and rendering.
+
+## Rule Catalog Implications
+
+Built-in language support should arrive in layers:
+
+1. Item selectors.
+2. Name and first-line signature extraction.
+3. `isImport` and `isExported` derivation for import/export syntax.
+4. Member extraction and member publicness.
+5. Language refinements for aliases and import/export shapes.
+
+This means an early built-in rule can be useful without pretending to be final.
+For example, a Rust struct selector can first prove rendering and entry merging,
+then later add field members and member publicness.
+
+The catalog can keep commented reference rules when they help future language
+refinement, but active rules should follow the current model.
+
+## Language And Custom Language Support
+
+Language expansion is an extractor-catalog problem, not a CLI-code problem.
+
+Built-in extractors should ship for common languages such as Rust, TypeScript,
+TSX, JavaScript, Python, and Go. Adding another built-in language should mean
+adding extractor entries and tests, not changing the extraction algorithm.
+
+Custom languages should work the same way:
+
+1. Register the custom parser in `sgconfig.yml` through ast-grep's existing
+   `customLanguages` support.
+2. Write one or more outline extractor documents with
+   `language: <custom-language-name>`.
+3. Run outline with `--outline-rules <FILE>`.
+
+Conceptual example:
+
+```yaml
+id: mylang-function
+language: mylang
+role: item
+symbolType: function
+rule:
+  pattern: def $NAME($$$ARGS) $$$BODY
+name: $NAME
+signature: def $NAME($$$ARGS)
+```
+
+```sh
+sg outline src --outline-rules mylang-outline.yml
+```
+
+To completely replace bundled behavior:
+
+```sh
+sg outline src \
+  --no-default-outline-rules \
+  --outline-rules project-outline.yml
+```
+
+Unsupported languages should return an empty outline and a successful exit
+status.
+
+## Future: Rich Signatures
+
+The initial extractor should not solve rich signature extraction. It should use
+the first non-empty line of the matched item/member node.
+
+Future versions can make signatures more faithful in two possible ways:
+
+1. Parse signatures into components and assemble them.
+
+   The extractor could capture or derive components such as modifiers, keyword,
+   name, generic parameters, parameters, return type, and receiver. The existing
+   template/metavariable machinery could then assemble those components in
+   `signature` or `detail`. This should stay limited to producing
+   signature/detail text, not arbitrary structured metadata fields.
+
+2. Extract a header range with expand-style boundaries.
+
+   The extractor could use a mechanism similar to `expandStart`/`expandEnd`:
+   start from the matched item/member node, then compute a smaller header range
+   ending before a configured body/value field or captured boundary. ast-grep
+   already has the underlying ingredients:
+
+   - `Node::range()` for byte offsets.
+   - `Node::text()` for matched source text.
+   - `Node::field("name")` and other field lookups for tree-sitter fields.
+   - `NodeMatch` metavariables from the ast-grep rule.
+   - `Root<StrDoc<_>>::get_text()` for slicing the full source.
+
+   This preserves source spelling and handles multiline declarations better than
+   first-line extraction, but it should be designed after the core rule schema is
+   stable.
+
+## Appendix: Prior Art
 
 We reviewed three existing outline-oriented projects to understand their data
 models and extraction tradeoffs.
@@ -188,502 +728,10 @@ Limits for ast-grep:
 - Selection ranges are useful for editor jumps, but not necessary for the CLI
   extraction model.
 
-## Signature Extraction
-
-Signatures are important because they let an agent understand a declaration
-without reading the body. They should be source-like, not semantically
-reconstructed.
-
-For the initial version, signature extraction should use the simplest useful
-approach:
-
-1. Take the matched item/member node's source text.
-2. Use the first non-empty line.
-3. Trim leading and trailing whitespace.
-4. Render that line as the signature.
-
-This is intentionally imperfect for multiline declarations, but it is
-predictable, syntax-only, cheap, and easy to test. It also avoids designing a
-signature-specific mini-language before the rest of the extraction model is
-stable.
-
-Future versions can improve signature extraction without changing the basic
-outline entry model. See [Future: Rich Signatures](#future-rich-signatures).
-
-## Output Model Summary
-
-The command contract, CLI filters, JSON shape, and text views are defined in
-[outline-command.md](outline-command.md). The extraction layer only needs to produce
-that model before CLI filtering and rendering:
-
-```text
-role        item or member.
-name        visible item/member name.
-symbolType  LSP-compatible outline category.
-range       full source range of the matched syntax.
-signature   first non-empty source line of the matched syntax.
-astKind     tree-sitter node kind of the matched syntax.
-```
-
-Top-level `item` entries can additionally carry `isImport`, `isExported`, `target`,
-and `alias`. Direct `member` entries can additionally carry `isPublic`.
-
-These fields are output facts, not necessarily separate extractor types. For example,
-`pub use internal_mod as api;` is one top-level item with both `isImport` and
-`isExported`; `pub struct Foo {}` is one top-level item with `isExported`.
-
-### Source Organization Boundary
-
-The extractor should preserve source organization instead of normalizing code into a
-semantic graph. Relationship-bearing syntax stays in signatures and ordinary entries:
-
-- `class A extends Base implements C {}` is a class entry whose signature keeps the
-  relationship syntax.
-- `impl Foo for A {}` is its own item with direct member entries; its methods are not
-  regrouped onto `A`.
-
-Members are direct structural children of top-level items: fields, methods,
-constructors, enum variants, trait/interface/type members, module/namespace
-declarations, and the JS/TS function-body helper declarations described in the command
-doc. The initial model should not recursively expose arbitrary nested blocks, closures,
-local variables, or expressions.
-
-## Extraction Strategy
-
-Extraction must be data-driven. The command should not have Rust match arms such
-as "if language is Rust, match `function_item`". Built-in support is a bundled
-extractor catalog. User and custom-language support is additional extractor YAML
-loaded by `--outline-rules`.
-
-An extractor starts with an ast-grep rule-core object. The `rule`,
-`constraints`, `utils`, and `transform` fields should be the same rule-core
-fields ast-grep already uses. Outline should not invent a second query language.
-
-### Rule Design Direction
-
-The rule catalog should not encode exported and non-exported forms as separate
-item extractors. For example, these two Rust declarations should not require two
-mostly duplicated item rules:
-
-```rust
-struct Foo {}
-pub struct Foo {}
-```
-
-Instead:
-
-1. One item matcher selects the declaration node.
-2. The extractor derives `name`, `signature`, and `isExported` from the matched
-   node and configured metadata.
-3. The final entry remains one top-level item.
-
-`isImport` is a boolean marker for import/dependency items. `isExported` is a
-boolean predicate for top-level items. `isPublic` is a member-only boolean
-predicate.
-
-Predicate rule objects are evaluated with the extracted item node as the
-candidate. Normal ast-grep relational rules such as `has` and `inside` keep
-their usual meaning relative to that candidate.
-
-Boolean derivation fields follow one rule:
-
-```text
-field omitted by extractor       output field is absent
-field present and rule matches   output field is true
-field present and rule misses    output field is false
-field set to true                output field is true
-field set to false               output field is false
-```
-
-This lets a language opt into member publicness without inventing
-public/private/internal categories. For example, Rust can declare `isPublic` for
-members and mark `pub`, `pub(crate)`, or `pub(super)` members as true. A language
-with no useful member publicness rule can omit `isPublic` entirely.
-
-Rust top-level example:
-
-```yaml
-extractors:
-  - id: rust-struct
-    language: Rust
-    role: item
-    symbolType: struct
-    node:
-      rule:
-        kind: struct_item
-    name:
-      field: name
-    isExported:
-      has:
-        regex: '^pub\b'
-```
-
-This handles both entries without duplicating the selector:
-
-```rust
-struct Foo {}
-pub struct Bar {}
-```
-
-```json
-{ "role": "item", "name": "Foo" }
-{ "role": "item", "name": "Bar", "isExported": true }
-```
-
-Rust import example:
-
-```yaml
-extractors:
-  - id: rust-use
-    language: Rust
-    role: item
-    symbolType: module
-    isImport: true
-    node:
-      rule:
-        kind: use_declaration
-    name:
-      text: normalized
-    target:
-      text: normalized
-    isExported:
-      has:
-        regex: '^pub\b'
-```
-
-This keeps ordinary imports and public imports in one extractor:
-
-```rust
-use crate::parser::Parser;
-pub use internal_mod as api;
-```
-
-```json
-{ "role": "item", "name": "Parser", "isImport": true, "target": "crate::parser::Parser" }
-{ "role": "item", "name": "api", "isImport": true, "isExported": true, "target": "internal_mod" }
-```
-
-Rust member publicness example:
-
-```yaml
-extractors:
-  - id: rust-field
-    language: Rust
-    role: member
-    symbolType: field
-    node:
-      rule:
-        kind: field_declaration
-    name:
-      field: name
-    isPublic:
-      has:
-        regex: '^pub\b'
-```
-
-JavaScript and TypeScript export wrappers should prefer deriving `export` from
-context over matching a separate exported declaration selector:
-
-```yaml
-extractors:
-  - id: ts-class
-    language: TypeScript
-    role: item
-    symbolType: class
-    node:
-      rule:
-        kind: class_declaration
-    name:
-      field: name
-    isExported:
-      inside:
-        kind: export_statement
-```
-
-This keeps one class extractor for both forms:
-
-```ts
-class Foo {}
-export class Bar {}
-```
-
-```json
-{ "role": "item", "name": "Foo" }
-{ "role": "item", "name": "Bar", "isExported": true }
-```
-
-Import and explicit export-list syntax are also top-level items with flags:
-
-```ts
-const foo = 1;
-export { foo };
-export { api as publicApi } from "./api";
-export * from "./all";
-```
-
-The local `const foo` is a normal item. The `export { foo }` item has
-`isExported: true`. The `export { api as publicApi } from "./api"` and
-`export * from "./all"` items have both `isImport: true` and `isExported: true`
-with `target` and `alias` metadata when syntax provides it.
-
-This YAML is illustrative, not a committed schema. The important design decision
-is the separation:
-
-```text
-ast-grep rule      selects candidate syntax.
-metadata extract   derives fields from the selected syntax.
-item flags          set isImport/isExported on top-level items.
-member logic       attaches direct member entries.
-renderer           chooses names/signatures/digest/expanded text.
-```
-
-Extractor metadata should describe outline-specific fields:
-
-```text
-id            Stable extractor id for diagnostics.
-language      Any `SgLang`: built-in language or registered custom language.
-symbolType    Output symbol type.
-node          ast-grep rule object that selects the candidate node.
-name          How to resolve the display name.
-signature     How to derive a source-like declaration signature.
-role          Outline placement: `item` or `member`.
-isImport      Whether a top-level item is an import/dependency edge.
-isExported    Boolean or predicate for public/module surface membership.
-isPublic      Optional member-only boolean predicate.
-target        Optional module/package/path target for import/export edges.
-alias         Optional renamed-from symbol for import/export edges.
-```
-
-The exact YAML schema is intentionally still open. The rule format needs enough
-structure to express the fields above, but it should stay much smaller than a
-general-purpose query language.
-
-## What To Avoid
-
-### Avoid Export-Specific Duplicated Item Rules
-
-Bad direction:
-
-```yaml
-- id: rust-struct
-  role: item
-  node:
-    rule: { kind: struct_item }
-
-- id: rust-exported-struct
-  role: item
-  isExported: true
-  node:
-    rule:
-      all:
-        - kind: struct_item
-        - regex: '^pub\s+struct'
-```
-
-This duplicates the core definition rule and gets worse for every language,
-construct, and export variation.
-
-### Avoid A Large New Mini-Language
-
-The outline rule format should not become a second query language with many
-custom expression types. ast-grep already has rule syntax. Outline-specific
-metadata should stay small and purpose-built.
-
-Prefer a small set of extraction helpers that are hard to express as ast-grep
-rules:
-
-- get tree-sitter field text, such as `field: name`.
-- get the first source line from the matched node as a signature.
-- inspect language-specific modifiers around the matched node.
-- attach direct member entries by syntax containment.
-- normalize import/export target and alias.
-
-### Avoid IDE-Only Symbols
-
-An IDE outline model with only `kind`, `name`, and selection range is not enough
-for agent use. Agents need signatures, line ranges, import/export flags, and
-members so they can decide whether to read the source body.
-
-### Avoid Semantic Promises In The Extractor
-
-The extraction layer should not claim to answer:
-
-- "Where is this symbol referenced?"
-- "What code is related to this symbol?"
-- "What is the full transitive public API?"
-- "Which implementation will runtime dispatch call?"
-
-Those require reference resolution, type resolution, or cross-file module
-resolution. They can be future layers, but they should not be hidden inside the
-basic file extractor.
-
-### Avoid Normalized Relationship Fields
-
-Do not add first-class fields such as `extends`, `implements`, `baseTypes`,
-`protocols`, or `implementedFor` to the outline entry model.
-
-Intent: make navigation easier by normalizing relationship syntax across
-languages.
-
-Decision: reject this for outline extraction. Relationship syntax is highly
-language-specific, and normalizing it makes the extractor more complicated while
-still being less faithful than the source. It also creates unclear membership
-semantics. For Rust, `struct A {}` and `impl Foo for A {}` are two syntactic
-entries, and the `impl` block can have its own direct members. For TypeScript,
-`class A extends Base implements C {}` is already understandable when preserved
-in the class signature. Keeping the syntactic shape also respects whether the
-source author chose a nested or flat organization.
-
-Agents that need to inspect relationship syntax can search for the relevant
-construct directly with ast-grep rules, or read the signature/body of the
-matched entry. Outline should expose the syntax, not normalize a cross-language
-relationship graph.
-
-### Avoid Custom Metadata Extraction
-
-Do not let outline rules define arbitrary output fields such as `async`,
-`override`, `static`, `abstract`, `decorators`, or language-specific modifier
-sets.
-
-Intent: make outline a general structural metadata extractor.
-
-Decision: reject this for outline extraction. These questions are better served
-by ordinary ast-grep rules because the user can express the exact syntax they
-care about:
-
-```sh
-sg run --pattern 'async $METHOD($$$ARGS) { $$$BODY }' src
-sg run --pattern 'override $METHOD($$$ARGS) { $$$BODY }' src
-```
-
-Outline should stay focused on file structure: items, import/export flags,
-names, ranges, first-line signatures, direct members, member publicness, and
-source organization.
-
-## Proposed Extraction Pipeline
-
-1. Parse the source file with ast-grep's language parser.
-2. Select applicable extractor definitions by language.
-3. Compile and run each extractor's `node.rule` ast-grep rule against the parsed AST.
-4. For each match, produce a candidate entry:
-   - source range from matched node.
-   - AST kind from matched node.
-   - symbol type from extractor metadata.
-   - outline placement from `role`.
-   - name from a field, metavariable, or edge normalizer.
-   - signature from the first non-empty line of the matched node.
-   - target/alias from import/export normalizer when applicable.
-5. Derive field-local values from syntax:
-   - import syntax can set `isImport`.
-   - top-level export syntax or language public-surface syntax can set `isExported`.
-   - member syntax can set `isPublic`.
-6. Deduplicate entries by range, symbol type, name, and edge target.
-7. Merge duplicate top-level items by range, symbol type, name, target, and
-   alias, preserving `isImport` and `isExported`.
-8. Attach direct members by syntax containment and derive member publicness where
-   the language exposes it.
-9. Sort entries in source order.
-10. Pass the file model to CLI filtering and rendering.
-
-## Rule Catalog Implications
-
-Built-in language support should arrive in layers:
-
-1. Item selectors.
-2. Name and first-line signature extraction.
-3. `isImport` and `isExported` derivation for import/export syntax.
-4. Member extraction and member publicness.
-5. Language refinements for aliases and import/export shapes.
-
-This means an early built-in rule can be useful without pretending to be final.
-For example, a Rust struct selector can first prove rendering and entry merging,
-then later add field members and member publicness.
-
-The catalog can keep commented reference rules when they help future language
-refinement, but active rules should follow the current model.
-
-## Language And Custom Language Support
-
-Language expansion is an extractor-catalog problem, not a CLI-code problem.
-
-Built-in extractors should ship for common languages such as Rust, TypeScript,
-TSX, JavaScript, Python, and Go. Adding another built-in language should mean
-adding extractor entries and tests, not changing the extraction algorithm.
-
-Custom languages should work the same way:
-
-1. Register the custom parser in `sgconfig.yml` through ast-grep's existing
-   `customLanguages` support.
-2. Write one or more outline extractor entries with
-   `language: <custom-language-name>`.
-3. Run outline with `--outline-rules <FILE>`.
-
-Conceptual example:
-
-```yaml
-extractors:
-  - id: mylang-function
-    language: mylang
-    symbolType: function
-    node:
-      rule:
-        pattern: def $NAME($$$ARGS) $$$BODY
-    name:
-      metavariable: NAME
-    role: item
-```
-
-```sh
-sg outline src --outline-rules mylang-outline.yml
-```
-
-To completely replace bundled behavior:
-
-```sh
-sg outline src \
-  --no-default-outline-rules \
-  --outline-rules project-outline.yml
-```
-
-Unsupported languages should return an empty outline and a successful exit
-status.
-
-## Future: Rich Signatures
-
-The initial extractor should not solve rich signature extraction. It should use
-the first non-empty line of the matched item/member node.
-
-Future versions can make signatures more faithful in two possible ways:
-
-1. Parse signatures into components and assemble them.
-
-   The extractor could capture or derive components such as modifiers, keyword,
-   name, generic parameters, parameters, return type, and receiver. A
-   TemplateFix-like formatter could then assemble those components into a
-   display signature. This should be limited to producing signature/detail text,
-   not arbitrary structured metadata fields.
-
-2. Extract a header range with expand-style boundaries.
-
-   The extractor could use a mechanism similar to `expandStart`/`expandEnd`:
-   start from the matched item/member node, then compute a smaller header range
-   ending before a configured body/value field or captured boundary. ast-grep
-   already has the underlying ingredients:
-
-   - `Node::range()` for byte offsets.
-   - `Node::text()` for matched source text.
-   - `Node::field("name")` and other field lookups for tree-sitter fields.
-   - `NodeMatch` metavariables from the ast-grep rule.
-   - `Root<StrDoc<_>>::get_text()` for slicing the full source.
-
-   This preserves source spelling and handles multiline declarations better than
-   first-line extraction, but it should be designed after the core rule schema is
-   stable.
-
 ## Open Questions
 
-- What is the smallest concrete rule schema that supports field extraction,
-  field-local derivation objects, and members without becoming a DSL?
+- What is the smallest concrete rule schema that supports text field extraction,
+  boolean derivation objects, and members without becoming a DSL?
 - Should import/export edge normalization be configured per language or
   implemented as a small set of built-in normalizers referenced by rules?
 - Which import/export edge normalizers should ship as built-ins for common alias

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -1,0 +1,880 @@
+# Outline Rule Extraction Design
+
+## Purpose
+
+This document designs the extraction layer behind `sg outline`. It is a
+companion to [outline-command.md](outline-command.md), which describes the CLI
+contract and output views.
+
+The extraction layer answers a narrower question:
+
+> Given one parsed source file and a set of ast-grep outline rules, what
+> structural entries should `sg outline` produce before CLI filtering and
+> rendering?
+
+The central design constraint is that outline extraction must be data-driven and
+ast-grep-native. Built-in language support should be a bundled rule catalog, not
+hard-coded Rust match arms. Custom-language support should be possible by loading
+additional outline rules.
+
+## Design Principles
+
+1. Extraction must be rule-based and configurable.
+
+   Outline extraction uses ast-grep rules to select syntax. Built-in languages
+   are supported by bundled rules, and custom languages are supported by loading
+   user-provided outline rules. Adding a language should primarily mean adding
+   rule definitions and tests, not adding language-specific branches to the CLI.
+
+2. Extraction is syntax-only.
+
+   Outline can use the parsed AST, source ranges, tree-sitter fields, source
+   text, and local syntactic context. It must not depend on type resolution,
+   reference resolution, call graphs, data flow, build-system analysis, or
+   cross-file semantic indexing. Features that require those capabilities belong
+   outside the initial outline extractor.
+
+## Current Requirements
+
+The extractor needs to produce enough structure for file-level code
+understanding:
+
+- top-level items: declarations, imports, and explicit export-surface syntax.
+- members: direct structural children of top-level items.
+- import flags: whether a top-level item is a dependency edge.
+- export flags: whether a top-level item belongs to the file/module public
+  surface.
+- member visibility: public/private/protected/internal accessibility for direct
+  members when the language has the concept.
+- signatures: the first non-empty source line of the matched item/member node.
+- names: stable display names for declarations and import/export edges.
+- ranges: full AST node ranges so an agent can open the exact source slice.
+
+The extractor does not need to solve semantic code intelligence:
+
+- no type resolution.
+- no reference resolution.
+- no call graph.
+- no normalized inheritance, extension, implementation, or protocol relationship
+  model.
+- no import path resolution beyond syntax.
+- no transitive public-surface resolver in the initial extraction layer.
+- no generic "related code" search.
+- no custom metadata extraction for ad hoc facts such as `async`, `override`,
+  `static`, `abstract`, or language-specific modifiers. Use normal ast-grep
+  rules for those queries.
+
+## Investigation Summary
+
+We reviewed three existing outline-oriented projects to understand their data
+models and extraction tradeoffs.
+
+### ast-bro
+
+Repository: <https://github.com/aeroxy/ast-bro>
+
+Relevant files reviewed:
+
+- `src/core.rs`
+- `src/adapters/rust.rs`
+- `src/adapters/typescript.rs`
+- `src/surface/rust.rs`
+- `src/surface/typescript.rs`
+- `src/surface/render.rs`
+
+Model:
+
+- A declaration tree contains `kind`, `name`, `signature`, `bases`, `attrs`,
+  docs, visibility, line/byte ranges, native AST kind, modifiers, children, and
+  calls.
+- Imports are separate `ImportBinding` objects with local binding, module, and
+  line.
+- Public API is handled by a separate surface resolver, not by the basic file
+  outline.
+- Signatures are stored as textual declaration strings derived from syntax, so
+  output preserves language spelling such as `pub fn`, `impl Trait for Type`,
+  generic parameters, return types, and base lists.
+
+What worked well:
+
+- Source-like signatures are much more useful to agents than only symbol names.
+- Visibility is stored as metadata, not represented as a separate declaration.
+- Rust `impl` methods are regrouped onto the implemented type in ast-bro. That
+  is useful for a semantic surface view, but ast-grep outline should keep the
+  syntactic `impl` entry instead.
+- Public-surface resolution is a separate layer that can follow re-exports and
+  glob exports.
+
+Limits for ast-grep:
+
+- The adapter logic is imperative Rust code per language. That does not satisfy
+  ast-grep's requirement that extraction logic be expressible as ast-grep rules.
+- The normalized `bases`/relationship model is useful in ast-bro, but ast-grep
+  should not adopt it in outline extraction.
+- The surface resolver is valuable, but it is a later feature because it needs
+  cross-file resolution.
+
+### ast-outline
+
+Repository: <https://github.com/ast-outline/ast-outline>
+
+Relevant files reviewed:
+
+- `src/ast_outline/core.py`
+- `src/ast_outline/adapters/rust.py`
+- `src/ast_outline/adapters/typescript.py`
+
+Model:
+
+- A declaration has `kind`, `name`, `signature`, `bases`, attrs, docs,
+  visibility, ranges, and children.
+- A parse result carries declarations, imports, conditional import counts, noise
+  regions, and import regions.
+- Text rendering has separate outline and digest views. Imports are optional and
+  separate from declarations.
+- Signatures are source slices up to the body/header boundary, then normalized
+  for concise output. This keeps type annotations, decorators/attrs where
+  selected, return types, inheritance, and language-native declaration keywords.
+
+What worked well:
+
+- Signatures are source-like, not reconstructed semantic models.
+- Digest output is a rendering choice, not a different extraction model.
+- Visibility is language-specific:
+  - Rust `pub` and `pub(...)`.
+  - TypeScript accessibility modifiers, `#private`, and naming conventions.
+  - Go exported-name casing.
+  - Python leading underscore convention.
+- Imports are first-class enough to render, but they do not dominate the default
+  file outline.
+
+Limits for ast-grep:
+
+- Like ast-bro, extraction is adapter code rather than ast-grep rules.
+- The normalized `bases` field should not become an ast-grep outline concept.
+- Export handling is mostly syntactic and not a full re-export resolver.
+
+### outline-treesitter-provider.nvim
+
+Repository: <https://github.com/epheien/outline-treesitter-provider.nvim>
+
+Relevant files reviewed:
+
+- `lua/outline/providers/treesitter/aerial/init.lua`
+- `lua/outline/providers/treesitter/aerial/extensions.lua`
+- `queries/rust/aerial.scm`
+- `queries/typescript/aerial.scm`
+
+Model:
+
+- The result is an IDE-style symbol tree: kind, name, ranges, selection range,
+  scope, parent, and children.
+- Extraction uses tree-sitter query captures.
+- There is no first-class signature, import/export flag, target, alias, or
+  member visibility model.
+
+What worked well:
+
+- LSP-compatible symbol categories are familiar.
+- Range containment is enough for many editor outline trees.
+- Language-specific display-name postprocessing is useful, such as Rust impl
+  display and Go receiver methods.
+
+Limits for ast-grep:
+
+- Raw tree-sitter queries are not acceptable for ast-grep outline extraction.
+- An IDE symbol tree is too weak for agent code understanding because it omits
+  signatures and import/export facets.
+- Selection ranges are useful for editor jumps, but not necessary for the CLI
+  extraction model.
+
+## Signature Extraction
+
+Signatures are important because they let an agent understand a declaration
+without reading the body. They should be source-like, not semantically
+reconstructed.
+
+For the initial version, signature extraction should use the simplest useful
+approach:
+
+1. Take the matched item/member node's source text.
+2. Use the first non-empty line.
+3. Trim leading and trailing whitespace.
+4. Render that line as the signature.
+
+This is intentionally imperfect for multiline declarations, but it is
+predictable, syntax-only, cheap, and easy to test. It also avoids designing a
+signature-specific mini-language before the rest of the extraction model is
+stable.
+
+Future versions can improve signature extraction without changing the basic
+outline entry model. See [Future: Rich Signatures](#future-rich-signatures).
+
+## Extraction Model
+
+`sg outline` should produce one file-level structure model made of outline entries.
+The model has one placement role and two top-level flags:
+
+```text
+role          Placement in the outline: `item` or `member`.
+isImport      True when a top-level item is a dependency edge.
+isExported    True when a top-level item belongs to the file/module surface.
+```
+
+This removes the older `definition`/`import`/`export` role axis. Most outline
+questions are projections over top-level items:
+
+```text
+Project/list view         top-level items where isExported is true.
+File structure view       top-level items where isImport is false.
+Dependency inspection     top-level items, including isImport items.
+Detailed file view        top-level items plus member entries.
+```
+
+These are output entries, not necessarily three separate rule types. The rule
+catalog should describe how to find candidate syntax. The extraction runtime
+should derive common metadata from the matched node where possible.
+
+### Top-Level Items
+
+A top-level item represents source structure at file/module scope. It can be a
+declaration, an import edge, or explicit export-surface syntax.
+
+Examples:
+
+- `struct Foo {}`
+- `pub struct Foo {}`
+- `use crate::parser::Parser;`
+- `pub use internal_mod as api;`
+- `function parseRule() {}`
+- `export function parseRule() {}`
+- `export { foo as bar } from "./foo";`
+- `export * from "./api";`
+- `class Parser {}`
+- `class Parser extends Base implements Visitor {}`
+- `interface MockServer {}`
+- `type Result<T> = ...`
+- `impl Foo for A {}`
+
+Required fields:
+
+```text
+role          `item`.
+name          Display name.
+symbolType    LSP-compatible outline category.
+range         Full AST node range.
+signature     First non-empty source line of the matched item/member node.
+astKind       Tree-sitter node kind of the matched node.
+members       Direct structural members.
+```
+
+Optional fields:
+
+```text
+isImport      True for dependency/import edge items.
+isExported    True for public/exported surface items.
+target        Source module/path/package when syntax provides one.
+alias         Local or exported alias when syntax provides one.
+detail        Small language-specific detail that belongs beside the signature.
+```
+
+Examples:
+
+```rust
+struct Foo {}
+pub struct Bar {}
+use crate::parser::Parser;
+pub use internal_mod as api;
+```
+
+```json
+{ "role": "item", "name": "Foo", "symbolType": "struct" }
+{ "role": "item", "name": "Bar", "symbolType": "struct", "isExported": true }
+{ "role": "item", "name": "Parser", "symbolType": "module", "isImport": true, "target": "crate::parser::Parser" }
+{ "role": "item", "name": "api", "symbolType": "module", "isImport": true, "isExported": true, "target": "internal_mod" }
+```
+
+```ts
+const foo = 1;
+export { foo };
+export { api as publicApi } from "./api";
+```
+
+```json
+{ "role": "item", "name": "foo", "symbolType": "constant" }
+{ "role": "item", "name": "foo", "symbolType": "module", "isExported": true }
+{ "role": "item", "name": "publicApi", "symbolType": "module", "isImport": true, "isExported": true, "target": "./api", "alias": "api" }
+```
+
+Do not extract inheritance or implementation relationships into a separate
+normalized field. Relationship-bearing syntax should be represented faithfully by
+ordinary entries and signatures:
+
+- `class A extends Base implements C {}` is a class entry whose signature keeps
+  `extends Base implements C`.
+- `impl Foo for A {}` is its own implementation entry with its own signature and
+  direct member entries.
+
+This preserves the source code's organization. If a language nests members
+inside a class, struct, enum, namespace, or module, outline should show that
+nested layout. If a language keeps related declarations flat, such as Rust
+`impl` blocks next to type declarations, outline should keep that flat layout
+rather than regrouping it into a semantic type view.
+
+### Member Entries
+
+A member entry is a direct structural child of a top-level item.
+
+Examples:
+
+- struct fields.
+- class fields and properties.
+- methods and constructors.
+- enum variants.
+- interface, trait, protocol, and type members.
+- methods inside Rust `impl` blocks, attached to the `impl` entry rather than
+  regrouped onto the target type.
+- named JavaScript/TypeScript function declarations directly inside a function
+  body, when those locals are used as file-structure helpers.
+
+Members have the same basic shape as declarations, but usually only need:
+
+```text
+role: member
+name
+symbolType
+visibility    Member-only accessibility marker.
+range
+signature
+astKind
+```
+
+The initial model should avoid arbitrary recursive nesting. `sg outline` is a
+file-structure command. It should expose top-level declarations and their direct
+members, not every nested block, closure, local variable, or expression.
+
+Import/export flags do not affect member entries. Visibility does not affect
+top-level items. A member can have visibility; a top-level item can have
+`isImport` and/or `isExported`.
+
+## Role, Import/Export Flags, And Visibility
+
+`role`, `isImport`, `isExported`, and `visibility` answer different questions:
+
+```text
+role          Where this entry appears in the outline: `item` or `member`.
+isImport      Whether a top-level item is a dependency edge.
+isExported    Whether a top-level item is part of the public/module surface.
+visibility    What accessibility marker a member has.
+```
+
+Visibility is only emitted for member entries:
+
+```text
+public
+protected
+private
+internal
+unknown
+```
+
+Examples:
+
+```rust
+struct Foo {}
+```
+
+Plain top-level item:
+
+```json
+{
+  "role": "item",
+  "name": "Foo",
+  "symbolType": "struct"
+}
+```
+
+```rust
+pub struct Foo {}
+```
+
+Exported top-level item:
+
+```json
+{
+  "role": "item",
+  "name": "Foo",
+  "symbolType": "struct",
+  "isExported": true
+}
+```
+
+```rust
+impl Foo {
+  pub fn new() -> Self {}
+  fn helper(&self) {}
+}
+```
+
+Members need visibility even when the parent is not exported:
+
+```json
+{
+  "role": "item",
+  "name": "Foo",
+  "symbolType": "struct",
+  "members": [
+    {
+      "role": "member",
+      "name": "new",
+      "symbolType": "method",
+      "visibility": "public"
+    },
+    {
+      "role": "member",
+      "name": "helper",
+      "symbolType": "method",
+      "visibility": "private"
+    }
+  ]
+}
+```
+
+This split keeps the output axes independent:
+
+- `role` controls placement.
+- `isImport` controls dependency-oriented views.
+- `isExported` controls public surface views.
+- `visibility` controls member accessibility display.
+
+## Extraction Strategy
+
+Extraction must be data-driven. The command should not have Rust match arms such
+as "if language is Rust, match `function_item`". Built-in support is a bundled
+extractor catalog. User and custom-language support is additional extractor YAML
+loaded by `--outline-rules`.
+
+An extractor starts with an ast-grep rule-core object. The `rule`,
+`constraints`, `utils`, and `transform` fields should be the same rule-core
+fields ast-grep already uses. Outline should not invent a second query language.
+
+### Rule Design Direction
+
+The rule catalog should not encode exported and non-exported forms as separate
+item extractors. For example, these two Rust declarations should not require two
+mostly duplicated item rules:
+
+```rust
+struct Foo {}
+pub struct Foo {}
+```
+
+Instead:
+
+1. One item matcher selects the declaration node.
+2. The extractor derives `name`, `signature`, and `isExported` from the matched
+   node and configured metadata.
+3. The final entry remains one top-level item.
+
+`isImport` is a boolean marker for import/dependency items. `isExported` is a
+boolean predicate for top-level items. Visibility is a member-only enum
+derivation object.
+
+Predicate rule objects are evaluated with the extracted item node as the
+candidate. Normal ast-grep relational rules such as `has` and `inside` keep
+their usual meaning relative to that candidate.
+
+Rust top-level example:
+
+```yaml
+extractors:
+  - id: rust-struct
+    language: Rust
+    role: item
+    symbolType: struct
+    node:
+      rule:
+        kind: struct_item
+    name:
+      field: name
+    isExported:
+      has:
+        regex: '^pub\b'
+```
+
+This handles both entries without duplicating the selector:
+
+```rust
+struct Foo {}
+pub struct Bar {}
+```
+
+```json
+{ "role": "item", "name": "Foo" }
+{ "role": "item", "name": "Bar", "isExported": true }
+```
+
+Rust import example:
+
+```yaml
+extractors:
+  - id: rust-use
+    language: Rust
+    role: item
+    symbolType: module
+    isImport: true
+    node:
+      rule:
+        kind: use_declaration
+    name:
+      text: normalized
+    target:
+      text: normalized
+    isExported:
+      has:
+        regex: '^pub\b'
+```
+
+This keeps ordinary imports and public imports in one extractor:
+
+```rust
+use crate::parser::Parser;
+pub use internal_mod as api;
+```
+
+```json
+{ "role": "item", "name": "Parser", "isImport": true, "target": "crate::parser::Parser" }
+{ "role": "item", "name": "api", "isImport": true, "isExported": true, "target": "internal_mod" }
+```
+
+Rust member visibility example:
+
+```yaml
+extractors:
+  - id: rust-field
+    language: Rust
+    role: member
+    symbolType: field
+    node:
+      rule:
+        kind: field_declaration
+    name:
+      field: name
+    visibility:
+      internal:
+        has:
+          regex: '^pub\(crate\)'
+      public:
+        has:
+          regex: '^pub\b'
+      private: default
+```
+
+JavaScript and TypeScript export wrappers should prefer deriving `export` from
+context over matching a separate exported declaration selector:
+
+```yaml
+extractors:
+  - id: ts-class
+    language: TypeScript
+    role: item
+    symbolType: class
+    node:
+      rule:
+        kind: class_declaration
+    name:
+      field: name
+    isExported:
+      inside:
+        kind: export_statement
+```
+
+This keeps one class extractor for both forms:
+
+```ts
+class Foo {}
+export class Bar {}
+```
+
+```json
+{ "role": "item", "name": "Foo" }
+{ "role": "item", "name": "Bar", "isExported": true }
+```
+
+Import and explicit export-list syntax are also top-level items with flags:
+
+```ts
+const foo = 1;
+export { foo };
+export { api as publicApi } from "./api";
+export * from "./all";
+```
+
+The local `const foo` is a normal item. The `export { foo }` item has
+`isExported: true`. The `export { api as publicApi } from "./api"` and
+`export * from "./all"` items have both `isImport: true` and `isExported: true`
+with `target` and `alias` metadata when syntax provides it.
+
+This YAML is illustrative, not a committed schema. The important design decision
+is the separation:
+
+```text
+ast-grep rule      selects candidate syntax.
+metadata extract   derives fields from the selected syntax.
+item flags          set isImport/isExported on top-level items.
+member logic       attaches direct member entries.
+renderer           chooses names/signatures/digest/expanded text.
+```
+
+Extractor metadata should describe outline-specific fields:
+
+```text
+id            Stable extractor id for diagnostics.
+language      Any `SgLang`: built-in language or registered custom language.
+symbolType    Output symbol type.
+node          ast-grep rule object that selects the candidate node.
+name          How to resolve the display name.
+signature     How to derive a source-like declaration signature.
+role          Outline placement: `item` or `member`.
+isImport      Whether a top-level item is an import/dependency edge.
+isExported    Boolean or predicate for public/module surface membership.
+visibility    Member-only accessibility derivation object.
+target        Optional module/package/path target for import/export edges.
+alias         Optional local or exported alias for import/export edges.
+```
+
+The exact YAML schema is intentionally still open. The rule format needs enough
+structure to express the fields above, but it should stay much smaller than a
+general-purpose query language.
+
+## What To Avoid
+
+### Avoid Export-Specific Duplicated Item Rules
+
+Bad direction:
+
+```yaml
+- id: rust-struct
+  role: item
+  rule: { kind: struct_item }
+
+- id: rust-exported-struct
+  role: item
+  isExported: true
+  rule:
+    all:
+      - kind: struct_item
+      - regex: '^pub\s+struct'
+```
+
+This duplicates the core definition rule and gets worse for every language,
+construct, and export variation.
+
+### Avoid A Large New Mini-Language
+
+The outline rule format should not become a second query language with many
+custom expression types. ast-grep already has rule syntax. Outline-specific
+metadata should stay small and purpose-built.
+
+Prefer a small set of extraction helpers that are hard to express as ast-grep
+rules:
+
+- get tree-sitter field text, such as `field: name`.
+- get the first source line from the matched node as a signature.
+- inspect language-specific modifiers around the matched node.
+- attach direct member entries by syntax containment.
+- normalize import/export target and alias.
+
+### Avoid IDE-Only Symbols
+
+An IDE outline model with only `kind`, `name`, and selection range is not enough
+for agent use. Agents need signatures, line ranges, import/export flags, and
+members so they can decide whether to read the source body.
+
+### Avoid Semantic Promises In The Extractor
+
+The extraction layer should not claim to answer:
+
+- "Where is this symbol referenced?"
+- "What code is related to this symbol?"
+- "What is the full transitive public API?"
+- "Which implementation will runtime dispatch call?"
+
+Those require reference resolution, type resolution, or cross-file module
+resolution. They can be future layers, but they should not be hidden inside the
+basic file extractor.
+
+### Avoid Normalized Relationship Fields
+
+Do not add first-class fields such as `extends`, `implements`, `baseTypes`,
+`protocols`, or `implementedFor` to the outline entry model.
+
+Intent: make navigation easier by normalizing relationship syntax across
+languages.
+
+Decision: reject this for outline extraction. Relationship syntax is highly
+language-specific, and normalizing it makes the extractor more complicated while
+still being less faithful than the source. It also creates unclear membership
+semantics. For Rust, `struct A {}` and `impl Foo for A {}` are two syntactic
+entries, and the `impl` block can have its own direct members. For TypeScript,
+`class A extends Base implements C {}` is already understandable when preserved
+in the class signature. Keeping the syntactic shape also respects whether the
+source author chose a nested or flat organization.
+
+Agents that need to inspect relationship syntax can search for the relevant
+construct directly with ast-grep rules, or read the signature/body of the
+matched entry. Outline should expose the syntax, not normalize a cross-language
+relationship graph.
+
+### Avoid Custom Metadata Extraction
+
+Do not let outline rules define arbitrary output fields such as `async`,
+`override`, `static`, `abstract`, `decorators`, or language-specific modifier
+sets.
+
+Intent: make outline a general structural metadata extractor.
+
+Decision: reject this for outline extraction. These questions are better served
+by ordinary ast-grep rules because the user can express the exact syntax they
+care about:
+
+```sh
+sg run --pattern 'async $METHOD($$$ARGS) { $$$BODY }' src
+sg run --pattern 'override $METHOD($$$ARGS) { $$$BODY }' src
+```
+
+Outline should stay focused on file structure: items, import/export flags,
+names, ranges, first-line signatures, direct members, member visibility, and
+source organization.
+
+## Proposed Extraction Pipeline
+
+1. Parse the source file with ast-grep's language parser.
+2. Select applicable extractor definitions by language.
+3. Compile and run each extractor's ast-grep `rule` against the parsed AST.
+4. For each match, produce a candidate entry:
+   - source range from matched node.
+   - AST kind from matched node.
+   - symbol type from extractor metadata.
+   - outline placement from `role`.
+   - name from a field, metavariable, or edge normalizer.
+   - signature from the first non-empty line of the matched node.
+   - target/alias from import/export normalizer when applicable.
+5. Derive field-local values from syntax:
+   - import syntax can set `isImport`.
+   - export/public syntax can set `isExported`.
+   - member syntax can set `visibility`.
+6. Deduplicate entries by range, symbol type, name, and edge target.
+7. Merge duplicate top-level items by range, symbol type, name, target, and
+   alias, preserving `isImport` and `isExported`.
+8. Attach direct members by syntax containment and derive member visibility where
+   the language exposes it.
+9. Sort entries in source order.
+10. Pass the file model to CLI filtering and rendering.
+
+## Rule Catalog Implications
+
+Built-in language support should arrive in layers:
+
+1. Item selectors.
+2. Name and first-line signature extraction.
+3. `isImport` and `isExported` derivation for import/export syntax.
+4. Member extraction and member visibility.
+5. Language refinements for aliases and import/export shapes.
+
+This means an early built-in rule can be useful without pretending to be final.
+For example, a Rust struct selector can first prove rendering and entry merging,
+then later add field members and member visibility.
+
+The catalog should keep previous experimental built-in rules as comments when
+they are useful references, but active rules should follow the current model.
+
+## Language And Custom Language Support
+
+Language expansion is an extractor-catalog problem, not a CLI-code problem.
+
+Built-in extractors should ship for common languages such as Rust, TypeScript,
+TSX, JavaScript, Python, and Go. Adding another built-in language should mean
+adding extractor entries and tests, not changing the extraction algorithm.
+
+Custom languages should work the same way:
+
+1. Register the custom parser in `sgconfig.yml` through ast-grep's existing
+   `customLanguages` support.
+2. Write one or more outline extractor entries with
+   `language: <custom-language-name>`.
+3. Run outline with `--outline-rules <FILE>`.
+
+Conceptual example:
+
+```yaml
+extractors:
+  - id: mylang-function
+    language: mylang
+    symbolType: function
+    node:
+      rule:
+        pattern: def $NAME($$$ARGS) $$$BODY
+    name:
+      metavariable: NAME
+    role: item
+```
+
+```sh
+sg outline src --outline-rules mylang-outline.yml
+```
+
+To completely replace bundled behavior:
+
+```sh
+sg outline src \
+  --no-default-outline-rules \
+  --outline-rules project-outline.yml
+```
+
+Unsupported languages should return an empty outline and a successful exit
+status.
+
+## Future: Rich Signatures
+
+The initial extractor should not solve rich signature extraction. It should use
+the first non-empty line of the matched item/member node.
+
+Future versions can make signatures more faithful in two possible ways:
+
+1. Parse signatures into components and assemble them.
+
+   The extractor could capture or derive components such as modifiers, keyword,
+   name, generic parameters, parameters, return type, and receiver. A
+   TemplateFix-like formatter could then assemble those components into a
+   display signature. This should be limited to producing signature/detail text,
+   not arbitrary structured metadata fields.
+
+2. Extract a header range with expand-style boundaries.
+
+   The extractor could use a mechanism similar to `expandStart`/`expandEnd`:
+   start from the matched item/member node, then compute a smaller header range
+   ending before a configured body/value field or captured boundary. ast-grep
+   already has the underlying ingredients:
+
+   - `Node::range()` for byte offsets.
+   - `Node::text()` for matched source text.
+   - `Node::field("name")` and other field lookups for tree-sitter fields.
+   - `NodeMatch` metavariables from the ast-grep rule.
+   - `Root<StrDoc<_>>::get_text()` for slicing the full source.
+
+   This preserves source spelling and handles multiline declarations better than
+   first-line extraction, but it should be designed after the core rule schema is
+   stable.
+
+## Open Questions
+
+- What is the smallest concrete rule schema that supports field extraction,
+  field-local derivation objects, and members without becoming a DSL?
+- Should import/export edge normalization be configured per language or
+  implemented as a small set of built-in normalizers referenced by rules?
+- How should aliases be represented consistently across Rust `pub use`,
+  TypeScript `export { foo as bar }`, Python `import x as y`, and Go imports?
+- Should custom-language rules be allowed to declare member visibility and
+  import/export flags, or should custom languages initially support only items,
+  names, and signatures?

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -130,12 +130,13 @@ isExported:
   has:
     regex: '^pub\b'
 ---
-id: rust-impl-method
+id: rust-field
 language: Rust
 role: member
-symbolType: method
+parentRuleIds: [rust-struct]
+symbolType: field
 rule:
-  pattern: $VIS fn $NAME($$$PARAMS) { $$$BODY }
+  pattern: $VIS $NAME: $TYPE
 name: $NAME
 isPublic:
   has:
@@ -154,6 +155,8 @@ Each extractor document has this shape:
 id          Stable extractor id for diagnostics.
 language    Any `SgLang`: built-in language or registered custom language.
 role        Output role: `item` or `member`.
+parentRuleIds
+            For `role: member`, eligible parent item extractor ids.
 symbolType  Output symbol type.
 rule        ast-grep rule object that selects the candidate node.
 constraints ast-grep constraints for metavariables.
@@ -169,10 +172,11 @@ isExported  Boolean or predicate for top-level public/module-surface items.
 isPublic    Boolean or predicate for member publicness.
 ```
 
-`role`, `symbolType`, and `name` are required. `signature` is optional; when
-omitted, the extractor uses the first non-empty line of the matched node as the
-signature. `target`, `alias`, `detail`, `isImport`, `isExported`, and
-`isPublic` are omitted unless the extractor can derive them.
+`role`, `symbolType`, and `name` are required. `parentRuleIds` is required for
+`role: member` and ignored for `role: item`. `signature` is optional; when omitted,
+the extractor uses the first non-empty line of the matched node as the signature.
+`target`, `alias`, `detail`, `isImport`, `isExported`, and `isPublic` are omitted
+unless the extractor can derive them.
 
 ### Text Field Extraction
 
@@ -262,6 +266,37 @@ duplicated exported/non-exported extractors. For example, `struct Foo {}` and
 `pub struct Foo {}` should use one struct extractor with `isExported`, not two
 mostly identical extractors.
 
+### Member Attachment
+
+Member extractors declare where their matches can attach with `parentRuleIds`:
+
+```yaml
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+rule:
+  pattern: $NAME($$$PARAMS) { $$$BODY }
+name: $NAME
+```
+
+`parentRuleIds` references `role: item` extractor IDs, not symbol names, type
+names, or `SymbolType` values. Unknown IDs and non-item IDs are configuration
+errors. It is an eligibility list. Actual attachment is still based on syntax
+containment:
+
+1. Extract all item and member candidates in the file.
+2. For each member candidate, find the nearest containing item candidate whose
+   extractor id is listed in `parentRuleIds`.
+3. Attach the member only when no other extracted item or member candidate lies
+   strictly between that item and the member.
+4. Drop the member if there is no eligible direct parent.
+
+This preserves source organization and keeps flat layouts flat. Do not infer
+membership from names, receiver types, implemented traits, module paths, references, or
+type resolution.
+
 ### Examples
 
 Rust struct:
@@ -332,6 +367,7 @@ Rust member publicness:
 id: rust-field
 language: Rust
 role: member
+parentRuleIds: [rust-struct]
 symbolType: field
 rule:
   pattern: $VIS $NAME: $TYPE
@@ -490,8 +526,9 @@ source organization.
 
 1. Parse the source file with ast-grep's language parser.
 2. Select applicable extractor definitions by language.
-3. Compile and run each extractor's ast-grep `rule` against the parsed AST.
-4. For each match, produce a candidate entry:
+3. Validate extractor references such as `parentRuleIds`.
+4. Compile and run each extractor's ast-grep `rule` against the parsed AST.
+5. For each match, produce a candidate entry:
    - source range from matched node.
    - AST kind from matched node.
    - symbol type from extractor metadata.
@@ -499,17 +536,16 @@ source organization.
    - name from `name`.
    - signature from `signature`, or the first non-empty line of the matched node.
    - target/alias from `target` and `alias` when applicable.
-5. Derive boolean values from syntax:
+6. Derive boolean values from syntax:
    - import syntax can set `isImport`.
    - top-level export syntax or language public-surface syntax can set `isExported`.
    - member syntax can set `isPublic`.
-6. Deduplicate entries by range, symbol type, name, and edge target.
-7. Merge duplicate top-level items by range, symbol type, name, target, and
+7. Deduplicate entries by range, symbol type, name, and edge target.
+8. Merge duplicate top-level items by range, symbol type, name, target, and
    alias, preserving `isImport` and `isExported`.
-8. Attach direct members by syntax containment and derive member publicness where
-   the language exposes it.
-9. Sort entries in source order.
-10. Pass the file model to CLI filtering and rendering.
+9. Attach direct members by syntax containment and `parentRuleIds`.
+10. Sort entries in source order.
+11. Pass the file model to CLI filtering and rendering.
 
 ## Rule Catalog Implications
 

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -44,8 +44,8 @@ understanding:
 - import flags: whether a top-level item is a dependency edge.
 - export flags: whether a top-level item belongs to the file/module public
   surface.
-- member visibility: public/private/protected/internal accessibility for direct
-  members when the language has the concept.
+- member publicness: whether a direct member is syntactically public/externally
+  usable when the language has the concept.
 - signatures: the first non-empty source line of the matched item/member node.
 - names: stable display names for declarations and import/export edges.
 - ranges: full AST node ranges so an agent can open the exact source slice.
@@ -221,14 +221,17 @@ isImport      True when a top-level item is a dependency edge.
 isExported    True when a top-level item belongs to the file/module surface.
 ```
 
-This removes the older `definition`/`import`/`export` role axis. Most outline
-questions are projections over top-level items:
+Outline does not use separate `definition`, `import`, and `export` roles. Imports
+and exports are flags on top-level items because one source construct can be both an
+import edge and an exported surface item. Most outline questions are projections over
+top-level items:
 
 ```text
-Project/list view         top-level items where isExported is true.
-File structure view       top-level items where isImport is false.
-Dependency inspection     top-level items, including isImport items.
-Detailed file view        top-level items plus member entries.
+--items exports       top-level items where isExported is true.
+--items structure     top-level items where isImport is false.
+--items imports       top-level items where isImport is true.
+--items all           every top-level item, including imports and re-exports.
+--view expanded       selected top-level items plus direct member entries.
 ```
 
 These are output entries, not necessarily three separate rule types. The rule
@@ -262,6 +265,8 @@ Required fields:
 role          `item`.
 name          Display name.
 symbolType    LSP-compatible outline category.
+isImport      Boolean flag; defaults to false.
+isExported    Boolean flag; defaults to false.
 range         Full AST node range.
 signature     First non-empty source line of the matched item/member node.
 astKind       Tree-sitter node kind of the matched node.
@@ -271,12 +276,13 @@ members       Direct structural members.
 Optional fields:
 
 ```text
-isImport      True for dependency/import edge items.
-isExported    True for public/exported surface items.
 target        Source module/path/package when syntax provides one.
-alias         Local or exported alias when syntax provides one.
+alias         Renamed-from symbol when syntax exposes a different visible name.
 detail        Small language-specific detail that belongs beside the signature.
 ```
+
+The JSON snippets below omit false boolean fields for readability. The public CLI
+JSON contract fills `isImport` and `isExported` with `false` on top-level items.
 
 Examples:
 
@@ -343,7 +349,7 @@ Members have the same basic shape as declarations, but usually only need:
 role: member
 name
 symbolType
-visibility    Member-only accessibility marker.
+isPublic      Optional member-only publicness flag.
 range
 signature
 astKind
@@ -353,29 +359,28 @@ The initial model should avoid arbitrary recursive nesting. `sg outline` is a
 file-structure command. It should expose top-level declarations and their direct
 members, not every nested block, closure, local variable, or expression.
 
-Import/export flags do not affect member entries. Visibility does not affect
-top-level items. A member can have visibility; a top-level item can have
+Import/export flags do not affect member entries. Publicness does not affect
+top-level items. A member can have `isPublic`; a top-level item can have
 `isImport` and/or `isExported`.
 
-## Role, Import/Export Flags, And Visibility
+## Role, Import/Export Flags, And Member Publicness
 
-`role`, `isImport`, `isExported`, and `visibility` answer different questions:
+`role`, `isImport`, `isExported`, and `isPublic` answer different questions:
 
 ```text
 role          Where this entry appears in the outline: `item` or `member`.
 isImport      Whether a top-level item is a dependency edge.
 isExported    Whether a top-level item is part of the public/module surface.
-visibility    What accessibility marker a member has.
+isPublic      Whether a member is part of its parent's syntactic public surface.
 ```
 
-Visibility is only emitted for member entries:
+`isPublic` is only emitted for member entries. It is deliberately not a full
+visibility enum:
 
 ```text
-public
-protected
-private
-internal
-unknown
+true         public/externally usable according to the language rule.
+false        private/not public according to the language rule.
+absent       unknown, unsupported, or not meaningful for this member/language.
 ```
 
 Examples:
@@ -416,7 +421,7 @@ impl Foo {
 }
 ```
 
-Members need visibility even when the parent is not exported:
+Members need publicness even when the parent is not exported:
 
 ```json
 {
@@ -428,13 +433,13 @@ Members need visibility even when the parent is not exported:
       "role": "member",
       "name": "new",
       "symbolType": "method",
-      "visibility": "public"
+      "isPublic": true
     },
     {
       "role": "member",
       "name": "helper",
       "symbolType": "method",
-      "visibility": "private"
+      "isPublic": false
     }
   ]
 }
@@ -445,7 +450,7 @@ This split keeps the output axes independent:
 - `role` controls placement.
 - `isImport` controls dependency-oriented views.
 - `isExported` controls public surface views.
-- `visibility` controls member accessibility display.
+- `isPublic` controls member display/filtering.
 
 ## Extraction Strategy
 
@@ -477,12 +482,27 @@ Instead:
 3. The final entry remains one top-level item.
 
 `isImport` is a boolean marker for import/dependency items. `isExported` is a
-boolean predicate for top-level items. Visibility is a member-only enum
-derivation object.
+boolean predicate for top-level items. `isPublic` is a member-only boolean
+predicate.
 
 Predicate rule objects are evaluated with the extracted item node as the
 candidate. Normal ast-grep relational rules such as `has` and `inside` keep
 their usual meaning relative to that candidate.
+
+Boolean derivation fields follow one rule:
+
+```text
+field omitted by extractor       output field is absent
+field present and rule matches   output field is true
+field present and rule misses    output field is false
+field set to true                output field is true
+field set to false               output field is false
+```
+
+This lets a language opt into member publicness without inventing
+public/private/internal categories. For example, Rust can declare `isPublic` for
+members and mark `pub`, `pub(crate)`, or `pub(super)` members as true. A language
+with no useful member publicness rule can omit `isPublic` entirely.
 
 Rust top-level example:
 
@@ -547,7 +567,7 @@ pub use internal_mod as api;
 { "role": "item", "name": "api", "isImport": true, "isExported": true, "target": "internal_mod" }
 ```
 
-Rust member visibility example:
+Rust member publicness example:
 
 ```yaml
 extractors:
@@ -560,14 +580,9 @@ extractors:
         kind: field_declaration
     name:
       field: name
-    visibility:
-      internal:
-        has:
-          regex: '^pub\(crate\)'
-      public:
-        has:
-          regex: '^pub\b'
-      private: default
+    isPublic:
+      has:
+        regex: '^pub\b'
 ```
 
 JavaScript and TypeScript export wrappers should prefer deriving `export` from
@@ -638,9 +653,9 @@ signature     How to derive a source-like declaration signature.
 role          Outline placement: `item` or `member`.
 isImport      Whether a top-level item is an import/dependency edge.
 isExported    Boolean or predicate for public/module surface membership.
-visibility    Member-only accessibility derivation object.
+isPublic      Optional member-only boolean predicate.
 target        Optional module/package/path target for import/export edges.
-alias         Optional local or exported alias for import/export edges.
+alias         Optional renamed-from symbol for import/export edges.
 ```
 
 The exact YAML schema is intentionally still open. The rule format needs enough
@@ -656,15 +671,17 @@ Bad direction:
 ```yaml
 - id: rust-struct
   role: item
-  rule: { kind: struct_item }
+  node:
+    rule: { kind: struct_item }
 
 - id: rust-exported-struct
   role: item
   isExported: true
-  rule:
-    all:
-      - kind: struct_item
-      - regex: '^pub\s+struct'
+  node:
+    rule:
+      all:
+        - kind: struct_item
+        - regex: '^pub\s+struct'
 ```
 
 This duplicates the core definition rule and gets worse for every language,
@@ -744,14 +761,14 @@ sg run --pattern 'override $METHOD($$$ARGS) { $$$BODY }' src
 ```
 
 Outline should stay focused on file structure: items, import/export flags,
-names, ranges, first-line signatures, direct members, member visibility, and
+names, ranges, first-line signatures, direct members, member publicness, and
 source organization.
 
 ## Proposed Extraction Pipeline
 
 1. Parse the source file with ast-grep's language parser.
 2. Select applicable extractor definitions by language.
-3. Compile and run each extractor's ast-grep `rule` against the parsed AST.
+3. Compile and run each extractor's `node.rule` ast-grep rule against the parsed AST.
 4. For each match, produce a candidate entry:
    - source range from matched node.
    - AST kind from matched node.
@@ -762,12 +779,12 @@ source organization.
    - target/alias from import/export normalizer when applicable.
 5. Derive field-local values from syntax:
    - import syntax can set `isImport`.
-   - export/public syntax can set `isExported`.
-   - member syntax can set `visibility`.
+   - top-level export syntax or language public-surface syntax can set `isExported`.
+   - member syntax can set `isPublic`.
 6. Deduplicate entries by range, symbol type, name, and edge target.
 7. Merge duplicate top-level items by range, symbol type, name, target, and
    alias, preserving `isImport` and `isExported`.
-8. Attach direct members by syntax containment and derive member visibility where
+8. Attach direct members by syntax containment and derive member publicness where
    the language exposes it.
 9. Sort entries in source order.
 10. Pass the file model to CLI filtering and rendering.
@@ -779,15 +796,15 @@ Built-in language support should arrive in layers:
 1. Item selectors.
 2. Name and first-line signature extraction.
 3. `isImport` and `isExported` derivation for import/export syntax.
-4. Member extraction and member visibility.
+4. Member extraction and member publicness.
 5. Language refinements for aliases and import/export shapes.
 
 This means an early built-in rule can be useful without pretending to be final.
 For example, a Rust struct selector can first prove rendering and entry merging,
-then later add field members and member visibility.
+then later add field members and member publicness.
 
-The catalog should keep previous experimental built-in rules as comments when
-they are useful references, but active rules should follow the current model.
+The catalog can keep commented reference rules when they help future language
+refinement, but active rules should follow the current model.
 
 ## Language And Custom Language Support
 
@@ -873,8 +890,8 @@ Future versions can make signatures more faithful in two possible ways:
   field-local derivation objects, and members without becoming a DSL?
 - Should import/export edge normalization be configured per language or
   implemented as a small set of built-in normalizers referenced by rules?
-- How should aliases be represented consistently across Rust `pub use`,
-  TypeScript `export { foo as bar }`, Python `import x as y`, and Go imports?
-- Should custom-language rules be allowed to declare member visibility and
+- Which import/export edge normalizers should ship as built-ins for common alias
+  syntaxes such as TypeScript `export { foo as bar }` and Python `import x as y`?
+- Should custom-language rules be allowed to declare member publicness and
   import/export flags, or should custom languages initially support only items,
   names, and signatures?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned "sg outline" spec: top-level Item vs Member model, new flags (--items, --pub-members, --type, --match, --view) and input-kind default behavior
  * Added outline extraction design: syntax-driven extraction pipeline, required output fields, non-goals, and rule catalog guidance
  * Clarified text/JSON contracts: newline-delimited streaming, one-based ranges, revised streamed/grouped shapes, simplified examples and reduced open questions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->