### PR TITLE
Reject root multi-metavariable patterns

### DIFF
--- a/crates/core/src/matcher/pattern.rs
+++ b/crates/core/src/matcher/pattern.rs
@@ -31,11 +31,20 @@ impl PatternBuilder<'_> {
   {
     let doc = parse(&self.src).map_err(PatternError::Parse)?;
     let root = Root::doc(doc);
-    if let Some(selector) = self.selector {
-      self.contextual(&root, selector)
+    let pattern = if let Some(selector) = self.selector {
+      self.contextual(&root, selector)?
     } else {
-      self.single(&root)
+      self.single(&root)?
+    };
+    // A multi meta variable matches a list of nodes, but a pattern matches a
+    // single node, so `$$$MULTI` as the root of a pattern is invalid input.
+    if let PatternNode::MetaVar {
+      meta_var: MetaVariable::MultiCapture(_) | MetaVariable::Multiple,
+    } = &pattern.node
+    {
+      return Err(PatternError::RootMultiMetaVar(self.src.to_string()));
     }
+    Ok(pattern)
   }
   fn single<D: Doc>(&self, root: &Root<D>) -> Result<Pattern, PatternError> {
     let goal = root.root();
@@ -248,6 +257,10 @@ pub enum PatternError {
   NoContent(String),
   #[error("Multiple AST nodes are detected. Please check the pattern source `{0}`.")]
   MultipleNode(String),
+  #[error(
+    "A multi meta variable is not allowed as the whole pattern. Please check the pattern source `{0}`."
+  )]
+  RootMultiMetaVar(String),
   #[error(transparent)]
   InvalidKind(#[from] KindMatcherError),
   #[error(
@@ -665,6 +678,35 @@ mod test {
     assert!(matches!(pattern, Err(PatternError::NoContent(_))));
     let pattern = Pattern::try_new("12  3344", Tsx);
     assert!(matches!(pattern, Err(PatternError::MultipleNode(_))));
+  }
+
+  #[test]
+  fn test_root_multi_meta_var_is_rejected() {
+    // gh #2697: a standalone multi meta variable is invalid input. A pattern
+    // matches a single node, so it must be rejected when the pattern is
+    // created, not silently stored as a single meta var.
+    for src in ["$$$A", "$$$PARAMS"] {
+      let pattern = Pattern::try_new(src, Tsx);
+      assert!(
+        matches!(pattern, Err(PatternError::RootMultiMetaVar(_))),
+        "expected RootMultiMetaVar for `{src}`, got {pattern:?}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_single_root_meta_var_is_accepted() {
+    // a single $META as the whole pattern is still valid
+    assert!(Pattern::try_new("$A", Tsx).is_ok());
+    assert!(Pattern::try_new("$_", Tsx).is_ok());
+  }
+
+  #[test]
+  fn test_in_list_multi_meta_var_is_unchanged() {
+    // in-list $$$ stays valid: the root node is the call expression, not the
+    // multi meta var, so existing matching behavior is preserved.
+    assert!(Pattern::try_new("foo($$$A, c)", Tsx).is_ok());
+    test_match("foo($$$A, c)", "foo(a, b, c)");
   }
 
   #[test]


### PR DESCRIPTION
Root `$$$META` patterns were still accepted at pattern creation time, even though they hit the same root-pattern problem discussed in #2697.

This rejects both named and bare root multi-metavariable patterns up front. In-list `$$$` behavior is unchanged.

I checked the redesign with formatting, pattern tests, core/config tests, the full cargo test suite, clippy, and `git diff --check`.

Fixes #2697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pattern validation now properly rejects root-level multi meta variables, preventing invalid pattern configurations from being created.

* **Tests**
  * Expanded test coverage for pattern validation to verify root-level multi meta variable rejection while maintaining support for nested multi meta variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->