### PR TITLE
feat: add outline entry model

### DIFF
--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -1,3 +1,7 @@
+// Extraction and rendering will consume this model in later slices.
+#[allow(dead_code)]
+mod model;
+
 use std::process::ExitCode;
 
 use clap::{Args, ValueEnum};

--- a/crates/cli/src/outline/model.rs
+++ b/crates/cli/src/outline/model.rs
@@ -1,0 +1,256 @@
+use std::borrow::Cow;
+use std::ops::Range;
+
+use serde::{Deserialize, Serialize};
+
+/// Outline symbol category.
+///
+/// The names follow LSP `DocumentSymbol.kind`, but ast-grep stores the symbolic
+/// category directly instead of exposing LSP numeric values.
+/// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_documentSymbol
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum SymbolType {
+  File,
+  Module,
+  Namespace,
+  Package,
+  Class,
+  Method,
+  Property,
+  Field,
+  Constructor,
+  Enum,
+  Interface,
+  Function,
+  Variable,
+  Constant,
+  String,
+  Number,
+  Boolean,
+  Array,
+  Object,
+  Key,
+  Null,
+  EnumMember,
+  Struct,
+  Event,
+  Operator,
+  TypeParameter,
+}
+
+/// Entry placement in the outline tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum EntryRole {
+  /// Top-level structure, such as `struct Foo`, `class Parser`, or `import ...`.
+  Item,
+  /// Direct child structure under an item, such as a field, method, or variant.
+  Member,
+}
+
+/// Zero-based character position in a file.
+///
+/// This mirrors scan JSON's private `Position` shape. Core `Position` is not
+/// serializable, and config's serializable range type is an internal matcher
+/// input shape with optional columns, so outline keeps its output contract local.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SourcePosition {
+  /// Zero-based line number.
+  line: usize,
+  /// Zero-based character column in the line.
+  column: usize,
+}
+
+/// Source range for an outline entry.
+///
+/// This mirrors scan JSON's private `Range` shape. Outline owns the type here
+/// so the model does not depend on scan rendering internals.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SourceRange {
+  /// Inclusive start and exclusive end byte offsets.
+  byte_offset: Range<usize>,
+  start: SourcePosition,
+  end: SourcePosition,
+}
+
+/// Shared structural data for either a top-level item or a direct member.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct OutlineEntry<'a> {
+  pub role: EntryRole,
+  pub symbol_type: SymbolType,
+  pub name: Cow<'a, str>,
+  pub range: SourceRange,
+  pub signature: Cow<'a, str>,
+  pub ast_kind: Cow<'a, str>,
+}
+
+/// One top-level outline item.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OutlineItem<'a> {
+  #[serde(flatten)]
+  pub entry: OutlineEntry<'a>,
+  pub is_import: bool,
+  pub is_exported: bool,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub members: Vec<OutlineMember<'a>>,
+}
+
+/// One direct member under an outline item.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct OutlineMember<'a> {
+  #[serde(flatten)]
+  pub entry: OutlineEntry<'a>,
+  pub is_public: bool,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn text(value: &'static str) -> Cow<'static, str> {
+    Cow::Borrowed(value)
+  }
+
+  fn test_range() -> SourceRange {
+    SourceRange {
+      byte_offset: 0..12,
+      start: SourcePosition { line: 0, column: 0 },
+      end: SourcePosition {
+        line: 0,
+        column: 12,
+      },
+    }
+  }
+
+  fn entry(
+    role: EntryRole,
+    symbol_type: SymbolType,
+    name: &'static str,
+    signature: &'static str,
+    ast_kind: &'static str,
+  ) -> OutlineEntry<'static> {
+    OutlineEntry {
+      role,
+      symbol_type,
+      name: text(name),
+      range: test_range(),
+      signature: text(signature),
+      ast_kind: text(ast_kind),
+    }
+  }
+
+  fn item(
+    symbol_type: SymbolType,
+    name: &'static str,
+    signature: &'static str,
+    ast_kind: &'static str,
+  ) -> OutlineItem<'static> {
+    OutlineItem {
+      entry: entry(EntryRole::Item, symbol_type, name, signature, ast_kind),
+      is_import: false,
+      is_exported: false,
+      members: vec![],
+    }
+  }
+
+  fn member(
+    symbol_type: SymbolType,
+    name: &'static str,
+    signature: &'static str,
+    ast_kind: &'static str,
+  ) -> OutlineMember<'static> {
+    OutlineMember {
+      entry: entry(EntryRole::Member, symbol_type, name, signature, ast_kind),
+      is_public: false,
+    }
+  }
+
+  #[test]
+  fn serializes_and_deserializes_outline_contract() {
+    let mut item = item(
+      SymbolType::Class,
+      "Parser",
+      "export class Parser {",
+      "class_declaration",
+    );
+    item.is_exported = true;
+    item.members = vec![member(
+      SymbolType::Method,
+      "parse",
+      "parse(input: string) {",
+      "method_definition",
+    )];
+
+    let json = serde_json::to_value(&item).expect("outline item should serialize");
+
+    assert_eq!(json["role"], "item");
+    assert_eq!(json["symbolType"], "class");
+    assert_eq!(json["name"], "Parser");
+    assert_eq!(json["isImport"], false);
+    assert_eq!(json["isExported"], true);
+    assert_eq!(json["members"][0]["role"], "member");
+    assert_eq!(json["members"][0]["symbolType"], "method");
+
+    let deserialized: OutlineItem<'static> =
+      serde_json::from_value(json).expect("outline item should deserialize");
+
+    assert_eq!(deserialized, item);
+  }
+
+  #[test]
+  fn deserializes_yaml_outline_contract() {
+    let yaml = r#"
+role: item
+symbolType: class
+name: Parser
+range:
+  byteOffset:
+    start: 0
+    end: 12
+  start:
+    line: 0
+    column: 0
+  end:
+    line: 0
+    column: 12
+signature: "export class Parser {"
+astKind: class_declaration
+isImport: false
+isExported: true
+members:
+  - role: member
+    symbolType: method
+    name: parse
+    range:
+      byteOffset:
+        start: 0
+        end: 12
+      start:
+        line: 0
+        column: 0
+      end:
+        line: 0
+        column: 12
+    signature: "parse(input: string) {"
+    astKind: method_definition
+    isPublic: false
+"#;
+
+    let item: OutlineItem = serde_yaml::from_str(yaml).expect("outline item should deserialize");
+
+    assert_eq!(item.entry.role, EntryRole::Item);
+    assert_eq!(item.entry.symbol_type, SymbolType::Class);
+    assert_eq!(item.entry.name, "Parser");
+    assert!(item.is_exported);
+    assert_eq!(item.members.len(), 1);
+    assert_eq!(item.members[0].entry.role, EntryRole::Member);
+    assert_eq!(item.members[0].entry.symbol_type, SymbolType::Method);
+    assert_eq!(item.members[0].entry.name, "parse");
+  }
+}


### PR DESCRIPTION
## Summary
- add the new outline entry model after removing the legacy placeholders
- model the current design as item/member entries with item import/export flags and member publicness
- add serializable source ranges, signatures, AST kind, optional details, and direct member nesting

## Test
- cargo fmt --check
- cargo test -p ast-grep --lib outline::model
- cargo test -p ast-grep --lib test_cli
- cargo check -p ast-grep
- cargo clippy -p ast-grep --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outline export now provides richer, nested symbol data: role/type, source ranges (start/end positions), signatures, optional details, import/export/alias flags, and member visibility; JSON uses camelCase names and omits empty fields.

* **Chores**
  * Added internal, serializable outline models to support the enhanced outline format.

* **Tests**
  * Unit tests cover serialization, omission of optional fields, import/export marking, and member nesting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->