### PR TITLE
fix: check undefined meta var in fix

### DIFF
--- a/crates/config/src/check_var.rs
+++ b/crates/config/src/check_var.rs
@@ -259,23 +259,6 @@ transform:
     assert_eq!(section, "transform");
   }
   #[test]
-  #[ignore = "FIX IT IN NEXT PR"]
-  fn test_undefined_vars_in_fix() {
-    let (name, section) = get_undefined(
-      r"
-rule: {pattern: $A}
-constraints: {A: {pattern: $C}}
-transform:
-  B:
-    replace: {source: $C, replace: a, by: b }
-fix: $D
-",
-    );
-    assert_eq!(name, "D");
-    assert_eq!(section, "fix");
-  }
-
-  #[test]
   fn test_defined_vars_in_utils() {
     let env = DeserializeEnv::new(TypeScript::Tsx);
     let ser_rule: SerializableRuleCore = from_str(

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -1,6 +1,6 @@
 use crate::GlobalRules;
 
-use crate::check_var::check_rewriters_in_transform;
+use crate::check_var::{CheckHint, check_rewriters_in_transform, check_rule_with_hint};
 use crate::fixer::{Fixer, SerializableFixer};
 use crate::label::{Label, LabelConfig, get_default_labels, get_labels_from_config};
 pub use crate::rewriter::SerializableRewriter;
@@ -209,6 +209,14 @@ impl<L: Language> RuleConfig<L> {
     } else {
       vec![]
     };
+    check_rule_with_hint(
+      &matcher.rule,
+      &matcher.registration,
+      &matcher.constraints,
+      &matcher.transform,
+      &fixer,
+      CheckHint::Normal,
+    )?;
     Ok(Self {
       inner,
       matcher,
@@ -617,6 +625,29 @@ test-rule:
     let nm = grep.root().find(&rule.matcher).unwrap();
     let replacement = fixer.generate_replacement(&nm);
     assert_eq!(String::from_utf8_lossy(&replacement), "string!!");
+  }
+
+  #[test]
+  fn test_undefined_vars_in_fix() {
+    let src = r"
+id: test
+language: Tsx
+rule: {pattern: console.log($A)}
+constraints: {A: {pattern: $C}}
+transform:
+  B:
+    replace: {source: $C, replace: a, by: b }
+fix: $D
+    ";
+    let rule: SerializableRuleConfig<TypeScript> = from_str(src).expect("should parse");
+    let ret = RuleConfig::try_from(rule, &Default::default());
+    match ret {
+      Err(RuleConfigError::Core(RuleCoreError::UndefinedMetaVar(name, section))) => {
+        assert_eq!(name, "D");
+        assert_eq!(section, "fix");
+      }
+      _ => panic!("unexpected result"),
+    }
   }
 
   #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced rule configuration validation to detect and properly report undefined metavariables in fix definitions, providing clearer error messages with the specific metavariable name and section identifier.

* **Tests**
  * Updated test suite to verify proper error handling and validation of rule configurations containing undefined metavariables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->