### PR TITLE
refactor: split fixer variable validation

### DIFF
--- a/crates/config/src/check_var.rs
+++ b/crates/config/src/check_var.rs
@@ -13,47 +13,38 @@ type RResult<T> = std::result::Result<T, RuleCoreError>;
 pub enum CheckHint {
   Global,
   Normal,
-  Skip,
 }
 
 /// Different rule sections have different variable scopes/check procedure.
 /// so we need to check rules with different hints.
-pub fn check_rule_with_hint(rule: &RuleCore, fixer: &[Fixer], hint: CheckHint) -> RResult<()> {
+pub fn check_rule_with_hint(rule: &RuleCore, hint: CheckHint) -> RResult<()> {
   match hint {
     CheckHint::Global => {
       // do not check utils defined here because global rules are not yet ready
-      check_vars(rule, fixer)?;
+      check_vars(rule)?;
     }
     CheckHint::Normal => {
       check_utils_defined(rule)?;
-      check_vars(rule, fixer)?;
-    }
-    CheckHint::Skip => {
-      // TODO: remove this hint, only used for rewriter check now
-      // since only get_matcher_with_hint is exposed
+      check_vars(rule)?;
     }
   }
   Ok(())
 }
 
-pub fn check_rewriters(
-  rule: &RuleCore,
-  fixer: &[Fixer],
-  upper_vars: &HashSet<&str>,
-) -> RResult<()> {
-  check_utils_defined(rule)?;
-  check_vars_in_rewriter(rule, fixer, upper_vars)?;
+pub fn check_fix(rule: &RuleCore, fixer: &[Fixer]) -> RResult<()> {
+  // TODO: check_vars are called twice
+  let vars = check_vars(rule)?;
+  check_var_in_fix(vars, fixer)?;
   Ok(())
 }
 
-fn check_vars_in_rewriter(
+pub fn check_rewriter_fix(
   rule: &RuleCore,
   fixer: &[Fixer],
   upper_vars: &HashSet<&str>,
 ) -> RResult<()> {
-  let vars = get_vars_from_rules(rule);
-  let vars = check_var_in_constraints(vars, &rule.constraints)?;
-  let mut vars = check_var_in_transform(vars, &rule.transform)?;
+  // TODO: check_vars are called twice
+  let mut vars = check_vars(rule)?;
   for v in upper_vars {
     vars.insert(v);
   }
@@ -69,12 +60,10 @@ fn check_utils_defined(rule: &RuleCore) -> RResult<()> {
   Ok(())
 }
 
-fn check_vars(rule: &RuleCore, fixer: &[Fixer]) -> RResult<()> {
+fn check_vars(rule: &RuleCore) -> RResult<HashSet<&str>> {
   let vars = get_vars_from_rules(rule);
   let vars = check_var_in_constraints(vars, &rule.constraints)?;
-  let vars = check_var_in_transform(vars, &rule.transform)?;
-  check_var_in_fix(vars, fixer)?;
-  Ok(())
+  check_var_in_transform(vars, &rule.transform)
 }
 
 fn get_vars_from_rules(rule: &RuleCore) -> HashSet<&str> {

--- a/crates/config/src/rewriter.rs
+++ b/crates/config/src/rewriter.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use thiserror::Error;
 
-use crate::check_var::{CheckHint, check_rewriters};
+use crate::check_var::check_rewriter_fix;
 use crate::fixer::{Fixer, FixerError, SerializableFixer};
 use crate::rule::DeserializeEnv;
 use crate::{RuleCore, RuleCoreError, SerializableRuleCore};
@@ -43,7 +43,6 @@ pub struct SerializableRewriter {
   pub core: SerializableRuleCore,
 }
 
-// TODO: change this to Rewriter::try_from
 impl SerializableRewriter {
   pub fn try_parse_rewriter<L: Language>(
     &self,
@@ -56,14 +55,14 @@ impl SerializableRewriter {
     };
     let rewriter = self
       .core
-      .get_matcher_with_hint(env.clone(), CheckHint::Skip)
+      .get_matcher(env.clone())
       .map_err(|e| attach_id(e.into()))?;
     let fixer =
       Fixer::parse(&self.fix, env, &self.core.transform).map_err(|e| attach_id(e.into()))?;
     if fixer.is_empty() {
       return Err(attach_id(RewriterErrorReason::NoFixInRewriter));
     }
-    check_rewriters(&rewriter, &fixer, upper_vars).map_err(|e| attach_id(e.into()))?;
+    check_rewriter_fix(&rewriter, &fixer, upper_vars).map_err(|e| attach_id(e.into()))?;
     Ok(Rewriter {
       matcher: rewriter,
       fixer,

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -1,6 +1,6 @@
 use crate::GlobalRules;
 
-use crate::check_var::{CheckHint, check_rewriters_in_transform, check_rule_with_hint};
+use crate::check_var::{check_fix, check_rewriters_in_transform};
 use crate::fixer::{Fixer, FixerError, SerializableFixer};
 use crate::label::{Label, LabelConfig, get_default_labels, get_labels_from_config};
 use crate::rewriter::RewriterError;
@@ -210,7 +210,7 @@ impl<L: Language> RuleConfig<L> {
     } else {
       vec![]
     };
-    check_rule_with_hint(&matcher, &fixer, CheckHint::Normal)?;
+    check_fix(&matcher, &fixer)?;
     Ok(Self {
       inner,
       matcher,

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -107,7 +107,7 @@ impl SerializableRuleCore {
   ) -> RResult<RuleCore> {
     let env = self.get_deserialize_env(env)?;
     let ret = self.get_matcher_from_env(&env)?;
-    check_rule_with_hint(&ret, &[], hint)?;
+    check_rule_with_hint(&ret, hint)?;
     Ok(ret)
   }
 }


### PR DESCRIPTION
## Summary
- split matcher variable validation from fixer variable validation
- validate RuleConfig fixes and rewriter fixes after parsing fixers
- parse rewriter matchers with normal rule validation and remove the old skip path

## Tests
- cargo check -p ast-grep-config
- cargo test -p ast-grep-config rule_config::test::test_rewriter_fix_rejects_undefined_var
- cargo test -p ast-grep-config rule_config::test::test_rewriter_use_upper_var
- cargo test -p ast-grep-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized configuration validation logic to better separate rule variable validation from fixer validation concerns.
  * Simplified validation flow by restructuring how matchers and fixers are validated during configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->