### PR TITLE
refactor: move optional fixer to RuleConfig

### DIFF
--- a/crates/cli/src/print/colored_print/test.rs
+++ b/crates/cli/src/print/colored_print/test.rs
@@ -263,7 +263,7 @@ fix: '{rewrite}'"
   .pop()
   .unwrap();
   let matcher = rule.get_matcher(&globals).expect("should parse");
-  let fixer = matcher.fixer.first().expect("should have fixer");
+  let fixer = rule.fixer.first().expect("should have fixer");
   let root = grep.root();
   let matches = root.find_all(&matcher);
   let diffs = matches.map(|n| (Diff::generate(n, &pattern, fixer), &rule));

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -456,7 +456,7 @@ language: TypeScript
   #[test]
   fn test_apply_rewrite() {
     let root = AstGrep::new("let a = () => c++", SupportLang::TypeScript.into());
-    let config = make_rule(
+    let mut config = make_rule(
       r"
 rule:
   all:
@@ -465,8 +465,8 @@ rule:
         - pattern: $A++
 fix: ($B, lifecycle.update(['$A']))",
     );
-    let mut matcher = config.matcher;
-    let fixer = matcher.fixer.remove(0);
+    let matcher = config.matcher;
+    let fixer = config.fixer.remove(0);
     let diffs = make_diffs(&root, matcher, &fixer);
     let ret = apply_rewrite(diffs);
     assert_eq!(ret, "let a = () => (c++, lifecycle.update(['c']))");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -400,7 +400,7 @@ fn match_rule_diff_on_file<T>(
   let diffs = matches
     .into_iter()
     .filter_map(|(rule, m)| {
-      let fixers = &rule.matcher.fixer;
+      let fixers = &rule.fixer;
       let diff = Diff::multiple(m, &rule.matcher, fixers)?;
       Some((diff, rule))
     })
@@ -417,7 +417,7 @@ fn match_rule_on_file<T>(
   processor: &impl PrintProcessor<T>,
 ) -> Result<T> {
   let file = SimpleFile::new(path.to_string_lossy(), file_content);
-  let processed = if let Some(fixer) = &rule.matcher.fixer.first() {
+  let processed = if let Some(fixer) = &rule.fixer.first() {
     let diffs = matches
       .into_iter()
       .map(|m| (Diff::generate(m, &rule.matcher, fixer), rule))

--- a/crates/cli/src/verify/snapshot.rs
+++ b/crates/cli/src/verify/snapshot.rs
@@ -95,7 +95,7 @@ impl TestSnapshot {
       .into_iter()
       .map(LabelSnapshot::from)
       .collect();
-    let Some(fix) = rule_config.matcher.fixer.first() else {
+    let Some(fix) = rule_config.fixer.first() else {
       return Ok(Some(Self {
         fixed: None,
         labels,

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -365,6 +365,7 @@ impl<'r, L: Language> CombinedScan<'r, L> {
       files: None,
       ignores: None,
       rewriters: None,
+      fix: None,
       url: None,
       metadata: None,
       labels: None,

--- a/crates/config/src/rewriter.rs
+++ b/crates/config/src/rewriter.rs
@@ -52,8 +52,6 @@ impl SerializableRewriter {
       upper_vars,
     )
     .map_err(|e| RuleConfigError::Rewriter(e, self.id.clone()))?;
-    // TODO: add undefined var check here
-    // see test_rewriter_fix_rejects_undefined_var
     Ok(Rewriter {
       matcher: rewriter,
       fixer,

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -1,7 +1,7 @@
 use crate::GlobalRules;
 
 use crate::check_var::check_rewriters_in_transform;
-use crate::fixer::Fixer;
+use crate::fixer::{Fixer, SerializableFixer};
 use crate::label::{Label, LabelConfig, get_default_labels, get_labels_from_config};
 pub use crate::rewriter::SerializableRewriter;
 use crate::rule::DeserializeEnv;
@@ -61,13 +61,17 @@ pub enum RuleConfigError {
 pub struct SerializableRuleConfig<L: Language> {
   #[serde(flatten)]
   pub core: SerializableRuleCore,
+  /// A pattern string or a FixConfig object to auto fix the issue.
+  /// It can reference metavariables appeared in rule.
+  /// See details in fix [object reference](https://ast-grep.github.io/reference/yaml/fix.html#fixconfig).
+  pub fix: Option<SerializableFixer>,
+  /// Rewrite rules for `rewrite` transformation
+  pub rewriters: Option<Vec<SerializableRewriter>>,
   /// Unique, descriptive identifier, e.g., no-unused-variable
   #[serde(default)]
   pub id: String,
   /// Specify the language to parse and the file extension to include in matching.
   pub language: L,
-  /// Rewrite rules for `rewrite` transformation
-  pub rewriters: Option<Vec<SerializableRewriter>>,
   /// Main message highlighting why this rule fired. It should be single line and concise,
   /// but specific enough to be understood without additional context.
   #[serde(default)]
@@ -187,6 +191,7 @@ impl<L: Language> DerefMut for SerializableRuleConfig<L> {
 pub struct RuleConfig<L: Language> {
   inner: SerializableRuleConfig<L>,
   pub matcher: RuleCore,
+  pub fixer: Vec<Fixer>,
 }
 
 impl<L: Language> RuleConfig<L> {
@@ -198,7 +203,17 @@ impl<L: Language> RuleConfig<L> {
     if matcher.potential_kinds().is_none() {
       return Err(RuleConfigError::MissingPotentialKinds);
     }
-    Ok(Self { inner, matcher })
+    let fixer = if let Some(fix) = &inner.fix {
+      let env = matcher.get_env(inner.language.clone());
+      Fixer::parse(fix, &env, &inner.transform).map_err(RuleCoreError::Fixer)?
+    } else {
+      vec![]
+    };
+    Ok(Self {
+      inner,
+      matcher,
+      fixer,
+    })
   }
 
   pub fn deserialize<'de>(
@@ -272,6 +287,7 @@ mod test {
       id: "".into(),
       language: TypeScript::Tsx,
       rewriters: None,
+      fix: None,
       message: "".into(),
       note: None,
       severity: Severity::Hint,

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -142,7 +142,7 @@ pub struct RuleCore {
   pub(crate) constraints: HashMap<String, Rule>,
   kinds: Option<BitSet>,
   pub(crate) transform: Option<Transform>,
-  pub fixer: Vec<Fixer>,
+  fixer: Vec<Fixer>,
   // this is required to hold util rule reference
   pub(crate) registration: RuleRegistration,
 }

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -31,7 +31,6 @@ impl RewriteData {
     rule: &RuleConfig<L>,
   ) -> Option<Self> {
     let fixers: Vec<_> = rule
-      .matcher
       .fixer
       .iter()
       .filter_map(|fixer| {


### PR DESCRIPTION
BREAKING CHANGE: this impacts Rust crate consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal fixer configuration access patterns to improve code organization and maintainability.
  * Updated rule configuration structure for better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->