### PR TITLE
Outline extractor execution

### DIFF
--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -1,4 +1,4 @@
-//! Combined outline extractor indexes.
+//! Combined outline extraction.
 //!
 //! Outline extraction has two matching phases. Top-level item extractors are
 //! matched during a file-wide AST traversal, so they are indexed by node kind in
@@ -6,14 +6,17 @@
 //! extractor has matched; they are grouped by parent item extractor id and then
 //! indexed sparsely by child node kind inside that parent-scoped group.
 //!
-//! This module only builds those indexes. It does not traverse the AST or
-//! perform scoped member extraction.
+//! Extraction uses explicit AST traversals instead of `find_all`. For each node,
+//! the node kind selects the small set of extractors that can possibly match.
+//! When a node becomes an outline item, item traversal skips that node's
+//! descendants and member extraction runs in the matched item's scope.
 
 use ast_grep_config::GlobalRules;
-use ast_grep_core::{Language, Matcher};
+use ast_grep_core::{Doc, Language, Matcher, Node, NodeMatch};
 use std::collections::HashMap;
 
 use crate::extractor::{ItemExtractor, MemberExtractor, OutlineRuleError, SerializableOutlineRule};
+use crate::model::{OutlineItem, OutlineMember};
 
 /// Runtime outline extractors organized for a shared item traversal.
 #[allow(dead_code)]
@@ -94,6 +97,44 @@ impl<L: Language> CombinedExtractors<L> {
       .into_iter()
       .flat_map(|indices| indices.iter().map(|&idx| &self.item_extractors[idx]))
   }
+
+  pub fn extract<'tree, D: Doc>(&self, root: Node<'tree, D>) -> Vec<OutlineItem<'tree>> {
+    let mut items = vec![];
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+      if let Some((extractor, node_match)) = self.match_item(&node) {
+        let members = self.extract_members(extractor, node_match.get_node());
+        items.push(extractor.extract(&node_match, members));
+        continue;
+      }
+      push_children(&mut stack, node);
+    }
+    items
+  }
+
+  fn match_item<'tree, D: Doc>(
+    &self,
+    node: &Node<'tree, D>,
+  ) -> Option<(&ItemExtractor<L>, NodeMatch<'tree, D>)> {
+    self
+      .item_extractors_for_kind(node.kind_id())
+      .find_map(|extractor| {
+        extractor
+          .match_node(node)
+          .map(|matched| (extractor, matched))
+      })
+  }
+
+  fn extract_members<'tree, D: Doc>(
+    &self,
+    item_extractor: &ItemExtractor<L>,
+    item_node: &Node<'tree, D>,
+  ) -> Vec<OutlineMember<'tree>> {
+    let Some(member_extractors) = self.member_extractors_for(&item_extractor.common.rule.id) else {
+      return vec![];
+    };
+    member_extractors.extract(item_node)
+  }
 }
 
 impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
@@ -105,6 +146,32 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
       .into_iter()
       .flat_map(|indices| indices.iter().map(|&idx| &self.extractors[idx]))
   }
+
+  pub fn extract<'tree, D: Doc>(&self, item_node: &Node<'tree, D>) -> Vec<OutlineMember<'tree>> {
+    let mut members = vec![];
+    let mut stack = item_node.children().collect::<Vec<_>>();
+    stack.reverse();
+    while let Some(node) = stack.pop() {
+      if let Some(member) = self.extract_member(&node) {
+        members.push(member);
+        continue;
+      }
+      push_children(&mut stack, node);
+    }
+    members
+  }
+
+  fn extract_member<'tree, D: Doc>(&self, node: &Node<'tree, D>) -> Option<OutlineMember<'tree>> {
+    self
+      .extractors_for_kind(node.kind_id())
+      .find_map(|extractor| extractor.match_node(node).map(|m| extractor.extract(&m)))
+  }
+}
+
+fn push_children<'tree, D: Doc>(stack: &mut Vec<Node<'tree, D>>, node: Node<'tree, D>) {
+  let mut children = node.children().collect::<Vec<_>>();
+  children.reverse();
+  stack.extend(children);
 }
 
 fn item_kind_mapping<L: Language>(item_extractors: &[ItemExtractor<L>]) -> Vec<Vec<usize>> {
@@ -145,6 +212,7 @@ fn member_mapping<L: Language>(
 mod tests {
   use super::*;
   use crate::extractor::parse_outline_rules;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_language::SupportLang;
 
   #[test]
@@ -199,5 +267,88 @@ name: other
     assert_eq!(item_extractors[0].common.rule.id, "ts-function");
     assert_eq!(identifier_members.len(), 1);
     assert_eq!(identifier_members[0].common.rule.id, "ts-member");
+  }
+
+  #[test]
+  fn extracts_items_without_visiting_matched_item_descendants() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  pattern: function $NAME() { $$$BODY }
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let combined = CombinedExtractors::try_from(extractors, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(
+      r#"
+function outer() {
+  function inner() {}
+}
+function after() {}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let names = items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["outer", "after"]);
+  }
+
+  #[test]
+  fn extracts_members_only_from_matched_parent_items() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  pattern: class $NAME { $$$BODY }
+name: $NAME
+signature: class $NAME
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+rule:
+  pattern:
+    context: class A { $NAME() { $$$BODY } }
+    selector: method_definition
+name: $NAME
+signature: $NAME()
+"#,
+    )
+    .expect("extractors should deserialize");
+    let combined = CombinedExtractors::try_from(extractors, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(
+      r#"
+class Box {
+  parse() {
+    function local() {}
+  }
+}
+function standalone() {}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].entry.name, "Box");
+    assert_eq!(items[0].members.len(), 1);
+    assert_eq!(items[0].members[0].entry.name, "parse");
+    assert_eq!(items[0].members[0].entry.signature, "parse()");
   }
 }

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -10,14 +10,19 @@ use ast_grep_config::{
   SerializableRule, SerializableRuleConfig, SerializableRuleCore, Severity,
 };
 use ast_grep_core::{
-  Language,
-  replacer::{TemplateFix, TemplateFixError},
+  Doc, Language, Node, NodeMatch,
+  matcher::{Matcher, MatcherExt},
+  replacer::{Replacer, TemplateFix, TemplateFixError},
+  source::Content,
 };
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Deserializer, Error as YamlError, with::singleton_map_recursive::deserialize};
+use std::borrow::Cow;
 use thiserror::Error;
 
-use crate::model::SymbolType;
+use crate::model::{
+  EntryRole, OutlineEntry, OutlineItem, OutlineMember, SourcePosition, SourceRange, SymbolType,
+};
 
 /// Serializable outline extractor definition loaded from an outline rule YAML document.
 ///
@@ -192,6 +197,20 @@ enum OutlinePredicate {
   Rule(Rule),
 }
 
+impl OutlinePredicate {
+  fn evaluate<D: Doc>(&self, node_match: &NodeMatch<D>) -> bool {
+    match self {
+      Self::Literal(value) => *value,
+      Self::Rule(rule) => {
+        let mut env = Cow::Borrowed(node_match.get_env());
+        rule
+          .match_node_with_env(node_match.get_node().clone(), &mut env)
+          .is_some()
+      }
+    }
+  }
+}
+
 fn compile_predicate<L: Language>(
   predicate: Option<SerializablePredicate>,
   default: bool,
@@ -237,6 +256,23 @@ impl<L: Language> ItemExtractor<L> {
       is_exported,
     })
   }
+
+  pub fn match_node<'tree, D: Doc>(&self, node: &Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+    self.common.rule.matcher.match_node(node.clone())
+  }
+
+  pub fn extract<'tree, D: Doc>(
+    &self,
+    node_match: &NodeMatch<'tree, D>,
+    members: Vec<OutlineMember<'tree>>,
+  ) -> OutlineItem<'tree> {
+    OutlineItem {
+      entry: self.common.extract_entry(EntryRole::Item, node_match),
+      is_import: self.is_import.evaluate(node_match),
+      is_exported: self.is_exported.evaluate(node_match),
+      members,
+    }
+  }
 }
 
 /// Runnable member extractor for direct child structure under an item.
@@ -265,6 +301,72 @@ impl<L: Language> MemberExtractor<L> {
       is_public,
     })
   }
+
+  pub fn match_node<'tree, D: Doc>(&self, node: &Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+    self.common.rule.matcher.match_node(node.clone())
+  }
+
+  pub fn extract<'tree, D: Doc>(&self, node_match: &NodeMatch<'tree, D>) -> OutlineMember<'tree> {
+    OutlineMember {
+      entry: self.common.extract_entry(EntryRole::Member, node_match),
+      is_public: self.is_public.evaluate(node_match),
+    }
+  }
+}
+
+impl<L: Language> ExtractorCommon<L> {
+  fn extract_entry<'tree, D: Doc>(
+    &self,
+    role: EntryRole,
+    node_match: &NodeMatch<'tree, D>,
+  ) -> OutlineEntry<'tree> {
+    let node = node_match.get_node();
+    OutlineEntry {
+      role,
+      symbol_type: self.symbol_type,
+      name: render_template(&self.name, node_match).into(),
+      range: source_range(node),
+      signature: self
+        .signature
+        .as_ref()
+        .map(|template| render_template(template, node_match))
+        .unwrap_or_else(|| default_signature(node))
+        .into(),
+      ast_kind: node.kind().into_owned().into(),
+    }
+  }
+}
+
+fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) -> String {
+  let bytes = template.generate_replacement(node_match);
+  <D::Source as Content>::encode_bytes(&bytes).to_string()
+}
+
+fn default_signature<D: Doc>(node: &Node<D>) -> String {
+  node
+    .text()
+    .lines()
+    .find_map(|line| {
+      let trimmed = line.trim();
+      (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+    .unwrap_or_default()
+}
+
+fn source_range<D: Doc>(node: &Node<D>) -> SourceRange {
+  let start = node.start_pos();
+  let end = node.end_pos();
+  SourceRange {
+    byte_offset: node.range(),
+    start: SourcePosition {
+      line: start.line(),
+      column: start.column(node),
+    },
+    end: SourcePosition {
+      line: end.line(),
+      column: end.column(node),
+    },
+  }
 }
 
 /// Parse a stream of YAML outline extractor documents.
@@ -280,6 +382,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_language::SupportLang;
 
   fn parse_rule(src: &str) -> SerializableOutlineRule<SupportLang> {
@@ -499,6 +602,44 @@ isImport: true
     assert_eq!(item.common.rule.id, "ts-function");
     assert!(matches!(item.is_import, OutlinePredicate::Literal(true)));
     assert!(matches!(item.is_exported, OutlinePredicate::Literal(true)));
+  }
+
+  #[test]
+  fn predicate_rule_reuses_match_metavariables() {
+    let rule = parse_rule(
+      r#"
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  pattern: class $NAME { $$$BODY }
+name: $NAME
+isExported:
+  has:
+    pattern:
+      context: class A { $NAME() { $$$BODY } }
+      selector: method_definition
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    let item = ItemExtractor::try_from(item, &Default::default()).expect("item rule should parse");
+    let root = SupportLang::TypeScript.ast_grep("class Foo { bar() {} }");
+    let class_node = root
+      .root()
+      .children()
+      .find(|node| node.kind() == "class_declaration")
+      .expect("class should exist");
+    let node_match = item
+      .match_node(&class_node)
+      .expect("class should match item rule");
+    let outline = item.extract(&node_match, vec![]);
+
+    assert_eq!(outline.entry.name.as_ref(), "Foo");
+    assert!(!outline.is_exported);
   }
 
   #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code outline extraction to properly skip nested items after a match, preventing duplicate nested structures from appearing in outlines.
  * Improved member extraction to respect scope boundaries, ensuring members are only captured from within their intended parent context.

* **Improvements**
  * Enhanced outline extraction with two-phase traversal for more accurate code structure detection and scoped member identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->