### PR TITLE
Preserve root multi-metavariable captures

### DIFF
--- a/crates/config/src/transform/rewrite.rs
+++ b/crates/config/src/transform/rewrite.rs
@@ -278,6 +278,18 @@ mod test {
   }
 
   #[test]
+  fn test_rewrite_root_multi_capture() {
+    let rewrite = Rewrite {
+      source: "$$$A".into(),
+      rewriters: str_vec!["re1"],
+      join_by: None,
+    };
+    let reg = make_rewriters(&["{id: re1, rule: {kind: number}, fix: '810'}"]);
+    let ret = apply_transformation(rewrite, "foo(1, 2)", "$$$A", reg);
+    assert_eq!(ret, "foo(810, 810)");
+  }
+
+  #[test]
   fn test_recursive_rewriters() {
     let rewrite = Rewrite {
       source: "$A".into(),

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -86,7 +86,7 @@ fn match_leaf_meta_var<'tree, D: Doc>(
       Some(())
     }
     MV::MultiCapture(name) => {
-      env.to_mut().insert(name, candidate.clone())?;
+      env.to_mut().insert_multi(name, vec![candidate.clone()])?;
       Some(())
     }
   }
@@ -244,6 +244,22 @@ mod test {
     test_match("foo($$$A, b, c)", "foo(a, b, c)");
     test_match("foo($$$A, a, b, c)", "foo(a, b, c)");
     test_non_match("foo($$$A, a, b, c)", "foo(b, c)");
+  }
+
+  #[test]
+  fn test_root_multi_variable_records_multi_match() {
+    let goal = Pattern::new("$$$A", Tsx);
+    let cand = Root::str("foo(1, 2)", Tsx);
+    let cand = cand.root();
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    let ret = match_node_non_recursive(&goal, cand.clone(), &mut env);
+    assert!(ret.is_some());
+
+    let env = env.into_owned();
+    assert!(env.get_match("A").is_none());
+    let matches = env.get_multiple_matches("A");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].text(), cand.text());
   }
 
   #[test]


### PR DESCRIPTION
Root `$$$META` patterns were being stored through the single-metavariable capture path, so the match data did not reflect the multi-match shape of the pattern.

This keeps root multi-metavariable captures in the multi-match path. In-list `$$$` behavior was already using that path and is unchanged.

I checked it with the red repro, the targeted tests, `cargo fmt --all -- --check`, `cargo test -p ast-grep-core`, `cargo test -p ast-grep-config`, the full `cargo test` with 651 passing, and `git diff --check`.

Fixes #2697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for multi-capture rewrite pattern functionality, ensuring correct handling and transformation of multiple captured matches.
  * Added test verification for multi-variable matching behavior to confirm proper environment recording of multiple-match entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->