### PR TITLE
fix: preserve unused suppression fixer

### DIFF
--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -210,6 +210,23 @@ fn test_scan_unused_suppression() -> Result<()> {
 }
 
 #[test]
+fn test_scan_update_all_removes_unused_suppression() -> Result<()> {
+  let dir = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/rule.yml", RULE1),
+    ("test.ts", "None(123) // ast-grep-ignore"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan", "--update-all", "--color", "never"])
+    .assert()
+    .success();
+  let updated = std::fs::read_to_string(dir.path().join("test.ts"))?;
+  assert!(!updated.contains("ast-grep-ignore"));
+  Ok(())
+}
+
+#[test]
 fn test_unused_suppression_only_in_scan() -> Result<()> {
   let dir = create_test_files([
     ("sgconfig.yml", CONFIG),

--- a/crates/config/src/combined.rs
+++ b/crates/config/src/combined.rs
@@ -337,13 +337,13 @@ impl<'r, L: Language> CombinedScan<'r, L> {
   }
 
   pub fn unused_config(severity: Severity, lang: L) -> RuleConfig<L> {
-    let mut config = SerializableRuleConfig {
+    let config = SerializableRuleConfig {
       id: UNUSED_SUPPRESSION_ID.into(),
       severity,
       message: "Unused 'ast-grep-ignore' directive.".into(),
+      fix: crate::from_str(r#"''"#).unwrap(),
       ..Self::builtin_config(lang)
     };
-    config.core.fix = crate::from_str(r#"''"#).unwrap();
     RuleConfig::try_from(config, &Default::default()).unwrap()
   }
 


### PR DESCRIPTION
## Summary
- move the built-in unused-suppression fixer onto the top-level rule fix field
- add a regression test for scan --update-all removing unused ast-grep-ignore directives

## Tests
- cargo test -p ast-grep --test scan_test test_scan_update_all_removes_unused_suppression
- cargo test -p ast-grep --test scan_test test_scan_unused_suppression
- cargo test -p ast-grep --test scan_test test_sg_scan_sarif_with_fixes
- cargo test -p ast-grep --test scan_test test_sg_scan_update_all_reports_unfixable_rules
- cargo test -p ast-grep-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating that `scan --update-all` correctly removes unused suppressions from source files.

* **Refactor**
  * Improved internal configuration construction pattern using immutable value assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->