### PR TITLE
feat: add outline rule schema

### DIFF
--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -1,6 +1,8 @@
 // Extraction and rendering will consume this model in later slices.
 #[allow(dead_code)]
 mod model;
+#[allow(dead_code)]
+mod rule;
 
 use std::process::ExitCode;
 
@@ -91,7 +93,7 @@ pub struct OutlineArg {
   /// Keep only top-level items matching this regex.
   ///
   /// The regex is matched against item names, signatures, first source lines,
-  /// and import/export targets and aliases. It never matches members.
+  /// and import/export item signatures. It never matches members.
   #[clap(long = "match", value_name = "REGEX")]
   match_item: Option<String>,
 

--- a/crates/cli/src/outline/model.rs
+++ b/crates/cli/src/outline/model.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 use std::ops::Range;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Outline symbol category.
 ///
 /// The names follow LSP `DocumentSymbol.kind`, but ast-grep stores the symbolic
 /// category directly instead of exposing LSP numeric values.
 /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_documentSymbol
-#[derive(Debug, Clone, Copy, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) enum SymbolType {
   File,
@@ -40,7 +40,7 @@ pub(super) enum SymbolType {
 }
 
 /// Entry placement in the outline tree.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) enum EntryRole {
   /// Top-level structure, such as `struct Foo`, `class Parser`, or `import ...`.

--- a/crates/cli/src/outline/rule.rs
+++ b/crates/cli/src/outline/rule.rs
@@ -1,0 +1,296 @@
+use ast_grep_config::{SerializableRewriter, SerializableRule, SerializableRuleCore};
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Deserializer, Error as YamlError, with::singleton_map_recursive::deserialize};
+
+use super::model::SymbolType;
+
+/// Serializable outline extractor definition loaded from an outline rule YAML document.
+///
+/// The `role` field selects the concrete rule shape. Item rules create top-level
+/// entries. Member rules create direct child entries that can attach to eligible
+/// item rules through `parentRuleIds`.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "role", rename_all = "camelCase")]
+enum SerializableOutlineRule {
+  /// Top-level structure, like functions, classes, and imports.
+  Item(SerializableItemRule),
+  /// Direct child structure under an item, such as fields, methods, or variants.
+  Member(SerializableMemberRule),
+}
+
+impl SerializableOutlineRule {
+  fn common(&self) -> &SerializableOutlineCommon {
+    match self {
+      Self::Item(rule) => &rule.common,
+      Self::Member(rule) => &rule.common,
+    }
+  }
+}
+
+/// Shared serializable fields for every outline extractor.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializableOutlineCommon {
+  /// Stable extractor id used in diagnostics and member parent references.
+  id: String,
+  /// Language name accepted by ast-grep, including built-in and registered custom languages.
+  language: String,
+  /// LSP-compatible outline category produced by this extractor.
+  symbol_type: SymbolType,
+  /// ast-grep rule-core fields used to select candidate syntax.
+  #[serde(flatten)]
+  matcher: SerializableRuleCore,
+  /// Rewrite rules for `rewrite` transformation
+  rewriters: Option<Vec<SerializableRewriter>>,
+  /// Name template evaluated from metavariables or transformed metavariables.
+  name: String,
+  /// Optional source-like signature template. The extractor falls back to the
+  /// first non-empty matched source line when omitted.
+  signature: Option<String>,
+}
+
+/// Item extractor for top-level file/module structure.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializableItemRule {
+  /// Common outline extractor fields.
+  #[serde(flatten)]
+  common: SerializableOutlineCommon,
+  /// Whether this item is an import/dependency edge.
+  is_import: Option<SerializablePredicate>,
+  /// Whether this item belongs to the file/module public surface.
+  is_exported: Option<SerializablePredicate>,
+}
+
+/// Member extractor for direct child structure under an item.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializableMemberRule {
+  /// Common outline extractor fields.
+  #[serde(flatten)]
+  common: SerializableOutlineCommon,
+  /// Eligible parent item extractor ids.
+  parent_rule_ids: Vec<String>,
+  /// Whether this member is syntactically public.
+  is_public: Option<SerializablePredicate>,
+}
+
+/// Boolean derivation for outline flags.
+///
+/// A literal boolean sets the output flag directly. A rule object is evaluated
+/// against the matched candidate node and sets the output flag from the match result.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SerializablePredicate {
+  /// Literal boolean value.
+  Literal(bool),
+  /// ast-grep predicate evaluated against the extracted candidate node.
+  Rule(Box<SerializableRule>),
+}
+
+/// Parse a stream of YAML outline extractor documents.
+fn parse_outline_rules(src: &str) -> Result<Vec<SerializableOutlineRule>, YamlError> {
+  Deserializer::from_str(src).map(deserialize).collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn parse_rule(src: &str) -> SerializableOutlineRule {
+    ast_grep_config::from_str(src).expect("outline rule should deserialize")
+  }
+
+  #[test]
+  fn deserializes_item_rule() {
+    let rule = parse_rule(
+      r#"
+id: rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: $VIS struct $NAME { $$$BODY }
+name: $NAME
+isExported:
+  has:
+    regex: '^pub\b'
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    assert_eq!(item.common.id, "rust-struct");
+    assert_eq!(item.common.language, "Rust");
+    assert_eq!(item.common.symbol_type, SymbolType::Struct);
+    assert_eq!(item.common.name, "$NAME");
+    assert!(matches!(
+      item.is_exported,
+      Some(SerializablePredicate::Rule(_))
+    ));
+    assert!(item.is_import.is_none());
+  }
+
+  #[test]
+  fn deserializes_member_rule() {
+    let rule = parse_rule(
+      r#"
+id: rust-field
+language: Rust
+role: member
+parentRuleIds: [rust-struct]
+symbolType: field
+rule:
+  pattern: '$VIS $NAME: $TYPE'
+name: $NAME
+signature: '$VIS $NAME: $TYPE'
+isPublic:
+  has:
+    regex: '^pub\b'
+"#,
+    );
+
+    let SerializableOutlineRule::Member(member) = rule else {
+      panic!("expected member rule");
+    };
+    assert_eq!(member.common.id, "rust-field");
+    assert_eq!(member.parent_rule_ids, vec!["rust-struct"]);
+    assert_eq!(member.common.symbol_type, SymbolType::Field);
+    assert_eq!(
+      member.common.signature.as_deref(),
+      Some("$VIS $NAME: $TYPE")
+    );
+    assert!(matches!(
+      member.is_public,
+      Some(SerializablePredicate::Rule(_))
+    ));
+  }
+
+  #[test]
+  fn deserializes_literal_booleans() {
+    let rule = parse_rule(
+      r#"
+id: rust-use
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: use $TARGET;
+name: $TARGET
+isImport: true
+isExported: false
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    assert!(matches!(
+      item.is_import,
+      Some(SerializablePredicate::Literal(true))
+    ));
+    assert!(matches!(
+      item.is_exported,
+      Some(SerializablePredicate::Literal(false))
+    ));
+  }
+
+  #[test]
+  fn deserializes_transform_and_rewriters() {
+    let rule = parse_rule(
+      r#"
+id: rust-use
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: use $TARGET;
+transform:
+  NAME:
+    replace:
+      source: $TARGET
+      replace: '^.*::'
+      by: ''
+rewriters:
+  - id: trim
+    rule:
+      pattern: $A
+    fix: $A
+name: $NAME
+isImport: true
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    assert_eq!(item.common.name, "$NAME");
+    assert!(item.common.matcher.transform.is_some());
+    assert_eq!(item.common.rewriters.as_ref().unwrap()[0].id, "trim");
+  }
+
+  #[test]
+  fn parses_yaml_document_stream() {
+    let rules = parse_outline_rules(
+      r#"
+id: rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: struct $NAME { $$$BODY }
+name: $NAME
+---
+id: rust-field
+language: Rust
+role: member
+parentRuleIds: [rust-struct]
+symbolType: field
+rule:
+  pattern: '$NAME: $TYPE'
+name: $NAME
+"#,
+    )
+    .expect("document stream should deserialize");
+
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].common().id, "rust-struct");
+    assert_eq!(rules[1].common().id, "rust-field");
+  }
+
+  #[test]
+  fn serializes_with_internal_role_tag() {
+    let rule = SerializableOutlineRule::Item(SerializableItemRule {
+      common: SerializableOutlineCommon {
+        id: "ts-function".into(),
+        language: "TypeScript".into(),
+        symbol_type: SymbolType::Function,
+        matcher: SerializableRuleCore {
+          rule: ast_grep_config::from_str(
+            r#"
+pattern: function $NAME() { $$$BODY }
+"#,
+          )
+          .expect("rule should deserialize"),
+          constraints: None,
+          utils: None,
+          transform: None,
+          fix: None,
+        },
+        rewriters: None,
+        name: "$NAME".into(),
+        signature: Some("function $NAME()".into()),
+      },
+      is_import: None,
+      is_exported: Some(SerializablePredicate::Literal(true)),
+    });
+
+    let value = serde_json::to_value(rule).expect("outline rule should serialize");
+
+    assert_eq!(value["role"], "item");
+    assert_eq!(value["id"], "ts-function");
+    assert_eq!(value["symbolType"], "function");
+    assert_eq!(value["isExported"], true);
+  }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -24,7 +24,9 @@ pub use rule::{
   SerializableRule, parse_selector,
 };
 pub use rule_collection::RuleCollection;
-pub use rule_config::{Metadata, RuleConfig, RuleConfigError, SerializableRuleConfig, Severity};
+pub use rule_config::{
+  Metadata, RuleConfig, RuleConfigError, SerializableRewriter, SerializableRuleConfig, Severity,
+};
 pub use rule_core::{RuleCore, RuleCoreError, SerializableRuleCore};
 pub use transform::Transformation;
 

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -590,7 +590,6 @@ pub struct OutlineItem {
   pub is_exported: bool,
   pub range: Range,
   pub signature: Option<String>,
-  pub detail: Option<String>,
   pub ast_kind: String,
   pub members: Vec<OutlineMember>,
 }
@@ -602,7 +601,6 @@ pub struct OutlineMember {
   pub is_public: Option<bool>,
   pub range: Range,
   pub signature: Option<String>,
-  pub detail: Option<String>,
   pub ast_kind: String,
 }
 
@@ -631,7 +629,6 @@ pub struct OutlineFlatSymbol {
   pub is_public: Option<bool>,
   pub range: Range,
   pub signature: Option<String>,
-  pub detail: Option<String>,
   pub ast_kind: String,
   pub container: Option<OutlineContainer>,
 }

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -164,7 +164,6 @@ utils       ast-grep local utility rules.
 transform   ast-grep transformations and rewriters.
 name        Output name from a metavar/template. Required.
 signature   Optional output signature from a metavar/template.
-detail      Optional small display detail from a metavar/template.
 isImport    Boolean or predicate for top-level import/dependency items.
 isExported  Boolean or predicate for top-level public/module-surface items.
 isPublic    Boolean or predicate for member publicness.
@@ -173,8 +172,8 @@ isPublic    Boolean or predicate for member publicness.
 `role`, `symbolType`, and `name` are required. `parentRuleIds` is required for
 `role: member` and ignored for `role: item`. `signature` is optional; when omitted,
 the extractor uses the first non-empty line of the matched node as the signature.
-`detail`, `isImport`, `isExported`, and `isPublic` are omitted unless the extractor
-can derive them.
+`isImport`, `isExported`, and `isPublic` are omitted unless the extractor can derive
+them.
 
 ### Text Field Extraction
 
@@ -218,8 +217,8 @@ $CLEAN_NAME  transformed metavariable text.
 literal text mixed with $VARS.
 ```
 
-The initial supported text fields should stay small: `name`, `signature`, and
-`detail`. Arbitrary custom fields are a non-goal.
+The initial supported text fields should stay small: `name` and `signature`.
+Arbitrary custom fields are a non-goal.
 
 ### Signature Field
 
@@ -614,8 +613,8 @@ Future versions can make signatures more faithful in two possible ways:
    The extractor could capture or derive components such as modifiers, keyword,
    name, generic parameters, parameters, return type, and receiver. The existing
    template/metavariable machinery could then assemble those components in
-   `signature` or `detail`. This should stay limited to producing
-   signature/detail text, not arbitrary structured metadata fields.
+   `signature`. This should stay limited to producing signature text, not
+   arbitrary structured metadata fields.
 
 2. Extract a header range with expand-style boundaries.
 


### PR DESCRIPTION
## Summary
- add serializable outline rule schema for item/member extractors
- support ast-grep rule fields, transforms, rewriters, and boolean derivation predicates
- add YAML/serde tests for internally tagged rule documents and document streams

## Verification
- cargo test -p ast-grep outline
- cargo check -p ast-grep
- cargo clippy -p ast-grep --all-targets -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outline extractor rule models for YAML/JSON configuration support.

* **Documentation**
  * Updated outline data schema: replaced `detail` field with `ast_kind` to provide clearer symbol categorization.
  * Clarified outline rule extraction scope and supported fields.

* **Chores**
  * Enhanced serialization support for outline data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->