### PR TITLE
Add outline rules for more languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "ast-grep-dynamic",
  "ast-grep-language",
  "ast-grep-lsp",
+ "ast-grep-outline",
  "atty",
  "clap",
  "clap_complete",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,6 +30,7 @@ ast-grep-config.workspace = true
 ast-grep-dynamic.workspace = true
 ast-grep-language.workspace = true
 ast-grep-lsp.workspace = true
+ast-grep-outline.workspace = true
 tree-sitter.workspace = true
 
 ansi_term = "0.12.1"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -367,7 +367,7 @@ mod test_cli {
     error("outline crates/cli/src --items public");
     error("outline crates/cli/src --view full");
     error("outline crates/cli/src --format json");
-    error("outline crates/cli/src --outline-rules rules.yml");
-    error("outline crates/cli/src --no-default-outline-rules");
+    ok("outline crates/cli/src --outline-rules rules.yml");
+    ok("outline crates/cli/src --no-default-outline-rules");
   }
 }

--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -1,10 +1,30 @@
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::thread;
 
+use anyhow::{Context, Result};
+use ast_grep_core::Language;
+use ast_grep_language::LanguageExt;
+use ast_grep_outline::{
+  DEFAULT_OUTLINE_RULES,
+  combined_extractor::CombinedExtractors,
+  extractor::{SerializableOutlineRule, parse_outline_rules},
+  model::{OutlineEntry, OutlineItem, OutlineMember, SymbolType},
+};
 use clap::{Args, ValueEnum};
+use ignore::WalkState;
+use regex::Regex;
+use serde::Serialize;
+use std::borrow::Cow;
+use std::fmt::Display;
+use std::sync::mpsc;
 
 use crate::lang::SgLang;
 use crate::print::{ColorArg, JsonStyle};
-use crate::utils::InputArgs;
+use crate::utils::{InputArgs, read_file};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum OutlineItems {
@@ -106,13 +126,1364 @@ pub struct OutlineArg {
   #[clap(long, default_value = "auto", value_name = "VIEW")]
   view: OutlineView,
 
+  /// Load additional outline extractor definitions.
+  #[clap(long, action = clap::ArgAction::Append, value_name = "FILE")]
+  outline_rules: Vec<PathBuf>,
+
+  /// Do not load bundled outline extractor definitions.
+  #[clap(long)]
+  no_default_outline_rules: bool,
+
   /// Input related options.
   #[clap(flatten)]
   input: InputArgs,
 }
 
 pub fn run_outline(arg: OutlineArg) -> anyhow::Result<ExitCode> {
-  let _ = arg;
-  println!("nothing found");
+  let rules = load_outline_rules(!arg.no_default_outline_rules, &arg.outline_rules)?;
+  let extractors = Arc::new(OutlineExtractors::try_from(rules)?);
+  let options = OutlineTextOptions::try_from(&arg)?;
+  let stdout = io::stdout();
+  let mut emitter = OutlineEmitter::new(io::BufWriter::new(stdout.lock()), arg.json, &options);
+  if arg.input.stdin {
+    emitter.emit(extract_stdin(&arg, &extractors, &options)?)?;
+  } else {
+    stream_paths(&arg, extractors, &options, &mut emitter)?;
+  }
+  emitter.finish()?;
   Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OutlineFile<'a> {
+  path: String,
+  language: String,
+  items: Vec<OutlineItem<'a>>,
+}
+
+// One command-level cache of compiled outline rules. File workers borrow this
+// by language, so YAML deserialization and rule compilation never sit on the
+// per-file read/parse/extract path.
+struct OutlineExtractors {
+  by_lang: HashMap<SgLang, CombinedExtractors<SgLang>>,
+}
+
+impl OutlineExtractors {
+  fn try_from(rules: Vec<SerializableOutlineRule<SgLang>>) -> Result<Self> {
+    let mut rules_by_lang: HashMap<SgLang, Vec<SerializableOutlineRule<SgLang>>> = HashMap::new();
+    for rule in rules {
+      rules_by_lang
+        .entry(rule.common().language)
+        .or_default()
+        .push(rule);
+    }
+    let by_lang = rules_by_lang
+      .into_iter()
+      .map(|(lang, rules)| {
+        CombinedExtractors::try_from(rules, &Default::default())
+          .map(|extractors| (lang, extractors))
+      })
+      .collect::<Result<_, _>>()?;
+    Ok(Self { by_lang })
+  }
+
+  fn is_empty(&self) -> bool {
+    self.by_lang.is_empty()
+  }
+
+  fn languages(&self) -> impl Iterator<Item = SgLang> + '_ {
+    self.by_lang.keys().copied()
+  }
+
+  fn extract<'tree>(
+    &self,
+    lang: SgLang,
+    root: ast_grep_core::Node<'tree, ast_grep_core::tree_sitter::StrDoc<SgLang>>,
+    options: &OutlineTextOptions,
+  ) -> Vec<OutlineItem<'static>> {
+    self
+      .by_lang
+      .get(&lang)
+      .map(|extractors| {
+        extractors
+          .extract(root)
+          .into_iter()
+          .filter_map(|mut item| {
+            if options.pub_members {
+              item.members.retain(|member| member.is_public);
+            }
+            matches_item_filters(&item, options).then(|| own_item(item))
+          })
+          .collect()
+      })
+      .unwrap_or_default()
+  }
+}
+
+fn load_outline_rules(
+  include_default: bool,
+  paths: &[PathBuf],
+) -> Result<Vec<SerializableOutlineRule<SgLang>>> {
+  let mut rules = vec![];
+  if include_default {
+    rules.extend(
+      parse_outline_rules(DEFAULT_OUTLINE_RULES).context("Cannot parse builtin outline rules")?,
+    );
+  }
+  for path in paths {
+    let source = std::fs::read_to_string(path)
+      .with_context(|| format!("Cannot read outline rules {}", path.display()))?;
+    rules.extend(
+      parse_outline_rules(&source)
+        .with_context(|| format!("Cannot parse outline rules {}", path.display()))?,
+    );
+  }
+  Ok(rules)
+}
+
+fn extract_stdin(
+  arg: &OutlineArg,
+  extractors: &OutlineExtractors,
+  options: &OutlineTextOptions,
+) -> Result<OutlineFile<'static>> {
+  let lang = arg.lang.expect("required by clap");
+  let source = io::read_to_string(io::stdin())?;
+  let grep = lang.ast_grep(source);
+  let items = extractors.extract(lang, grep.root(), options);
+  Ok(OutlineFile {
+    path: "STDIN".to_string(),
+    language: lang.to_string(),
+    items,
+  })
+}
+
+fn stream_paths(
+  arg: &OutlineArg,
+  extractors: Arc<OutlineExtractors>,
+  options: &OutlineTextOptions,
+  emitter: &mut OutlineEmitter<impl Write>,
+) -> Result<()> {
+  if arg.lang.is_none() && extractors.is_empty() {
+    return Ok(());
+  }
+  let walker = outline_walk(&arg.input, arg.lang, &extractors)?;
+  let (tx, rx) = mpsc::channel();
+  let lang = arg.lang;
+  let options = Arc::new(options.clone());
+  let producer = thread::spawn(move || {
+    walker.run(|| {
+      let tx = tx.clone();
+      let extractors = extractors.clone();
+      let options = options.clone();
+      Box::new(move |result| {
+        let Some(path) = outline_path(result) else {
+          return WalkState::Continue;
+        };
+        let Some(file) = extract_path_or_report(&path, lang, &extractors, &options) else {
+          return WalkState::Continue;
+        };
+        if tx.send(file).is_err() {
+          return WalkState::Quit;
+        }
+        WalkState::Continue
+      })
+    });
+  });
+
+  let mut result = Ok(());
+  while let Ok(file) = rx.recv() {
+    if let Err(err) = emitter.emit(file) {
+      result = Err(err);
+      break;
+    }
+  }
+  drop(rx);
+  producer
+    .join()
+    .map_err(|_| anyhow::anyhow!("outline walker thread panicked"))?;
+  result
+}
+
+fn outline_walk(
+  input: &InputArgs,
+  lang: Option<SgLang>,
+  extractors: &OutlineExtractors,
+) -> Result<ignore::WalkParallel> {
+  if let Some(lang) = lang {
+    input.walk_lang(lang)
+  } else {
+    input.walk_langs(extractors.languages())
+  }
+}
+
+fn outline_path(result: Result<ignore::DirEntry, ignore::Error>) -> Option<PathBuf> {
+  let entry = match result {
+    Ok(entry) => entry,
+    Err(err) => {
+      eprintln!("ERROR: {err}");
+      return None;
+    }
+  };
+  entry.file_type()?.is_file().then(|| entry.into_path())
+}
+
+fn extract_path_or_report(
+  path: &Path,
+  lang: Option<SgLang>,
+  extractors: &OutlineExtractors,
+  options: &OutlineTextOptions,
+) -> Option<OutlineFile<'static>> {
+  match extract_path(path, lang, extractors, options) {
+    Ok(file) => file,
+    Err(err) => {
+      eprintln!("ERROR: {err:#}");
+      None
+    }
+  }
+}
+
+fn extract_path(
+  path: &Path,
+  lang: Option<SgLang>,
+  extractors: &OutlineExtractors,
+  options: &OutlineTextOptions,
+) -> Result<Option<OutlineFile<'static>>> {
+  let Some(lang) = lang.or_else(|| SgLang::from_path(path)) else {
+    return Ok(None);
+  };
+  let source =
+    read_file(path).with_context(|| format!("Cannot extract outline from {}", path.display()))?;
+  let grep = lang.ast_grep(source);
+  let items = extractors.extract(lang, grep.root(), options);
+  if !options.show_empty_files && items.is_empty() {
+    return Ok(None);
+  }
+  Ok(Some(OutlineFile {
+    path: path.to_string_lossy().into_owned(),
+    language: lang.to_string(),
+    items,
+  }))
+}
+
+fn own_item(item: OutlineItem<'_>) -> OutlineItem<'static> {
+  OutlineItem {
+    entry: own_entry(item.entry),
+    is_import: item.is_import,
+    is_exported: item.is_exported,
+    members: item.members.into_iter().map(own_member).collect(),
+  }
+}
+
+fn own_member(member: OutlineMember<'_>) -> OutlineMember<'static> {
+  OutlineMember {
+    entry: own_entry(member.entry),
+    is_public: member.is_public,
+  }
+}
+
+fn own_entry(entry: OutlineEntry<'_>) -> OutlineEntry<'static> {
+  OutlineEntry {
+    role: entry.role,
+    symbol_type: entry.symbol_type,
+    name: Cow::Owned(entry.name.into_owned()),
+    range: entry.range,
+    signature: Cow::Owned(entry.signature.into_owned()),
+    ast_kind: Cow::Owned(entry.ast_kind.into_owned()),
+  }
+}
+
+#[derive(Clone)]
+struct OutlineTextOptions {
+  items: OutlineItems,
+  view: OutlineView,
+  symbol_types: Option<Vec<SymbolType>>,
+  item_matcher: Option<Regex>,
+  pub_members: bool,
+  use_color: bool,
+  show_empty_files: bool,
+}
+
+impl OutlineTextOptions {
+  fn try_from(arg: &OutlineArg) -> Result<Self> {
+    let has_directory_input = !arg.input.stdin && arg.input.paths.iter().any(|path| path.is_dir());
+    Ok(Self {
+      items: resolve_items(arg.items, has_directory_input),
+      view: resolve_view(arg.view, has_directory_input),
+      symbol_types: arg
+        .symbol_type
+        .as_deref()
+        .map(parse_symbol_types)
+        .transpose()?,
+      item_matcher: arg
+        .match_item
+        .as_deref()
+        .map(Regex::new)
+        .transpose()
+        .context("Cannot parse outline item matcher")?,
+      pub_members: arg.pub_members,
+      use_color: arg.color.should_use_color(),
+      show_empty_files: arg.input.stdin || !has_directory_input,
+    })
+  }
+}
+
+fn resolve_items(items: OutlineItems, has_directory_input: bool) -> OutlineItems {
+  match (items, has_directory_input) {
+    (OutlineItems::Auto, true) => OutlineItems::Exports,
+    (OutlineItems::Auto, false) => OutlineItems::Structure,
+    _ => items,
+  }
+}
+
+fn resolve_view(view: OutlineView, has_directory_input: bool) -> OutlineView {
+  match (view, has_directory_input) {
+    (OutlineView::Auto, true) => OutlineView::Names,
+    (OutlineView::Auto, false) => OutlineView::Digest,
+    _ => view,
+  }
+}
+
+fn parse_symbol_types(source: &str) -> Result<Vec<SymbolType>> {
+  source
+    .split(',')
+    .map(|raw| {
+      let raw = raw.trim();
+      parse_symbol_type(raw).with_context(|| format!("Unknown outline symbol type `{raw}`"))
+    })
+    .collect()
+}
+
+fn parse_symbol_type(raw: &str) -> Option<SymbolType> {
+  let normalized = raw
+    .chars()
+    .filter(|ch| *ch != '-' && *ch != '_')
+    .flat_map(char::to_lowercase)
+    .collect::<String>();
+  Some(match normalized.as_str() {
+    "file" => SymbolType::File,
+    "module" => SymbolType::Module,
+    "namespace" => SymbolType::Namespace,
+    "package" => SymbolType::Package,
+    "class" => SymbolType::Class,
+    "method" => SymbolType::Method,
+    "property" => SymbolType::Property,
+    "field" => SymbolType::Field,
+    "constructor" => SymbolType::Constructor,
+    "enum" => SymbolType::Enum,
+    "interface" => SymbolType::Interface,
+    "function" => SymbolType::Function,
+    "variable" => SymbolType::Variable,
+    "constant" => SymbolType::Constant,
+    "string" => SymbolType::String,
+    "number" => SymbolType::Number,
+    "boolean" => SymbolType::Boolean,
+    "array" => SymbolType::Array,
+    "object" => SymbolType::Object,
+    "key" => SymbolType::Key,
+    "null" => SymbolType::Null,
+    "enummember" => SymbolType::EnumMember,
+    "struct" => SymbolType::Struct,
+    "event" => SymbolType::Event,
+    "operator" => SymbolType::Operator,
+    "typeparameter" => SymbolType::TypeParameter,
+    _ => return None,
+  })
+}
+
+fn matches_item_filters(item: &OutlineItem, options: &OutlineTextOptions) -> bool {
+  matches_items_mode(item, options.items)
+    && matches_symbol_type(item, options.symbol_types.as_deref())
+    && matches_item_regex(item, options.item_matcher.as_ref())
+}
+
+fn matches_items_mode(item: &OutlineItem, items: OutlineItems) -> bool {
+  match items {
+    OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
+    OutlineItems::Structure => !item.is_import,
+    OutlineItems::Exports => item.is_exported,
+    OutlineItems::Imports => item.is_import,
+    OutlineItems::All => true,
+  }
+}
+
+fn matches_symbol_type(item: &OutlineItem, symbol_types: Option<&[SymbolType]>) -> bool {
+  symbol_types.is_none_or(|types| types.contains(&item.entry.symbol_type))
+}
+
+fn matches_item_regex(item: &OutlineItem, matcher: Option<&Regex>) -> bool {
+  matcher.is_none_or(|matcher| {
+    matcher.is_match(&item.entry.name) || matcher.is_match(&item.entry.signature)
+  })
+}
+
+struct OutlineEmitter<'a, W> {
+  out: W,
+  json: Option<JsonStyle>,
+  options: &'a OutlineTextOptions,
+  text_style: OutlineTextStyle,
+  is_first: bool,
+  emitted_any: bool,
+}
+
+impl<'a, W: Write> OutlineEmitter<'a, W> {
+  fn new(out: W, json: Option<JsonStyle>, options: &'a OutlineTextOptions) -> Self {
+    Self {
+      out,
+      json,
+      options,
+      text_style: OutlineTextStyle::new(options.use_color, options.items),
+      is_first: true,
+      emitted_any: false,
+    }
+  }
+
+  fn emit(&mut self, file: OutlineFile<'static>) -> Result<()> {
+    match self.json {
+      Some(JsonStyle::Pretty) => self.emit_pretty_json(&file)?,
+      Some(JsonStyle::Compact) => self.emit_compact_json(&file)?,
+      Some(JsonStyle::Stream) => {
+        serde_json::to_writer(&mut self.out, &file)?;
+        writeln!(self.out)?;
+      }
+      None => print_text_file_to(
+        &mut self.out,
+        &file,
+        self.options,
+        &self.text_style,
+        self.is_first,
+      )?,
+    }
+    self.is_first = false;
+    self.emitted_any = true;
+    self.out.flush()?;
+    Ok(())
+  }
+
+  fn finish(&mut self) -> Result<()> {
+    match self.json {
+      Some(JsonStyle::Pretty) => {
+        if self.emitted_any {
+          writeln!(self.out, "]")?;
+        } else {
+          writeln!(self.out, "[]")?;
+        }
+      }
+      Some(JsonStyle::Compact) => {
+        if self.emitted_any {
+          writeln!(self.out, "]")?;
+        } else {
+          writeln!(self.out, "[]")?;
+        }
+      }
+      Some(JsonStyle::Stream) => {}
+      None if !self.emitted_any => {
+        writeln!(self.out, "nothing found")?;
+      }
+      None => {}
+    }
+    self.out.flush()?;
+    Ok(())
+  }
+
+  fn emit_pretty_json(&mut self, file: &OutlineFile) -> Result<()> {
+    if self.is_first {
+      writeln!(self.out, "[")?;
+    } else {
+      writeln!(self.out, ",")?;
+    }
+    let object = serde_json::to_string_pretty(file)?;
+    for line in object.lines() {
+      writeln!(self.out, "  {line}")?;
+    }
+    Ok(())
+  }
+
+  fn emit_compact_json(&mut self, file: &OutlineFile) -> Result<()> {
+    if self.is_first {
+      write!(self.out, "[")?;
+    } else {
+      write!(self.out, ",")?;
+    }
+    serde_json::to_writer(&mut self.out, file)?;
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+fn print_text_to(
+  mut out: &mut impl Write,
+  files: &[OutlineFile],
+  options: &OutlineTextOptions,
+) -> Result<()> {
+  let style = OutlineTextStyle::new(options.use_color, options.items);
+  if files.is_empty() {
+    writeln!(out, "nothing found")?;
+    return Ok(());
+  }
+  for (idx, file) in files.iter().enumerate() {
+    print_text_file_to(&mut out, file, options, &style, idx == 0)?;
+  }
+  Ok(())
+}
+
+fn print_text_file_to(
+  mut out: &mut impl Write,
+  file: &OutlineFile,
+  options: &OutlineTextOptions,
+  style: &OutlineTextStyle,
+  is_first: bool,
+) -> Result<()> {
+  if !is_first {
+    writeln!(out)?;
+  }
+  writeln!(out, "{}", style.file(&file.path))?;
+  if file.items.is_empty() {
+    writeln!(out, "nothing found")?;
+  } else {
+    let line_number_width = line_number_width(file);
+    match options.view {
+      OutlineView::Auto => unreachable!("outline view should be resolved"),
+      OutlineView::Names => print_names(&mut out, file, style)?,
+      OutlineView::Signatures => print_signatures(&mut out, file, style, line_number_width)?,
+      OutlineView::Digest => print_digest(&mut out, file, style, line_number_width)?,
+      OutlineView::Expanded => print_expanded(&mut out, file, style, line_number_width)?,
+    }
+  }
+  Ok(())
+}
+
+fn print_names(out: &mut impl Write, file: &OutlineFile, style: &OutlineTextStyle) -> Result<()> {
+  for (symbol_type, names) in grouped_item_names(&file.items) {
+    writeln!(
+      out,
+      "{}: {}",
+      style.grouped_label(symbol_type, symbol_type_name(symbol_type)),
+      names
+        .iter()
+        .map(|name| style.grouped_item_name(name))
+        .collect::<Vec<_>>()
+        .join(", ")
+    )?;
+  }
+  Ok(())
+}
+
+fn print_signatures(
+  out: &mut impl Write,
+  file: &OutlineFile,
+  style: &OutlineTextStyle,
+  line_number_width: usize,
+) -> Result<()> {
+  for item in &file.items {
+    writeln!(out, "{}", item_line(item, style, true, line_number_width))?;
+  }
+  Ok(())
+}
+
+fn print_digest(
+  out: &mut impl Write,
+  file: &OutlineFile,
+  style: &OutlineTextStyle,
+  line_number_width: usize,
+) -> Result<()> {
+  let member_indent = grouped_member_indent(line_number_width);
+  for item in &file.items {
+    writeln!(out, "{}", item_line(item, style, true, line_number_width))?;
+    for (symbol_type, names) in grouped_member_names(&item.members) {
+      writeln!(
+        out,
+        "{}{}: {}",
+        member_indent,
+        style.grouped_label(symbol_type, plural_symbol_type_name(symbol_type)),
+        names
+          .iter()
+          .map(|name| style.grouped_member_name(name))
+          .collect::<Vec<_>>()
+          .join(", ")
+      )?;
+    }
+  }
+  Ok(())
+}
+
+fn grouped_member_indent(line_number_width: usize) -> String {
+  " ".repeat(line_number_width + 4)
+}
+
+fn print_expanded(
+  out: &mut impl Write,
+  file: &OutlineFile,
+  style: &OutlineTextStyle,
+  line_number_width: usize,
+) -> Result<()> {
+  for item in &file.items {
+    writeln!(out, "{}", item_line(item, style, true, line_number_width))?;
+    for member in &item.members {
+      writeln!(out, "{}", member_line(member, style, line_number_width))?;
+    }
+  }
+  Ok(())
+}
+
+fn line_number_width(file: &OutlineFile) -> usize {
+  file
+    .items
+    .iter()
+    .flat_map(|item| {
+      std::iter::once(item.entry.range.start.line + 1).chain(
+        item
+          .members
+          .iter()
+          .map(|member| member.entry.range.start.line + 1),
+      )
+    })
+    .max()
+    .unwrap_or(1)
+    .to_string()
+    .len()
+}
+
+#[derive(Clone)]
+struct StyledName {
+  text: String,
+  is_import: bool,
+  is_exported: bool,
+  is_public: bool,
+}
+
+fn grouped_item_names(items: &[OutlineItem]) -> Vec<(SymbolType, Vec<StyledName>)> {
+  let mut groups = empty_symbol_groups();
+  for item in items {
+    push_grouped_name(
+      &mut groups,
+      item.entry.symbol_type,
+      StyledName {
+        text: item.entry.name.to_string(),
+        is_import: item.is_import,
+        is_exported: item.is_exported,
+        is_public: true,
+      },
+    );
+  }
+  groups.retain(|(_, names)| !names.is_empty());
+  groups
+}
+
+fn grouped_member_names(members: &[OutlineMember]) -> Vec<(SymbolType, Vec<StyledName>)> {
+  let mut groups = empty_symbol_groups();
+  for member in members.iter().filter(|member| member.is_public) {
+    push_grouped_name(
+      &mut groups,
+      member.entry.symbol_type,
+      StyledName {
+        text: member.entry.name.to_string(),
+        is_import: false,
+        is_exported: false,
+        is_public: member.is_public,
+      },
+    );
+  }
+  for member in members.iter().filter(|member| !member.is_public) {
+    push_grouped_name(
+      &mut groups,
+      member.entry.symbol_type,
+      StyledName {
+        text: member.entry.name.to_string(),
+        is_import: false,
+        is_exported: false,
+        is_public: member.is_public,
+      },
+    );
+  }
+  groups.retain(|(_, names)| !names.is_empty());
+  groups
+}
+
+fn empty_symbol_groups() -> Vec<(SymbolType, Vec<StyledName>)> {
+  SYMBOL_TYPE_ORDER
+    .iter()
+    .map(|&symbol_type| (symbol_type, vec![]))
+    .collect()
+}
+
+fn push_grouped_name(
+  groups: &mut Vec<(SymbolType, Vec<StyledName>)>,
+  symbol_type: SymbolType,
+  name: StyledName,
+) {
+  if let Some((_, names)) = groups.iter_mut().find(|(ty, _)| *ty == symbol_type) {
+    names.push(name);
+  } else {
+    groups.push((symbol_type, vec![name]));
+  }
+}
+
+fn item_line(
+  item: &OutlineItem,
+  style: &OutlineTextStyle,
+  emphasize_exported: bool,
+  line_number_width: usize,
+) -> String {
+  format!(
+    "{}: {}",
+    style.line_number(format_args!(
+      "{:>line_number_width$}",
+      item.entry.range.start.line + 1
+    )),
+    style.entry_signature(
+      &item.entry,
+      item.entry.symbol_type,
+      item.is_import,
+      emphasize_exported && item.is_exported
+    )
+  )
+}
+
+fn member_line(
+  member: &OutlineMember,
+  style: &OutlineTextStyle,
+  line_number_width: usize,
+) -> String {
+  format!(
+    "{}:   {}",
+    style.line_number(format_args!(
+      "{:>line_number_width$}",
+      member.entry.range.start.line + 1
+    )),
+    style.member_signature(member, member.entry.symbol_type)
+  )
+}
+
+fn signature_or_name<'entry, 'text>(entry: &'entry OutlineEntry<'text>) -> &'entry str {
+  if entry.signature.is_empty() {
+    &entry.name
+  } else {
+    &entry.signature
+  }
+}
+
+fn symbol_type_name(symbol_type: SymbolType) -> &'static str {
+  match symbol_type {
+    SymbolType::File => "file",
+    SymbolType::Module => "module",
+    SymbolType::Namespace => "namespace",
+    SymbolType::Package => "package",
+    SymbolType::Class => "class",
+    SymbolType::Method => "method",
+    SymbolType::Property => "property",
+    SymbolType::Field => "field",
+    SymbolType::Constructor => "constructor",
+    SymbolType::Enum => "enum",
+    SymbolType::Interface => "interface",
+    SymbolType::Function => "function",
+    SymbolType::Variable => "variable",
+    SymbolType::Constant => "constant",
+    SymbolType::String => "string",
+    SymbolType::Number => "number",
+    SymbolType::Boolean => "boolean",
+    SymbolType::Array => "array",
+    SymbolType::Object => "object",
+    SymbolType::Key => "key",
+    SymbolType::Null => "null",
+    SymbolType::EnumMember => "enumMember",
+    SymbolType::Struct => "struct",
+    SymbolType::Event => "event",
+    SymbolType::Operator => "operator",
+    SymbolType::TypeParameter => "typeParameter",
+  }
+}
+
+fn plural_symbol_type_name(symbol_type: SymbolType) -> &'static str {
+  match symbol_type {
+    SymbolType::Class => "classes",
+    SymbolType::Property => "properties",
+    SymbolType::Enum => "enums",
+    SymbolType::Struct => "structs",
+    SymbolType::TypeParameter => "typeParameters",
+    _ => match symbol_type_name(symbol_type) {
+      "boolean" => "booleans",
+      "enumMember" => "enumMembers",
+      "namespace" => "namespaces",
+      "constructor" => "constructors",
+      "interface" => "interfaces",
+      "function" => "functions",
+      "variable" => "variables",
+      "constant" => "constants",
+      "operator" => "operators",
+      "package" => "packages",
+      "module" => "modules",
+      "method" => "methods",
+      "field" => "fields",
+      "event" => "events",
+      "array" => "arrays",
+      "file" => "files",
+      "string" => "strings",
+      "number" => "numbers",
+      "object" => "objects",
+      "key" => "keys",
+      "null" => "nulls",
+      _ => symbol_type_name(symbol_type),
+    },
+  }
+}
+
+const SYMBOL_TYPE_ORDER: &[SymbolType] = &[
+  SymbolType::File,
+  SymbolType::Module,
+  SymbolType::Namespace,
+  SymbolType::Package,
+  SymbolType::Class,
+  SymbolType::Struct,
+  SymbolType::Enum,
+  SymbolType::Interface,
+  SymbolType::Function,
+  SymbolType::Method,
+  SymbolType::Constructor,
+  SymbolType::Property,
+  SymbolType::Field,
+  SymbolType::EnumMember,
+  SymbolType::Variable,
+  SymbolType::Constant,
+  SymbolType::String,
+  SymbolType::Number,
+  SymbolType::Boolean,
+  SymbolType::Array,
+  SymbolType::Object,
+  SymbolType::Key,
+  SymbolType::Null,
+  SymbolType::Event,
+  SymbolType::Operator,
+  SymbolType::TypeParameter,
+];
+
+struct OutlineTextStyle {
+  use_color: bool,
+  emphasize_imports: bool,
+  emphasize_exports: bool,
+}
+
+impl OutlineTextStyle {
+  fn new(use_color: bool, items: OutlineItems) -> Self {
+    Self {
+      use_color,
+      emphasize_imports: items != OutlineItems::Imports,
+      emphasize_exports: items != OutlineItems::Exports,
+    }
+  }
+
+  fn file(&self, text: impl Display) -> String {
+    self.paint(ansi_term::Style::new().underline(), text)
+  }
+
+  fn line_number(&self, text: impl Display) -> String {
+    self.paint(ansi_term::Style::new().dimmed(), text)
+  }
+
+  fn grouped_label(&self, symbol_type: SymbolType, text: impl Display) -> String {
+    let text = text.to_string();
+    if !self.use_color {
+      return text;
+    }
+    symbol_type_style(symbol_type).paint(text).to_string()
+  }
+
+  fn entry_signature(
+    &self,
+    entry: &OutlineEntry,
+    symbol_type: SymbolType,
+    is_import: bool,
+    emphasize_name: bool,
+  ) -> String {
+    let name_style = item_name_style(
+      symbol_type,
+      self.emphasize_imports && is_import,
+      self.emphasize_exports && emphasize_name,
+    );
+    self.signature(entry, name_style, None)
+  }
+
+  fn member_signature(&self, member: &OutlineMember, symbol_type: SymbolType) -> String {
+    let surrounding_style = if member.is_public {
+      None
+    } else {
+      Some(ansi_term::Style::new().dimmed())
+    };
+    let name_style = if member.is_public {
+      symbol_type_style(symbol_type)
+    } else {
+      symbol_type_style(symbol_type).dimmed()
+    };
+    self.signature(&member.entry, name_style, surrounding_style)
+  }
+
+  fn grouped_item_name(&self, name: &StyledName) -> String {
+    let mut style = ansi_term::Style::new();
+    if self.emphasize_imports && name.is_import {
+      style = style.italic();
+    }
+    if self.emphasize_exports && name.is_exported {
+      style = style.bold();
+    }
+    self.paint(style, &name.text)
+  }
+
+  fn grouped_member_name(&self, name: &StyledName) -> String {
+    let style = if name.is_public {
+      ansi_term::Style::new()
+    } else {
+      ansi_term::Style::new().dimmed()
+    };
+    self.paint(style, &name.text)
+  }
+
+  fn paint(&self, style: ansi_term::Style, text: impl Display) -> String {
+    if self.use_color {
+      style.paint(text.to_string()).to_string()
+    } else {
+      text.to_string()
+    }
+  }
+
+  fn signature(
+    &self,
+    entry: &OutlineEntry,
+    name_style: ansi_term::Style,
+    surrounding_style: Option<ansi_term::Style>,
+  ) -> String {
+    let signature = signature_or_name(entry);
+    if !self.use_color {
+      return signature.to_string();
+    }
+    let Some(start) = signature.find(entry.name.as_ref()) else {
+      return surrounding_style.map_or_else(
+        || signature.to_string(),
+        |style| self.paint(style, signature),
+      );
+    };
+    let end = start + entry.name.len();
+    let before = surrounding_style.map_or_else(
+      || signature[..start].to_string(),
+      |style| self.paint(style, &signature[..start]),
+    );
+    let name = name_style.paint(&signature[start..end]).to_string();
+    let after = surrounding_style.map_or_else(
+      || signature[end..].to_string(),
+      |style| self.paint(style, &signature[end..]),
+    );
+    format!("{before}{name}{after}")
+  }
+}
+
+fn symbol_type_style(symbol_type: SymbolType) -> ansi_term::Style {
+  use ansi_term::Color;
+  let color = match symbol_type {
+    SymbolType::File | SymbolType::Module | SymbolType::Namespace | SymbolType::Package => {
+      Color::Cyan
+    }
+    SymbolType::Class | SymbolType::Struct | SymbolType::Object => Color::Blue,
+    SymbolType::Enum | SymbolType::EnumMember => Color::Purple,
+    SymbolType::Interface | SymbolType::TypeParameter => Color::Fixed(39),
+    SymbolType::Function | SymbolType::Method | SymbolType::Constructor => Color::Green,
+    SymbolType::Property | SymbolType::Field | SymbolType::Key => Color::Yellow,
+    SymbolType::Variable | SymbolType::Constant => Color::Fixed(214),
+    SymbolType::String
+    | SymbolType::Number
+    | SymbolType::Boolean
+    | SymbolType::Array
+    | SymbolType::Null => Color::Fixed(208),
+    SymbolType::Event | SymbolType::Operator => Color::Red,
+  };
+  color.normal()
+}
+
+fn item_name_style(
+  symbol_type: SymbolType,
+  is_import: bool,
+  is_exported: bool,
+) -> ansi_term::Style {
+  let mut style = symbol_type_style(symbol_type);
+  if is_import {
+    style = style.italic();
+  }
+  if is_exported {
+    style = style.bold();
+  }
+  style
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use ast_grep_outline::model::{EntryRole, SourcePosition, SourceRange};
+
+  fn options(view: OutlineView) -> OutlineTextOptions {
+    OutlineTextOptions {
+      items: OutlineItems::All,
+      view,
+      symbol_types: None,
+      item_matcher: None,
+      pub_members: false,
+      use_color: false,
+      show_empty_files: true,
+    }
+  }
+
+  fn range(line: usize) -> SourceRange {
+    SourceRange {
+      byte_offset: 0..0,
+      start: SourcePosition { line, column: 0 },
+      end: SourcePosition { line, column: 0 },
+    }
+  }
+
+  fn entry(
+    role: EntryRole,
+    symbol_type: SymbolType,
+    name: &'static str,
+    signature: &'static str,
+    line: usize,
+  ) -> OutlineEntry<'static> {
+    OutlineEntry {
+      role,
+      symbol_type,
+      name: Cow::Borrowed(name),
+      range: range(line),
+      signature: Cow::Borrowed(signature),
+      ast_kind: Cow::Borrowed("test_node"),
+    }
+  }
+
+  fn member(
+    symbol_type: SymbolType,
+    name: &'static str,
+    signature: &'static str,
+    line: usize,
+    is_public: bool,
+  ) -> OutlineMember<'static> {
+    OutlineMember {
+      entry: entry(EntryRole::Member, symbol_type, name, signature, line),
+      is_public,
+    }
+  }
+
+  fn outline_file() -> OutlineFile<'static> {
+    OutlineFile {
+      path: "src/parser.ts".to_string(),
+      language: "TypeScript".to_string(),
+      items: vec![OutlineItem {
+        entry: entry(
+          EntryRole::Item,
+          SymbolType::Class,
+          "Parser",
+          "export class Parser",
+          39,
+        ),
+        is_import: false,
+        is_exported: true,
+        members: vec![
+          member(SymbolType::Method, "parse", "parse(...)", 43, true),
+          member(SymbolType::Method, "recover", "recover(...)", 72, false),
+        ],
+      }],
+    }
+  }
+
+  #[test]
+  fn renders_digest_like_design_doc() {
+    let mut output = vec![];
+    print_text_to(
+      &mut output,
+      &[outline_file()],
+      &options(OutlineView::Digest),
+    )
+    .expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert_eq!(
+      output,
+      "src/parser.ts\n40: export class Parser\n      methods: parse, recover\n"
+    );
+  }
+
+  #[test]
+  fn renders_expanded_members_like_design_doc() {
+    let mut output = vec![];
+    print_text_to(
+      &mut output,
+      &[outline_file()],
+      &options(OutlineView::Expanded),
+    )
+    .expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert_eq!(
+      output,
+      "src/parser.ts\n40: export class Parser\n44:   parse(...)\n73:   recover(...)\n"
+    );
+  }
+
+  #[test]
+  fn aligns_line_numbers_to_file_width() {
+    let mut file = outline_file();
+    file.items.push(OutlineItem {
+      entry: entry(EntryRole::Item, SymbolType::Function, "late", "late()", 99),
+      is_import: false,
+      is_exported: false,
+      members: vec![],
+    });
+    let mut output = vec![];
+    print_text_to(&mut output, &[file], &options(OutlineView::Expanded))
+      .expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert_eq!(
+      output,
+      "src/parser.ts\n 40: export class Parser\n 44:   parse(...)\n 73:   recover(...)\n100: late()\n"
+    );
+
+    let mut file = outline_file();
+    file.items.push(OutlineItem {
+      entry: entry(EntryRole::Item, SymbolType::Function, "late", "late()", 99),
+      is_import: false,
+      is_exported: false,
+      members: vec![],
+    });
+    let mut output = vec![];
+    print_text_to(&mut output, &[file], &options(OutlineView::Digest)).expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("\n       methods: parse, recover\n"));
+  }
+
+  #[test]
+  fn renders_empty_direct_file_block() {
+    let mut output = vec![];
+    let file = OutlineFile {
+      path: "src/empty.ts".to_string(),
+      language: "TypeScript".to_string(),
+      items: vec![],
+    };
+    print_text_to(&mut output, &[file], &options(OutlineView::Digest)).expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert_eq!(output, "src/empty.ts\nnothing found\n");
+  }
+
+  #[test]
+  fn separates_file_blocks_with_blank_line() {
+    let mut output = vec![];
+    let first = outline_file();
+    let mut second = outline_file();
+    second.path = "src/checker.ts".to_string();
+    print_text_to(
+      &mut output,
+      &[first, second],
+      &options(OutlineView::Signatures),
+    )
+    .expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("src/parser.ts\n40: export class Parser\n\nsrc/checker.ts\n"));
+  }
+
+  #[test]
+  fn emitter_streams_text_file_blocks() {
+    let options = options(OutlineView::Signatures);
+    let mut output = vec![];
+    {
+      let mut emitter = OutlineEmitter::new(&mut output, None, &options);
+      emitter.emit(outline_file()).expect("file should emit");
+      let mut second = outline_file();
+      second.path = "src/checker.ts".to_string();
+      emitter.emit(second).expect("file should emit");
+      emitter.finish().expect("output should finish");
+    }
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("src/parser.ts\n40: export class Parser\n\nsrc/checker.ts\n"));
+  }
+
+  #[test]
+  fn emitter_streams_json_lines_per_file() {
+    let options = options(OutlineView::Signatures);
+    let mut output = vec![];
+    {
+      let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Stream), &options);
+      emitter.emit(outline_file()).expect("file should emit");
+      let mut second = outline_file();
+      second.path = "src/checker.ts".to_string();
+      emitter.emit(second).expect("file should emit");
+      emitter.finish().expect("output should finish");
+    }
+    let output = String::from_utf8(output).expect("output should be utf8");
+    let lines = output.lines().collect::<Vec<_>>();
+
+    assert_eq!(lines.len(), 2);
+    for line in lines {
+      serde_json::from_str::<serde_json::Value>(line).expect("line should be json");
+    }
+  }
+
+  #[test]
+  fn emitter_streams_valid_compact_json_array() {
+    let options = options(OutlineView::Signatures);
+    let mut output = vec![];
+    {
+      let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Compact), &options);
+      emitter.emit(outline_file()).expect("file should emit");
+      let mut second = outline_file();
+      second.path = "src/checker.ts".to_string();
+      emitter.emit(second).expect("file should emit");
+      emitter.finish().expect("output should finish");
+    }
+    let output: serde_json::Value =
+      serde_json::from_slice(&output).expect("output should be a json array");
+
+    assert_eq!(output.as_array().expect("json should be array").len(), 2);
+  }
+
+  #[test]
+  fn signature_view_styles_exported_items() {
+    let mut options = options(OutlineView::Signatures);
+    options.use_color = true;
+    let mut output = vec![];
+    print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("export class \u{1b}[1;34mParser\u{1b}[0m"));
+  }
+
+  #[test]
+  fn colors_symbol_types_differently() {
+    let style = OutlineTextStyle::new(true, OutlineItems::All);
+    let class = style.grouped_label(SymbolType::Class, "class");
+    let function = style.grouped_label(SymbolType::Function, "function");
+    let label = style.grouped_label(SymbolType::Function, "functions");
+
+    assert_ne!(class, function);
+    assert!(class.contains("\u{1b}["));
+    assert!(function.contains("\u{1b}["));
+    assert!(label.contains("\u{1b}["));
+    assert!(!label.contains("\u{1b}[7;"));
+    assert!(label.contains("functions"));
+  }
+
+  #[test]
+  fn styles_outline_flags_with_ansi() {
+    let style = OutlineTextStyle::new(true, OutlineItems::All);
+    let file = style.file("src/parser.ts");
+    let import = style.entry_signature(
+      &entry(
+        EntryRole::Item,
+        SymbolType::Module,
+        "std::fmt",
+        "use std::fmt;",
+        0,
+      ),
+      SymbolType::Module,
+      true,
+      false,
+    );
+    let exported = style.entry_signature(
+      &entry(
+        EntryRole::Item,
+        SymbolType::Function,
+        "parse",
+        "pub fn parse()",
+        0,
+      ),
+      SymbolType::Function,
+      false,
+      true,
+    );
+    let public_member = style.member_signature(
+      &member(SymbolType::Method, "parse", "parse()", 0, true),
+      SymbolType::Method,
+    );
+    let private_member = style.member_signature(
+      &member(SymbolType::Method, "recover", "recover()", 0, false),
+      SymbolType::Method,
+    );
+
+    assert!(file.contains("\u{1b}[4"));
+    assert!(import.contains("\u{1b}["));
+    assert!(exported.contains("\u{1b}["));
+    assert_ne!(import, "use std::fmt;");
+    assert_ne!(exported, "pub fn parse()");
+    assert_ne!(public_member, private_member);
+    assert!(private_member.contains("\u{1b}["));
+  }
+
+  #[test]
+  fn keeps_digest_and_names_entries_uncolored() {
+    let mut options = options(OutlineView::Names);
+    options.use_color = true;
+    let mut output = vec![];
+    print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("Parser"));
+    assert!(!output.contains("\u{1b}[34mParser"));
+    assert!(output.contains("\u{1b}[1mParser"));
+
+    options.view = OutlineView::Digest;
+    let mut output = vec![];
+    print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+    let output = String::from_utf8(output).expect("output should be utf8");
+
+    assert!(output.contains("parse"));
+    assert!(output.contains("recover"));
+    assert!(!output.contains("\u{1b}[32mparse"));
+    assert!(!output.contains("\u{1b}[2;32mrecover"));
+    assert!(output.contains("\u{1b}[2mrecover"));
+  }
+
+  #[test]
+  fn suppresses_redundant_item_mode_styles() {
+    let import_style = OutlineTextStyle::new(true, OutlineItems::Imports);
+    let export_style = OutlineTextStyle::new(true, OutlineItems::Exports);
+    let mixed_style = OutlineTextStyle::new(true, OutlineItems::All);
+    let import_name = StyledName {
+      text: "std::fmt".to_string(),
+      is_import: true,
+      is_exported: false,
+      is_public: true,
+    };
+    let export_name = StyledName {
+      text: "api".to_string(),
+      is_import: false,
+      is_exported: true,
+      is_public: true,
+    };
+
+    assert_eq!(import_style.grouped_item_name(&import_name), "std::fmt");
+    assert_eq!(export_style.grouped_item_name(&export_name), "api");
+    assert_ne!(mixed_style.grouped_item_name(&import_name), "std::fmt");
+    assert_ne!(mixed_style.grouped_item_name(&export_name), "api");
+
+    let import_signature = entry(
+      EntryRole::Item,
+      SymbolType::Module,
+      "std::fmt",
+      "use std::fmt;",
+      0,
+    );
+    let export_signature = entry(
+      EntryRole::Item,
+      SymbolType::Function,
+      "api",
+      "pub fn api()",
+      0,
+    );
+
+    assert_eq!(
+      import_style.entry_signature(&import_signature, SymbolType::Module, true, false),
+      "use \u{1b}[36mstd::fmt\u{1b}[0m;"
+    );
+    assert_eq!(
+      export_style.entry_signature(&export_signature, SymbolType::Function, false, true),
+      "pub fn \u{1b}[32mapi\u{1b}[0m()"
+    );
+  }
 }

--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -6,13 +6,19 @@
 //! extractor has matched; they are grouped by parent item extractor id and then
 //! indexed sparsely by child node kind inside that parent-scoped group.
 //!
-//! Extraction uses explicit pre-order traversals instead of `find_all`. For each
-//! node, the node kind selects the small set of extractors that can possibly
-//! match. When a node becomes an outline item, item traversal skips that node's
-//! descendants and member extraction runs in the matched item's scope.
+//! Extraction uses tree-sitter cursor-backed pre-order traversals instead of
+//! `find_all`. For each node, the node kind selects the small set of extractors
+//! that can possibly match. When a node becomes an outline item, item traversal
+//! skips that node's descendants and member extraction runs in the matched
+//! item's scope.
 
 use ast_grep_config::GlobalRules;
-use ast_grep_core::{Doc, Language, Matcher, Node, NodeMatch};
+use ast_grep_core::{
+  Doc, Language, Matcher, Node, NodeMatch,
+  meta_var::MetaVarEnv,
+  tree_sitter::{LanguageExt, StrDoc, Visitor},
+};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::extractor::{ItemExtractor, MemberExtractor, OutlineRuleError, SerializableOutlineRule};
@@ -98,24 +104,28 @@ impl<L: Language> CombinedExtractors<L> {
       .flat_map(|indices| indices.iter().map(|&idx| &self.item_extractors[idx]))
   }
 
-  pub fn extract<'tree, D: Doc>(&self, root: Node<'tree, D>) -> Vec<OutlineItem<'tree>> {
+  pub fn extract<'tree>(&self, root: Node<'tree, StrDoc<L>>) -> Vec<OutlineItem<'tree>>
+  where
+    L: LanguageExt,
+  {
     let mut items = vec![];
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-      if let Some((extractor, node_match)) = self.match_item(node.clone()) {
+    let matcher = ItemTraversalMatcher { combined: self };
+    for matched in Visitor::new(matcher).reentrant(false).visit(root) {
+      if let Some((extractor, node_match)) = self.match_item(matched.get_node().clone()) {
         let members = self.extract_members(extractor, node_match.get_node().clone());
         items.push(extractor.extract(&node_match, members));
-        continue;
       }
-      push_children(&mut stack, node);
     }
     items
   }
 
-  fn match_item<'tree, D: Doc>(
+  fn match_item<'tree>(
     &self,
-    node: Node<'tree, D>,
-  ) -> Option<(&ItemExtractor<L>, NodeMatch<'tree, D>)> {
+    node: Node<'tree, StrDoc<L>>,
+  ) -> Option<(&ItemExtractor<L>, NodeMatch<'tree, StrDoc<L>>)>
+  where
+    L: LanguageExt,
+  {
     self
       .item_extractors_for_kind(node.kind_id())
       .find_map(|extractor| {
@@ -125,11 +135,14 @@ impl<L: Language> CombinedExtractors<L> {
       })
   }
 
-  fn extract_members<'tree, D: Doc>(
+  fn extract_members<'tree>(
     &self,
     item_extractor: &ItemExtractor<L>,
-    item_node: Node<'tree, D>,
-  ) -> Vec<OutlineMember<'tree>> {
+    item_node: Node<'tree, StrDoc<L>>,
+  ) -> Vec<OutlineMember<'tree>>
+  where
+    L: LanguageExt,
+  {
     let Some(member_extractors) = self.member_extractors_for(&item_extractor.common.rule.id) else {
       return vec![];
     };
@@ -147,21 +160,26 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
       .flat_map(|indices| indices.iter().map(|&idx| &self.extractors[idx]))
   }
 
-  pub fn extract<'tree, D: Doc>(&self, item_node: Node<'tree, D>) -> Vec<OutlineMember<'tree>> {
+  pub fn extract<'tree>(&self, item_node: Node<'tree, StrDoc<L>>) -> Vec<OutlineMember<'tree>>
+  where
+    L: LanguageExt,
+  {
     let mut members = vec![];
-    let mut stack = item_node.children().collect::<Vec<_>>();
-    stack.reverse();
-    while let Some(node) = stack.pop() {
-      if let Some(member) = self.extract_member(node.clone()) {
-        members.push(member);
-        continue;
+    let matcher = MemberTraversalMatcher { combined: self };
+    for child in item_node.children() {
+      for matched in Visitor::new(&matcher).reentrant(false).visit(child) {
+        if let Some(member) = self.extract_member(matched.get_node().clone()) {
+          members.push(member);
+        }
       }
-      push_children(&mut stack, node);
     }
     members
   }
 
-  fn extract_member<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<OutlineMember<'tree>> {
+  fn extract_member<'tree>(&self, node: Node<'tree, StrDoc<L>>) -> Option<OutlineMember<'tree>>
+  where
+    L: LanguageExt,
+  {
     self
       .extractors_for_kind(node.kind_id())
       .find_map(|extractor| {
@@ -172,10 +190,46 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
   }
 }
 
-fn push_children<'tree, D: Doc>(stack: &mut Vec<Node<'tree, D>>, node: Node<'tree, D>) {
-  let mut children = node.children().collect::<Vec<_>>();
-  children.reverse();
-  stack.extend(children);
+struct ItemTraversalMatcher<'a, L: Language> {
+  combined: &'a CombinedExtractors<L>,
+}
+
+impl<L: Language> Matcher for ItemTraversalMatcher<'_, L> {
+  fn match_node_with_env<'tree, D: Doc>(
+    &self,
+    node: Node<'tree, D>,
+    env: &mut Cow<MetaVarEnv<'tree, D>>,
+  ) -> Option<Node<'tree, D>> {
+    for extractor in self.combined.item_extractors_for_kind(node.kind_id()) {
+      let Some(matched) = extractor.match_node(node.clone()) else {
+        continue;
+      };
+      *env = Cow::Owned(matched.get_env().clone());
+      return Some(matched.get_node().clone());
+    }
+    None
+  }
+}
+
+struct MemberTraversalMatcher<'a, L: Language> {
+  combined: &'a CombinedMemberExtractors<'a, L>,
+}
+
+impl<L: Language> Matcher for MemberTraversalMatcher<'_, L> {
+  fn match_node_with_env<'tree, D: Doc>(
+    &self,
+    node: Node<'tree, D>,
+    env: &mut Cow<MetaVarEnv<'tree, D>>,
+  ) -> Option<Node<'tree, D>> {
+    for extractor in self.combined.extractors_for_kind(node.kind_id()) {
+      let Some(matched) = extractor.match_node(node.clone()) else {
+        continue;
+      };
+      *env = Cow::Owned(matched.get_env().clone());
+      return Some(matched.get_node().clone());
+    }
+    None
+  }
 }
 
 fn item_kind_mapping<L: Language>(item_extractors: &[ItemExtractor<L>]) -> Vec<Vec<usize>> {

--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -1,4 +1,4 @@
-//! Combined outline extractor indexes.
+//! Combined outline extraction.
 //!
 //! Outline extraction has two matching phases. Top-level item extractors are
 //! matched during a file-wide AST traversal, so they are indexed by node kind in
@@ -6,14 +6,17 @@
 //! extractor has matched; they are grouped by parent item extractor id and then
 //! indexed sparsely by child node kind inside that parent-scoped group.
 //!
-//! This module only builds those indexes. It does not traverse the AST or
-//! perform scoped member extraction.
+//! Extraction uses explicit pre-order traversals instead of `find_all`. For each
+//! node, the node kind selects the small set of extractors that can possibly
+//! match. When a node becomes an outline item, item traversal skips that node's
+//! descendants and member extraction runs in the matched item's scope.
 
 use ast_grep_config::GlobalRules;
-use ast_grep_core::{Language, Matcher};
+use ast_grep_core::{Doc, Language, Matcher, Node, NodeMatch};
 use std::collections::HashMap;
 
 use crate::extractor::{ItemExtractor, MemberExtractor, OutlineRuleError, SerializableOutlineRule};
+use crate::model::{OutlineItem, OutlineMember};
 
 /// Runtime outline extractors organized for a shared item traversal.
 #[allow(dead_code)]
@@ -94,6 +97,44 @@ impl<L: Language> CombinedExtractors<L> {
       .into_iter()
       .flat_map(|indices| indices.iter().map(|&idx| &self.item_extractors[idx]))
   }
+
+  pub fn extract<'tree, D: Doc>(&self, root: Node<'tree, D>) -> Vec<OutlineItem<'tree>> {
+    let mut items = vec![];
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+      if let Some((extractor, node_match)) = self.match_item(node.clone()) {
+        let members = self.extract_members(extractor, node_match.get_node().clone());
+        items.push(extractor.extract(&node_match, members));
+        continue;
+      }
+      push_children(&mut stack, node);
+    }
+    items
+  }
+
+  fn match_item<'tree, D: Doc>(
+    &self,
+    node: Node<'tree, D>,
+  ) -> Option<(&ItemExtractor<L>, NodeMatch<'tree, D>)> {
+    self
+      .item_extractors_for_kind(node.kind_id())
+      .find_map(|extractor| {
+        extractor
+          .match_node(node.clone())
+          .map(|matched| (extractor, matched))
+      })
+  }
+
+  fn extract_members<'tree, D: Doc>(
+    &self,
+    item_extractor: &ItemExtractor<L>,
+    item_node: Node<'tree, D>,
+  ) -> Vec<OutlineMember<'tree>> {
+    let Some(member_extractors) = self.member_extractors_for(&item_extractor.common.rule.id) else {
+      return vec![];
+    };
+    member_extractors.extract(item_node)
+  }
 }
 
 impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
@@ -105,6 +146,36 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
       .into_iter()
       .flat_map(|indices| indices.iter().map(|&idx| &self.extractors[idx]))
   }
+
+  pub fn extract<'tree, D: Doc>(&self, item_node: Node<'tree, D>) -> Vec<OutlineMember<'tree>> {
+    let mut members = vec![];
+    let mut stack = item_node.children().collect::<Vec<_>>();
+    stack.reverse();
+    while let Some(node) = stack.pop() {
+      if let Some(member) = self.extract_member(node.clone()) {
+        members.push(member);
+        continue;
+      }
+      push_children(&mut stack, node);
+    }
+    members
+  }
+
+  fn extract_member<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<OutlineMember<'tree>> {
+    self
+      .extractors_for_kind(node.kind_id())
+      .find_map(|extractor| {
+        extractor
+          .match_node(node.clone())
+          .map(|m| extractor.extract(&m))
+      })
+  }
+}
+
+fn push_children<'tree, D: Doc>(stack: &mut Vec<Node<'tree, D>>, node: Node<'tree, D>) {
+  let mut children = node.children().collect::<Vec<_>>();
+  children.reverse();
+  stack.extend(children);
 }
 
 fn item_kind_mapping<L: Language>(item_extractors: &[ItemExtractor<L>]) -> Vec<Vec<usize>> {
@@ -145,6 +216,7 @@ fn member_mapping<L: Language>(
 mod tests {
   use super::*;
   use crate::extractor::parse_outline_rules;
+  use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_language::SupportLang;
 
   #[test]
@@ -199,5 +271,88 @@ name: other
     assert_eq!(item_extractors[0].common.rule.id, "ts-function");
     assert_eq!(identifier_members.len(), 1);
     assert_eq!(identifier_members[0].common.rule.id, "ts-member");
+  }
+
+  #[test]
+  fn extracts_items_without_visiting_matched_item_descendants() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  pattern: function $NAME() { $$$BODY }
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let combined = CombinedExtractors::try_from(extractors, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(
+      r#"
+function outer() {
+  function inner() {}
+}
+function after() {}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let names = items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["outer", "after"]);
+  }
+
+  #[test]
+  fn extracts_members_only_from_matched_parent_items() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  pattern: class $NAME { $$$BODY }
+name: $NAME
+signature: class $NAME
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+rule:
+  pattern:
+    context: class A { $NAME() { $$$BODY } }
+    selector: method_definition
+name: $NAME
+signature: $NAME()
+"#,
+    )
+    .expect("extractors should deserialize");
+    let combined = CombinedExtractors::try_from(extractors, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(
+      r#"
+class Box {
+  parse() {
+    function local() {}
+  }
+}
+function standalone() {}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].entry.name, "Box");
+    assert_eq!(items[0].members.len(), 1);
+    assert_eq!(items[0].members[0].entry.name, "parse");
+    assert_eq!(items[0].members[0].entry.signature, "parse()");
   }
 }

--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -1,763 +1,1107 @@
-/*
-Legacy reference from an earlier outline prototype.
-
-PR 1 intentionally does not compile or ship builtin outline rules. Keep this
-draft nearby as design input for the later extraction-rule and builtin-rule PRs.
+//! Bundled outline extractor rules.
+//!
+//! Built-ins use the same YAML schema as user-provided `--outline-rules`
+//! files. Keeping them data-driven preserves the same loading and execution path
+//! for built-in and custom languages.
 
 pub const DEFAULT_OUTLINE_RULES: &str = r#"
-extractors:
-  - id: rust-use
-    language: Rust
-    kind: module
-    role: import
-    name: text
-    exported: textPrefix:pub
-    rule: { kind: use_declaration }
-  - id: rust-mod
-    language: Rust
-    kind: module
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: mod_item }
-  - id: rust-function
-    language: Rust
-    kind: function
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: function_item }
-  - id: rust-struct
-    language: Rust
-    kind: struct
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: struct_item }
-  - id: rust-enum
-    language: Rust
-    kind: enum
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: enum_item }
-  - id: rust-trait
-    language: Rust
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: trait_item }
-  - id: rust-type
-    language: Rust
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: type_item }
-  - id: rust-const
-    language: Rust
-    kind: constant
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: const_item }
-  - id: rust-static
-    language: Rust
-    kind: variable
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: static_item }
-  - id: rust-impl
-    language: Rust
-    kind: object
-    role: definition
-    name: auto
-    exported: never
-    rule: { kind: impl_item }
-  - id: rust-field
-    language: Rust
-    kind: field
-    role: definition
-    name: field:name
-    exported: textPrefix:pub
-    rule: { kind: field_declaration }
-  - id: rust-enum-variant
-    language: Rust
-    kind: enumMember
-    role: definition
-    name: auto
-    exported: never
-    rule: { kind: enum_variant }
-
-  - id: ts-import
-    language: TypeScript
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_statement }
-  - id: ts-re-export
-    language: TypeScript
-    kind: module
-    role: export
-    name: text
-    exported: always
-    rule:
-      all:
-        - kind: export_statement
-        - regex: '^\s*export\s+(\{|\*|type\s+\{)'
-  - id: ts-function
-    language: TypeScript
-    kind: function
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: function_declaration }
-  - id: ts-class
-    language: TypeScript
-    kind: class
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: class_declaration
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: ts-interface
-    language: TypeScript
-    kind: interface
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: interface_declaration }
-  - id: ts-type
-    language: TypeScript
-    kind: interface
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: type_alias_declaration }
-  - id: ts-method-signature
-    language: TypeScript
-    kind: method
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: method_signature
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: ts-property-signature
-    language: TypeScript
-    kind: field
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: property_signature
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: ts-method
-    language: TypeScript
-    kind: method
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: method_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: ts-field
-    language: TypeScript
-    kind: field
-    role: definition
-    name: auto
-    exported: never
-    rule:
-      all:
-        - kind: public_field_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: ts-const
-    language: TypeScript
-    kind: constant
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-        - not:
-            has:
-              kind: arrow_function
-              stopBy: end
-  - id: ts-const-function
-    language: TypeScript
-    kind: function
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - has:
-            kind: arrow_function
-            stopBy: end
-
-  - id: tsx-import
-    language: Tsx
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_statement }
-  - id: tsx-re-export
-    language: Tsx
-    kind: module
-    role: export
-    name: text
-    exported: always
-    rule:
-      all:
-        - kind: export_statement
-        - regex: '^\s*export\s+(\{|\*|type\s+\{)'
-  - id: tsx-function
-    language: Tsx
-    kind: function
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: function_declaration }
-  - id: tsx-class
-    language: Tsx
-    kind: class
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: class_declaration
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: tsx-interface
-    language: Tsx
-    kind: interface
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: interface_declaration }
-  - id: tsx-type
-    language: Tsx
-    kind: interface
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: type_alias_declaration }
-  - id: tsx-method-signature
-    language: Tsx
-    kind: method
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: method_signature
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: tsx-property-signature
-    language: Tsx
-    kind: field
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: property_signature
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: tsx-method
-    language: Tsx
-    kind: method
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: method_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: tsx-field
-    language: Tsx
-    kind: field
-    role: definition
-    name: auto
-    exported: never
-    rule:
-      all:
-        - kind: public_field_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: tsx-const
-    language: Tsx
-    kind: constant
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-        - not:
-            has:
-              kind: arrow_function
-              stopBy: end
-  - id: tsx-const-function
-    language: Tsx
-    kind: function
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - has:
-            kind: arrow_function
-            stopBy: end
-
-  - id: js-import
-    language: JavaScript
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_statement }
-  - id: js-re-export
-    language: JavaScript
-    kind: module
-    role: export
-    name: text
-    exported: always
-    rule:
-      all:
-        - kind: export_statement
-        - regex: '^\s*export\s+(\{|\*)'
-  - id: js-function
-    language: JavaScript
-    kind: function
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule: { kind: function_declaration }
-  - id: js-class
-    language: JavaScript
-    kind: class
-    role: definition
-    name: field:name
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: class_declaration
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: js-method
-    language: JavaScript
-    kind: method
-    role: definition
-    name: field:name
-    exported: never
-    rule:
-      all:
-        - kind: method_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: js-field
-    language: JavaScript
-    kind: field
-    role: definition
-    name: auto
-    exported: never
-    rule:
-      all:
-        - kind: public_field_definition
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-  - id: js-const
-    language: JavaScript
-    kind: constant
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - not:
-            inside:
-              kind: statement_block
-              stopBy: end
-        - not:
-            has:
-              kind: arrow_function
-              stopBy: end
-  - id: js-const-function
-    language: JavaScript
-    kind: function
-    role: definition
-    name: auto
-    exported: ancestorKind:export_statement
-    rule:
-      all:
-        - kind: lexical_declaration
-        - regex: '^\s*const\b'
-        - has:
-            kind: arrow_function
-            stopBy: end
-
-  - id: py-import
-    language: Python
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_statement }
-  - id: py-from-import
-    language: Python
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_from_statement }
-  - id: py-function
-    language: Python
-    kind: function
-    role: definition
-    name: field:name
-    exported: never
-    rule: { kind: function_definition }
-  - id: py-class
-    language: Python
-    kind: class
-    role: definition
-    name: field:name
-    exported: never
-    rule: { kind: class_definition }
-
-  - id: go-package
-    language: Go
-    kind: package
-    role: definition
-    name: auto
-    exported: never
-    rule: { kind: package_clause }
-  - id: go-import
-    language: Go
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_declaration }
-  - id: go-function
-    language: Go
-    kind: function
-    role: definition
-    name: field:name
-    exported: nameUppercase
-    rule: { kind: function_declaration }
-  - id: go-method
-    language: Go
-    kind: method
-    role: definition
-    name: field:name
-    exported: nameUppercase
-    rule: { kind: method_declaration }
-  - id: go-type
-    language: Go
-    kind: interface
-    role: definition
-    name: auto
-    exported: nameUppercase
-    rule: { kind: type_declaration }
-  - id: go-const
-    language: Go
-    kind: constant
-    role: definition
-    name: auto
-    exported: nameUppercase
-    rule: { kind: const_declaration }
-  - id: go-var
-    language: Go
-    kind: variable
-    role: definition
-    name: auto
-    exported: nameUppercase
-    rule: { kind: var_declaration }
-
-  - id: java-package
-    language: Java
-    kind: package
-    role: definition
-    name: text
-    exported: never
-    rule: { kind: package_declaration }
-  - id: java-import
-    language: Java
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_declaration }
-  - id: java-class
-    language: Java
-    kind: class
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: class_declaration }
-  - id: java-record
-    language: Java
-    kind: struct
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: record_declaration }
-  - id: java-interface
-    language: Java
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: interface_declaration }
-  - id: java-annotation
-    language: Java
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: annotation_type_declaration }
-  - id: java-enum
-    language: Java
-    kind: enum
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: enum_declaration }
-  - id: java-method
-    language: Java
-    kind: method
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: method_declaration }
-  - id: java-constructor
-    language: Java
-    kind: constructor
-    role: definition
-    name: field:name
-    exported: textPrefix:public
-    rule: { kind: constructor_declaration }
-  - id: java-public-static-final-constant
-    language: Java
-    kind: constant
-    role: definition
-    name: $NAME
-    exported: always
-    rule:
-      pattern:
-        context: class A { public static final $T $NAME = $V; }
-        selector: field_declaration
-
-  - id: kotlin-import
-    language: Kotlin
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_header }
-  - id: kotlin-class
-    language: Kotlin
-    kind: class
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule:
-      all:
-        - kind: class_declaration
-        - regex: '^\s*(public\s+)?class\b'
-  - id: kotlin-interface
-    language: Kotlin
-    kind: interface
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule:
-      all:
-        - kind: class_declaration
-        - regex: '^\s*(public\s+)?interface\b'
-  - id: kotlin-object
-    language: Kotlin
-    kind: object
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule: { kind: object_declaration }
-  - id: kotlin-function
-    language: Kotlin
-    kind: function
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule:
-      all:
-        - kind: function_declaration
-        - not:
-            inside:
-              kind: function_body
-              stopBy: end
-  - id: kotlin-property
-    language: Kotlin
-    kind: variable
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule:
-      all:
-        - kind: property_declaration
-        - not:
-            inside:
-              kind: function_body
-              stopBy: end
-  - id: kotlin-typealias
-    language: Kotlin
-    kind: interface
-    role: definition
-    name: auto
-    exported: notTextPrefixAny:private,internal
-    rule: { kind: type_alias }
-
-  - id: swift-import
-    language: Swift
-    kind: module
-    role: import
-    name: text
-    exported: never
-    rule: { kind: import_declaration }
-  - id: swift-class
-    language: Swift
-    kind: class
-    role: definition
-    name: firstNameLike
-    exported: textPrefixAny:public,open
-    rule:
-      any:
-        - all:
-            - kind: class_declaration
-            - regex: '^\s*(public\s+|open\s+)?class\b'
-        - all:
-            - kind: function_declaration
-            - regex: '^\s*(public\s+|open\s+)?class\b'
-  - id: swift-struct
-    language: Swift
-    kind: struct
-    role: definition
-    name: firstNameLike
-    exported: textPrefix:public
-    rule:
-      all:
-        - kind: class_declaration
-        - regex: '^\s*(public\s+)?struct\b'
-  - id: swift-enum
-    language: Swift
-    kind: enum
-    role: definition
-    name: firstNameLike
-    exported: textPrefix:public
-    rule:
-      all:
-        - kind: class_declaration
-        - regex: '^\s*(public\s+)?enum\b'
-  - id: swift-protocol
-    language: Swift
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefixAny:public,open
-    rule: { kind: protocol_declaration }
-  - id: swift-function
-    language: Swift
-    kind: function
-    role: definition
-    name: field:name
-    exported: textPrefixAny:public,open
-    rule:
-      all:
-        - kind: function_declaration
-        - regex: '^\s*(@[A-Za-z_][A-Za-z0-9_]*(\([^)]*\))?\s+)*(public\s+|open\s+|internal\s+|fileprivate\s+|private\s+)?(static\s+|class\s+|mutating\s+|nonmutating\s+|override\s+|final\s+)*func\b'
-        - not:
-            inside:
-              kind: function_body
-              stopBy: end
-  - id: swift-property
-    language: Swift
-    kind: variable
-    role: definition
-    name: field:name
-    exported: textPrefixAny:public,open
-    rule:
-      all:
-        - kind: property_declaration
-        - not:
-            inside:
-              kind: function_body
-              stopBy: end
-  - id: swift-typealias
-    language: Swift
-    kind: interface
-    role: definition
-    name: field:name
-    exported: textPrefixAny:public,open
-    rule: { kind: typealias_declaration }
+id: rust-use-public
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'pub use $PATH;'
+name: '$PATH'
+isImport: true
+isExported: true
+---
+id: rust-use
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'use $PATH;'
+name: '$PATH'
+isImport: true
+isExported: false
+---
+id: rust-mod-public
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'pub mod $NAME;'
+name: '$NAME'
+signature: 'pub mod $NAME'
+isExported: true
+---
+id: rust-mod
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'mod $NAME;'
+name: '$NAME'
+signature: 'mod $NAME'
+isExported: false
+---
+id: rust-mod-inline-public
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'pub mod $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'pub mod $NAME'
+isExported: true
+---
+id: rust-mod-inline
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: 'mod $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'mod $NAME'
+isExported: false
+---
+id: rust-function-visible
+language: Rust
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: function_item
+    - regex: '^pub\('
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: true
+---
+id: rust-function-public-generic-return-where
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isExported: true
+---
+id: rust-function-generic-return-where
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isExported: false
+---
+id: rust-function-public-generic-where
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
+isExported: true
+---
+id: rust-function-generic-where
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
+isExported: false
+---
+id: rust-function-public-generic-return
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isExported: true
+---
+id: rust-function-generic-return
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isExported: false
+---
+id: rust-function-public-generic
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
+isExported: true
+---
+id: rust-function-generic
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
+isExported: false
+---
+id: rust-function-public
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME($$$ARGS) { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS)'
+isExported: true
+---
+id: rust-function
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME($$$ARGS) { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS)'
+isExported: false
+---
+id: rust-function-public-return
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'pub fn $NAME($$$ARGS) -> $RET { $$$BODY }'
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS) -> $RET'
+isExported: true
+---
+id: rust-function-return
+language: Rust
+role: item
+symbolType: function
+rule:
+  pattern: 'fn $NAME($$$ARGS) -> $RET { $$$BODY }'
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS) -> $RET'
+isExported: false
+---
+id: rust-struct-visible
+language: Rust
+role: item
+symbolType: struct
+rule:
+  all:
+    - kind: struct_item
+    - regex: '^pub\('
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: true
+---
+id: rust-struct-public-any
+language: Rust
+role: item
+symbolType: struct
+rule:
+  all:
+    - kind: struct_item
+    - regex: '^pub\s+struct'
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: true
+---
+id: rust-struct-any
+language: Rust
+role: item
+symbolType: struct
+rule:
+  all:
+    - kind: struct_item
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: false
+---
+id: rust-struct-public
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: 'pub struct $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'pub struct $NAME'
+isExported: true
+---
+id: rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  pattern: 'struct $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'struct $NAME'
+isExported: false
+---
+id: rust-enum-visible
+language: Rust
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: enum_item
+    - regex: '^pub\('
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: true
+---
+id: rust-enum-public-any
+language: Rust
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: enum_item
+    - regex: '^pub\s+enum'
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: true
+---
+id: rust-enum-any
+language: Rust
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: enum_item
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isExported: false
+---
+id: rust-enum-public
+language: Rust
+role: item
+symbolType: enum
+rule:
+  pattern: 'pub enum $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'pub enum $NAME'
+isExported: true
+---
+id: rust-enum
+language: Rust
+role: item
+symbolType: enum
+rule:
+  pattern: 'enum $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'enum $NAME'
+isExported: false
+---
+id: rust-trait-public
+language: Rust
+role: item
+symbolType: interface
+rule:
+  pattern: 'pub trait $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'pub trait $NAME'
+isExported: true
+---
+id: rust-trait
+language: Rust
+role: item
+symbolType: interface
+rule:
+  pattern: 'trait $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'trait $NAME'
+isExported: false
+---
+id: rust-impl-trait-generic
+language: Rust
+role: item
+symbolType: object
+rule:
+  pattern: 'impl<$$$GENERICS> $TRAIT for $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'impl<$$$GENERICS> $TRAIT for $NAME'
+isExported: false
+---
+id: rust-impl-trait
+language: Rust
+role: item
+symbolType: object
+rule:
+  pattern: 'impl $TRAIT for $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'impl $TRAIT for $NAME'
+isExported: false
+---
+id: rust-impl-generic
+language: Rust
+role: item
+symbolType: object
+rule:
+  pattern: 'impl<$$$GENERICS> $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'impl<$$$GENERICS> $NAME'
+isExported: false
+---
+id: rust-impl
+language: Rust
+role: item
+symbolType: object
+rule:
+  pattern: 'impl $NAME { $$$BODY }'
+name: '$NAME'
+signature: 'impl $NAME'
+isExported: false
+---
+id: rust-const-public
+language: Rust
+role: item
+symbolType: constant
+rule:
+  pattern: 'pub const $NAME: $TYPE = $VALUE;'
+name: '$NAME'
+signature: 'pub const $NAME: $TYPE'
+isExported: true
+---
+id: rust-const
+language: Rust
+role: item
+symbolType: constant
+rule:
+  pattern: 'const $NAME: $TYPE = $VALUE;'
+name: '$NAME'
+signature: 'const $NAME: $TYPE'
+isExported: false
+---
+id: rust-static-public
+language: Rust
+role: item
+symbolType: variable
+rule:
+  pattern: 'pub static $NAME: $TYPE = $VALUE;'
+name: '$NAME'
+signature: 'pub static $NAME: $TYPE'
+isExported: true
+---
+id: rust-static
+language: Rust
+role: item
+symbolType: variable
+rule:
+  pattern: 'static $NAME: $TYPE = $VALUE;'
+name: '$NAME'
+signature: 'static $NAME: $TYPE'
+isExported: false
+---
+id: rust-field
+language: Rust
+role: member
+parentRuleIds: [rust-struct-visible, rust-struct-public-any, rust-struct-any, rust-struct-public, rust-struct]
+symbolType: field
+rule:
+  kind: field_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: '$NAME'
+isPublic:
+  regex: '^pub\b'
+---
+id: rust-enum-variant
+language: Rust
+role: member
+parentRuleIds: [rust-enum-visible, rust-enum-public-any, rust-enum-any, rust-enum-public, rust-enum]
+symbolType: enumMember
+rule:
+  kind: enum_variant
+  has:
+    field: name
+    pattern: $NAME
+name: '$NAME'
+signature: '$NAME'
+isPublic: true
+---
+id: rust-mod-member-function-public
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: function
+rule:
+  pattern:
+    context: 'mod A { pub fn $NAME($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS)'
+isPublic: true
+---
+id: rust-mod-member-function
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: function
+rule:
+  pattern:
+    context: 'mod A { fn $NAME($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS)'
+isPublic: false
+---
+id: rust-mod-member-function-public-return
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: function
+rule:
+  pattern:
+    context: 'mod A { pub fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS) -> $RET'
+isPublic: true
+---
+id: rust-mod-member-function-return
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: function
+rule:
+  pattern:
+    context: 'mod A { fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS) -> $RET'
+isPublic: false
+---
+id: rust-mod-member-struct-public
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: struct
+rule:
+  pattern:
+    context: 'mod A { pub struct $NAME { $$$BODY } }'
+    selector: struct_item
+name: '$NAME'
+signature: 'pub struct $NAME'
+isPublic: true
+---
+id: rust-mod-member-struct
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: struct
+rule:
+  pattern:
+    context: 'mod A { struct $NAME { $$$BODY } }'
+    selector: struct_item
+name: '$NAME'
+signature: 'struct $NAME'
+isPublic: false
+---
+id: rust-mod-member-enum-public
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: enum
+rule:
+  pattern:
+    context: 'mod A { pub enum $NAME { $$$BODY } }'
+    selector: enum_item
+name: '$NAME'
+signature: 'pub enum $NAME'
+isPublic: true
+---
+id: rust-mod-member-enum
+language: Rust
+role: member
+parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+symbolType: enum
+rule:
+  pattern:
+    context: 'mod A { enum $NAME { $$$BODY } }'
+    selector: enum_item
+name: '$NAME'
+signature: 'enum $NAME'
+isPublic: false
+---
+id: rust-method-public
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS)'
+isPublic: true
+---
+id: rust-method
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS)'
+isPublic: false
+---
+id: rust-method-public-return
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME($$$ARGS) -> $RET'
+isPublic: true
+---
+id: rust-method-return
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME($$$ARGS) -> $RET'
+isPublic: false
+---
+id: rust-method-visible
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  all:
+    - kind: function_item
+    - regex: '^pub\('
+    - has:
+        field: name
+        pattern: $NAME
+name: '$NAME'
+isPublic: true
+---
+id: rust-method-public-generic-return-where
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isPublic: true
+---
+id: rust-method-generic-return-where
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isPublic: false
+---
+id: rust-method-public-generic-where
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
+isPublic: true
+---
+id: rust-method-generic-where
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
+isPublic: false
+---
+id: rust-method-public-generic
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
+isPublic: true
+---
+id: rust-method-generic
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
+isPublic: false
+---
+id: rust-method-public-generic-return
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isPublic: true
+---
+id: rust-method-generic-return
+language: Rust
+role: member
+parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+symbolType: method
+rule:
+  pattern:
+    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY } }'
+    selector: function_item
+name: '$NAME'
+signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+isPublic: false
 "#;
-*/
+
+#[cfg(test)]
+mod tests {
+  use super::DEFAULT_OUTLINE_RULES;
+  use crate::{
+    combined_extractor::CombinedExtractors, extractor::parse_outline_rules, model::SymbolType,
+  };
+  use ast_grep_core::tree_sitter::LanguageExt;
+  use ast_grep_language::SupportLang;
+
+  fn rust_combined() -> CombinedExtractors<SupportLang> {
+    let rules = parse_outline_rules::<SupportLang>(DEFAULT_OUTLINE_RULES)
+      .expect("builtin outline rules should deserialize")
+      .into_iter()
+      .filter(|rule| rule.common().language == SupportLang::Rust)
+      .collect::<Vec<_>>();
+    CombinedExtractors::try_from(rules, &Default::default()).expect("rules should compile")
+  }
+
+  #[test]
+  fn rust_builtin_rules_extract_file_outline() {
+    let combined = rust_combined();
+    let grep = SupportLang::Rust.ast_grep(
+      r#"
+pub use crate::api::Parser;
+use std::fmt;
+
+pub struct Config {
+  pub name: String,
+  enabled: bool,
+}
+
+enum Mode {
+  Fast,
+  Slow,
+  RuleConfig(#[from] RuleConfigError),
+  Predicate(#[from] RuleSerializeError),
+  Template(#[from] TemplateFixError),
+  Complex {
+    /// nth-child syntax
+    position: NthChildSimple,
+    /// select the nth node that matches the rule, like CSS's of syntax
+    of_rule: Option<Box<SerializableRule>>,
+    /// matches from the end instead like CSS's nth-last-child
+    #[serde(default)]
+    reverse: bool,
+  },
+}
+
+impl Config {
+  pub fn new(name: String) -> Self {
+    Self { name, enabled: true }
+  }
+
+  fn enabled(&self) -> bool {
+    self.enabled
+  }
+}
+
+fn helper() {}
+
+mod tests {
+  fn nested_helper() {}
+
+  #[test]
+  fn parses_config() {}
+}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let names = items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      names,
+      vec![
+        "crate::api::Parser",
+        "std::fmt",
+        "Config",
+        "Mode",
+        "Config",
+        "helper",
+        "tests"
+      ]
+    );
+
+    let config = items
+      .iter()
+      .find(|item| item.entry.name == "Config" && item.entry.symbol_type == SymbolType::Struct)
+      .expect("Config struct should be extracted");
+    let fields = config
+      .members
+      .iter()
+      .map(|member| (member.entry.name.as_ref(), member.is_public))
+      .collect::<Vec<_>>();
+    assert_eq!(fields, vec![("name", true), ("enabled", false)]);
+
+    let mode = items
+      .iter()
+      .find(|item| item.entry.name == "Mode")
+      .expect("Mode enum should be extracted");
+    let variants = mode
+      .members
+      .iter()
+      .map(|member| (member.entry.name.as_ref(), member.entry.signature.as_ref()))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      variants,
+      vec![
+        ("Fast", "Fast"),
+        ("Slow", "Slow"),
+        ("RuleConfig", "RuleConfig"),
+        ("Predicate", "Predicate"),
+        ("Template", "Template"),
+        ("Complex", "Complex")
+      ]
+    );
+
+    let implementation = items
+      .iter()
+      .find(|item| item.entry.name == "Config" && item.entry.symbol_type == SymbolType::Object)
+      .expect("Config impl should be extracted");
+    let methods = implementation
+      .members
+      .iter()
+      .map(|member| (member.entry.name.as_ref(), member.is_public))
+      .collect::<Vec<_>>();
+    assert_eq!(methods, vec![("new", true), ("enabled", false)]);
+
+    let tests = items
+      .iter()
+      .find(|item| item.entry.name == "tests")
+      .expect("inline test module should be extracted");
+    let members = tests
+      .members
+      .iter()
+      .map(|member| (member.entry.symbol_type, member.entry.name.as_ref()))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      members,
+      vec![
+        (SymbolType::Function, "nested_helper"),
+        (SymbolType::Function, "parses_config")
+      ]
+    );
+  }
+
+  #[test]
+  fn rust_builtin_rules_scope_inline_modules_and_impls() {
+    let combined = rust_combined();
+    let grep = SupportLang::Rust.ast_grep(
+      r#"
+mod tests {
+  pub fn public_case() {}
+  fn helper() -> bool { false }
+  struct Fixture {}
+  enum Mode { A }
+}
+
+trait Service {}
+
+impl Service for Config {
+  fn run(&self) {}
+}
+
+impl<T> Box<T> {
+  pub fn value(&self) -> &T { todo!() }
+}
+
+impl Rewrite<String> {
+  pub fn parse<L: Language>(&self, lang: &L) -> Result<Rewrite<MetaVariable>, TransformError> {
+    todo!()
+  }
+}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let names = items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      names,
+      vec!["tests", "Service", "Config", "Box<T>", "Rewrite<String>"]
+    );
+
+    let tests = items
+      .iter()
+      .find(|item| item.entry.name == "tests")
+      .expect("inline test module should be extracted");
+    let module_members = tests
+      .members
+      .iter()
+      .map(|member| (member.entry.symbol_type, member.entry.name.as_ref()))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      module_members,
+      vec![
+        (SymbolType::Function, "public_case"),
+        (SymbolType::Function, "helper"),
+        (SymbolType::Struct, "Fixture"),
+        (SymbolType::Enum, "Mode")
+      ]
+    );
+
+    let trait_impl = items
+      .iter()
+      .find(|item| item.entry.signature == "impl Service for Config")
+      .expect("trait impl should be extracted");
+    let trait_impl_methods = trait_impl
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>();
+    assert_eq!(trait_impl_methods, vec!["run"]);
+
+    let generic_impl = items
+      .iter()
+      .find(|item| item.entry.signature == "impl<T> Box<T>")
+      .expect("generic impl should be extracted");
+    let generic_impl_methods = generic_impl
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>();
+    assert_eq!(generic_impl_methods, vec!["value"]);
+
+    let rewrite_impl = items
+      .iter()
+      .find(|item| item.entry.signature == "impl Rewrite<String>")
+      .expect("impl with type arguments should be extracted");
+    let rewrite_methods = rewrite_impl
+      .members
+      .iter()
+      .map(|member| {
+        (
+          member.entry.name.as_ref(),
+          member.entry.signature.as_ref(),
+          member.is_public,
+        )
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      rewrite_methods,
+      vec![(
+        "parse",
+        "pub fn parse<L: Language>(&self, lang: &L) -> Result<Rewrite<MetaVariable>, TransformError>",
+        true
+      )]
+    );
+  }
+
+  #[test]
+  fn rust_builtin_rules_extract_tokio_declaration_shapes() {
+    let combined = rust_combined();
+    let grep = SupportLang::Rust.ast_grep(
+      r#"
+pub(super) struct Cell<T: Future, S> {
+  pub(super) header: Header,
+  core: Core<T, S>,
+}
+
+pub(crate) struct Launch(Vec<Arc<Worker>>);
+
+struct Local<T>(T);
+
+pub(super) enum Scheduler<T> {
+  CurrentThread(T),
+  MultiThread,
+}
+
+enum Stage<T: Future> {
+  Running(T),
+  Finished,
+}
+
+pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+where
+  F: Future + Send + 'static,
+  F::Output: Send + 'static,
+{
+  todo!()
+}
+
+pub(crate) fn block_in_place<F, R>(f: F) -> R
+where
+  F: FnOnce() -> R,
+{
+  f()
+}
+
+fn with_current<R>(f: impl FnOnce(Option<&Context>) -> R) -> R {
+  f(None)
+}
+
+impl<T: Future> CoreStage<T> {
+  pub(super) fn with_mut<R>(&self, f: impl FnOnce(*mut Stage<T>) -> R) -> R {
+    todo!()
+  }
+
+  fn with_core<F, R>(&self, f: F) -> R
+  where
+    F: FnOnce(&mut Core) -> R,
+  {
+    todo!()
+  }
+}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let item_shapes = items
+      .iter()
+      .map(|item| {
+        (
+          item.entry.symbol_type,
+          item.entry.name.as_ref(),
+          item.is_exported,
+        )
+      })
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      item_shapes,
+      vec![
+        (SymbolType::Struct, "Cell", true),
+        (SymbolType::Struct, "Launch", true),
+        (SymbolType::Struct, "Local", false),
+        (SymbolType::Enum, "Scheduler", true),
+        (SymbolType::Enum, "Stage", false),
+        (SymbolType::Function, "spawn", true),
+        (SymbolType::Function, "block_in_place", true),
+        (SymbolType::Function, "with_current", false),
+        (SymbolType::Object, "CoreStage<T>", false),
+      ]
+    );
+
+    let scheduler = items
+      .iter()
+      .find(|item| item.entry.name == "Scheduler")
+      .expect("restricted visibility generic enum should be extracted");
+    let variants = scheduler
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>();
+    assert_eq!(variants, vec!["CurrentThread", "MultiThread"]);
+
+    let implementation = items
+      .iter()
+      .find(|item| item.entry.name == "CoreStage<T>")
+      .expect("generic impl should be extracted");
+    let methods = implementation
+      .members
+      .iter()
+      .map(|member| {
+        (
+          member.entry.name.as_ref(),
+          member.entry.signature.as_ref(),
+          member.is_public,
+        )
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      methods,
+      vec![
+        (
+          "with_mut",
+          "pub(super) fn with_mut<R>(&self, f: impl FnOnce(*mut Stage<T>) -> R) -> R {",
+          true
+        ),
+        ("with_core", "fn with_core<F, R>(&self, f: F) -> R", false),
+      ]
+    );
+  }
+}

--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -4,7 +4,8 @@
 //! files. Keeping them data-driven preserves the same loading and execution path
 //! for built-in and custom languages.
 
-pub const DEFAULT_OUTLINE_RULES: &str = r#"
+pub const DEFAULT_OUTLINE_RULES: &str = concat!(
+  r#"
 id: rust-use-public
 language: Rust
 role: item
@@ -723,7 +724,20 @@ rule:
 name: '$NAME'
 signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
 isPublic: false
-"#;
+"#,
+  "\n---\n",
+  include_str!("default_rules/typescript.yml"),
+  "\n---\n",
+  include_str!("default_rules/python.yml"),
+  "\n---\n",
+  include_str!("default_rules/go.yml"),
+  "\n---\n",
+  include_str!("default_rules/kotlin.yml"),
+  "\n---\n",
+  include_str!("default_rules/java.yml"),
+  "\n---\n",
+  include_str!("default_rules/swift.yml"),
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/outline/src/default_rules/go.yml
+++ b/crates/outline/src/default_rules/go.yml
@@ -1,0 +1,131 @@
+id: go-import
+language: Go
+role: item
+symbolType: module
+rule:
+  kind: import_spec
+  has:
+    pattern: '"$PATH"'
+name: $PATH
+isImport: true
+isExported: false
+---
+id: go-function
+language: Go
+role: item
+symbolType: function
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+---
+id: go-method
+language: Go
+role: item
+symbolType: method
+rule:
+  kind: method_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+---
+id: go-struct-type
+language: Go
+role: item
+symbolType: struct
+rule:
+  all:
+    - kind: type_spec
+    - has:
+        field: name
+        pattern: $NAME
+    - has:
+        kind: struct_type
+name: $NAME
+---
+id: go-interface-type
+language: Go
+role: item
+symbolType: interface
+rule:
+  all:
+    - kind: type_spec
+    - has:
+        field: name
+        pattern: $NAME
+    - has:
+        kind: interface_type
+name: $NAME
+---
+id: go-struct-field
+language: Go
+role: member
+parentRuleIds: [go-struct-type]
+symbolType: field
+rule:
+  kind: field_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  has:
+    field: name
+    regex: '^[A-Z]'
+---
+id: go-interface-method
+language: Go
+role: member
+parentRuleIds: [go-interface-type]
+symbolType: method
+rule:
+  kind: method_elem
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  has:
+    field: name
+    regex: '^[A-Z]'
+---
+id: go-type
+language: Go
+role: item
+symbolType: typeParameter
+rule:
+  all:
+    - kind: type_spec
+    - has:
+        field: name
+        pattern: $NAME
+    - not:
+        has:
+          kind: struct_type
+    - not:
+        has:
+          kind: interface_type
+name: $NAME
+---
+id: go-const
+language: Go
+role: item
+symbolType: constant
+rule:
+  kind: const_spec
+  has:
+    pattern: $NAME
+name: $NAME
+---
+id: go-var
+language: Go
+role: item
+symbolType: variable
+rule:
+  kind: var_spec
+  has:
+    pattern: $NAME
+name: $NAME

--- a/crates/outline/src/default_rules/java.yml
+++ b/crates/outline/src/default_rules/java.yml
@@ -1,0 +1,112 @@
+id: java-static-import
+language: Java
+role: item
+symbolType: module
+rule:
+  pattern: import static $PATH;
+name: $PATH
+signature: import static $PATH
+isImport: true
+isExported: false
+---
+id: java-import
+language: Java
+role: item
+symbolType: module
+rule:
+  pattern: import $PATH;
+name: $PATH
+signature: import $PATH
+isImport: true
+isExported: false
+---
+id: java-interface
+language: Java
+role: item
+symbolType: interface
+rule:
+  all:
+    - kind: interface_declaration
+    - has:
+        field: name
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^public\b'
+---
+id: java-enum
+language: Java
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: enum_declaration
+    - has:
+        field: name
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^public\b'
+---
+id: java-class
+language: Java
+role: item
+symbolType: class
+rule:
+  all:
+    - kind: class_declaration
+    - has:
+        field: name
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^public\b'
+---
+id: java-member-method
+language: Java
+role: member
+parentRuleIds: [java-interface, java-enum, java-class]
+symbolType: method
+rule:
+  all:
+    - kind: method_declaration
+    - has:
+        field: name
+        pattern: $NAME
+name: $NAME
+isPublic:
+  regex: '^public\b'
+---
+id: java-member-constructor
+language: Java
+role: member
+parentRuleIds: [java-enum, java-class]
+symbolType: constructor
+rule:
+  all:
+    - kind: constructor_declaration
+    - has:
+        field: name
+        pattern: $NAME
+name: $NAME
+isPublic:
+  regex: '^public\b'
+---
+id: java-member-field
+language: Java
+role: member
+parentRuleIds: [java-interface, java-enum, java-class]
+symbolType: field
+rule:
+  all:
+    - kind: field_declaration
+    - has:
+        field: declarator
+        has:
+          field: name
+          pattern: $NAME
+    - not:
+        regex: '^(private|protected|final)\b'
+name: $NAME
+isPublic:
+  regex: '^public\b'

--- a/crates/outline/src/default_rules/kotlin.yml
+++ b/crates/outline/src/default_rules/kotlin.yml
@@ -1,0 +1,243 @@
+id: kotlin-import-alias
+language: Kotlin
+role: item
+symbolType: module
+rule:
+  pattern: import $PATH as $ALIAS
+name: $ALIAS
+signature: import $PATH as $ALIAS
+isImport: true
+isExported: false
+---
+id: kotlin-import
+language: Kotlin
+role: item
+symbolType: module
+rule:
+  pattern: import $PATH
+name: $PATH
+signature: import $PATH
+isImport: true
+isExported: false
+---
+id: kotlin-enum
+language: Kotlin
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?enum\s+class\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-interface
+language: Kotlin
+role: item
+symbolType: interface
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?interface\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-object
+language: Kotlin
+role: item
+symbolType: object
+rule:
+  all:
+    - kind: object_declaration
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-class
+language: Kotlin
+role: item
+symbolType: class
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?(data\s+)?class\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-function
+language: Kotlin
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        kind: simple_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-nested-enum
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: enum
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?enum\s+class\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-nested-interface
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: interface
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?interface\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-nested-object
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: object
+rule:
+  all:
+    - kind: object_declaration
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-nested-class
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: class
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|private\s+|internal\s+)?(data\s+)?class\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-companion-object
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: object
+rule:
+  all:
+    - kind: companion_object
+    - inside:
+        kind: class_body
+name: companion object
+signature: companion object
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-constructor
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-class]
+symbolType: constructor
+rule:
+  all:
+    - kind: secondary_constructor
+    - inside:
+        kind: class_body
+name: constructor
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-function
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-enum, kotlin-interface, kotlin-object, kotlin-class]
+symbolType: method
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        kind: simple_identifier
+        pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'
+---
+id: kotlin-member-property
+language: Kotlin
+role: member
+parentRuleIds: [kotlin-interface, kotlin-object, kotlin-class]
+symbolType: property
+rule:
+  all:
+    - kind: property_declaration
+    - has:
+        kind: variable_declaration
+        has:
+          kind: simple_identifier
+          pattern: $NAME
+    - inside:
+        kind: class_body
+name: $NAME
+isPublic:
+  not:
+    regex: '^\s*(?:@[^\n]+\s*)*(private|internal)\b'

--- a/crates/outline/src/default_rules/python.yml
+++ b/crates/outline/src/default_rules/python.yml
@@ -1,0 +1,146 @@
+id: python-import
+language: Python
+role: item
+symbolType: module
+rule:
+  pattern: import $NAME
+name: $NAME
+isImport: true
+isExported: false
+---
+id: python-import-from
+language: Python
+role: item
+symbolType: module
+rule:
+  pattern: from $MODULE import $NAME
+name: $MODULE.$NAME
+isImport: true
+isExported: false
+---
+id: python-class
+language: Python
+role: item
+symbolType: class
+rule:
+  kind: class_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+---
+id: python-module-constant
+language: Python
+role: item
+symbolType: constant
+rule:
+  all:
+    - kind: assignment
+    - has:
+        field: left
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: left
+        regex: '^[A-Z_][A-Z0-9_]*$'
+    - not:
+        any:
+          - inside:
+              kind: class_definition
+              stopBy: end
+          - inside:
+              kind: function_definition
+              stopBy: end
+name: $NAME
+---
+id: python-module-variable
+language: Python
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: assignment
+    - has:
+        field: left
+        kind: identifier
+        pattern: $NAME
+    - not:
+        has:
+          field: left
+          regex: '^[A-Z_][A-Z0-9_]*$'
+    - not:
+        any:
+          - inside:
+              kind: class_definition
+              stopBy: end
+          - inside:
+              kind: function_definition
+              stopBy: end
+name: $NAME
+---
+id: python-async-function
+language: Python
+role: item
+symbolType: function
+rule:
+  pattern: 'async def $NAME($$$ARGS): $$$BODY'
+name: $NAME
+---
+id: python-function
+language: Python
+role: item
+symbolType: function
+rule:
+  kind: function_definition
+  has:
+    field: name
+    pattern: $NAME
+  not:
+    inside:
+      kind: class_definition
+name: $NAME
+---
+id: python-nested-class
+language: Python
+role: member
+parentRuleIds: [python-class]
+symbolType: class
+rule:
+  kind: class_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+---
+id: python-class-field
+language: Python
+role: member
+parentRuleIds: [python-class]
+symbolType: field
+rule:
+  all:
+    - kind: assignment
+    - has:
+        field: left
+        kind: identifier
+        pattern: $NAME
+    - inside:
+        kind: expression_statement
+        inside:
+          kind: block
+          inside:
+            kind: class_definition
+            field: body
+name: $NAME
+---
+id: python-method
+language: Python
+role: member
+parentRuleIds: [python-class]
+symbolType: method
+rule:
+  kind: function_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME

--- a/crates/outline/src/default_rules/swift.yml
+++ b/crates/outline/src/default_rules/swift.yml
@@ -1,0 +1,149 @@
+id: swift-preconcurrency-import
+language: Swift
+role: item
+symbolType: module
+rule:
+  pattern: '@preconcurrency import $MODULE'
+name: $MODULE
+signature: '@preconcurrency import $MODULE'
+isImport: true
+isExported: false
+---
+id: swift-import
+language: Swift
+role: item
+symbolType: module
+rule:
+  pattern: import $MODULE
+name: $MODULE
+signature: import $MODULE
+isImport: true
+isExported: false
+---
+id: swift-class
+language: Swift
+role: item
+symbolType: class
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*(public\s+|open\s+)?(final\s+)?class\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*(public|open)\b'
+---
+id: swift-protocol
+language: Swift
+role: item
+symbolType: interface
+rule:
+  all:
+    - kind: protocol_declaration
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*public\b'
+---
+id: swift-struct
+language: Swift
+role: item
+symbolType: struct
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*public\s+struct\b|^\s*struct\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*public\b'
+---
+id: swift-enum
+language: Swift
+role: item
+symbolType: enum
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*public\s+enum\b|^\s*enum\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*public\b'
+---
+id: swift-actor
+language: Swift
+role: item
+symbolType: object
+rule:
+  all:
+    - kind: class_declaration
+    - regex: '^\s*public\s+actor\b|^\s*actor\b'
+    - has:
+        kind: type_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*public\b'
+---
+id: swift-function
+language: Swift
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        kind: simple_identifier
+        pattern: $NAME
+name: $NAME
+isExported:
+  regex: '^\s*(public|open)\b'
+---
+id: swift-member-init
+language: Swift
+role: member
+parentRuleIds: [swift-class, swift-struct, swift-enum, swift-actor]
+symbolType: constructor
+rule:
+  kind: init_declaration
+name: init
+isPublic:
+  regex: '^\s*public\b'
+---
+id: swift-member-function
+language: Swift
+role: member
+parentRuleIds: [swift-class, swift-struct, swift-enum, swift-actor]
+symbolType: method
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        kind: simple_identifier
+        pattern: $NAME
+name: $NAME
+isPublic:
+  regex: '^\s*(public|open)\b'
+---
+id: swift-member-protocol-function
+language: Swift
+role: member
+parentRuleIds: [swift-protocol]
+symbolType: method
+rule:
+  all:
+    - kind: protocol_function_declaration
+    - has:
+        kind: simple_identifier
+        pattern: $NAME
+name: $NAME
+isPublic: true

--- a/crates/outline/src/default_rules/typescript.yml
+++ b/crates/outline/src/default_rules/typescript.yml
@@ -1,0 +1,875 @@
+id: ts-import
+language: TypeScript
+role: item
+symbolType: module
+rule:
+  kind: import_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: true
+isExported: false
+---
+id: ts-export-from
+language: TypeScript
+role: item
+symbolType: module
+rule:
+  kind: export_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: false
+isExported: true
+---
+id: ts-export-list
+language: TypeScript
+role: item
+symbolType: module
+rule:
+  pattern: 'export { $$$SPECIFIERS };'
+name: exports
+isImport: false
+isExported: true
+---
+id: ts-export-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: function_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: ts-export-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: class_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: ts-export-interface
+language: TypeScript
+role: item
+symbolType: interface
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: interface_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: ts-interface
+language: TypeScript
+role: item
+symbolType: interface
+rule:
+  kind: interface_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: ts-export-type
+language: TypeScript
+role: item
+symbolType: struct
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: type_alias_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: ts-type
+language: TypeScript
+role: item
+symbolType: struct
+rule:
+  kind: type_alias_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: ts-export-enum
+language: TypeScript
+role: item
+symbolType: enum
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: enum_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: ts-enum
+language: TypeScript
+role: item
+symbolType: enum
+rule:
+  kind: enum_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: ts-export-const
+language: TypeScript
+role: item
+symbolType: constant
+rule:
+  pattern: 'export const $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: ts-export-const-typed
+language: TypeScript
+role: item
+symbolType: constant
+rule:
+  pattern: 'export const $NAME: $TYPE = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: ts-export-let
+language: TypeScript
+role: item
+symbolType: variable
+rule:
+  pattern: 'export let $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: ts-export-let-typed
+language: TypeScript
+role: item
+symbolType: variable
+rule:
+  pattern: 'export let $NAME: $TYPE = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: ts-top-level-arrow-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-top-level-const
+language: TypeScript
+role: item
+symbolType: constant
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^const\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-top-level-const-typed
+language: TypeScript
+role: item
+symbolType: constant
+rule:
+  all:
+    - pattern:
+        context: 'const $NAME: $TYPE = $VALUE;'
+        selector: variable_declarator
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-top-level-let-uninitialized
+language: TypeScript
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - not:
+        has:
+          field: value
+          pattern: $VALUE
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-top-level-let
+language: TypeScript
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-top-level-let-typed
+language: TypeScript
+role: item
+symbolType: variable
+rule:
+  all:
+    - any:
+        - pattern:
+            context: 'let $NAME: $TYPE = $VALUE;'
+            selector: variable_declarator
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: ts-class-constructor
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-class, ts-class]
+symbolType: constructor
+rule:
+  pattern:
+    context: 'class A { constructor($$$ARGS) { $$$BODY } }'
+    selector: method_definition
+name: constructor
+isPublic: true
+---
+id: ts-class-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-class, ts-class]
+symbolType: method
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      kind: accessibility_modifier
+      regex: '^(private|protected)$'
+---
+id: ts-class-field
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-class, ts-class]
+symbolType: field
+rule:
+  kind: public_field_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      kind: accessibility_modifier
+      regex: '^(private|protected)$'
+---
+id: ts-interface-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-interface, ts-interface]
+symbolType: method
+rule:
+  kind: method_signature
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic: true
+---
+id: ts-interface-property
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-interface, ts-interface]
+symbolType: field
+rule:
+  kind: property_signature
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic: true
+---
+id: ts-enum-member
+language: TypeScript
+role: member
+parentRuleIds: [ts-export-enum, ts-enum]
+symbolType: enumMember
+rule:
+  pattern:
+    context: 'enum A { $NAME }'
+    selector: property_identifier
+name: $NAME
+isPublic: true
+---
+id: tsx-import
+language: Tsx
+role: item
+symbolType: module
+rule:
+  kind: import_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: true
+isExported: false
+---
+id: tsx-export-from
+language: Tsx
+role: item
+symbolType: module
+rule:
+  kind: export_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: false
+isExported: true
+---
+id: tsx-export-list
+language: Tsx
+role: item
+symbolType: module
+rule:
+  pattern: 'export { $$$SPECIFIERS };'
+name: exports
+isImport: false
+isExported: true
+---
+id: tsx-export-function
+language: Tsx
+role: item
+symbolType: function
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: function_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: tsx-function
+language: Tsx
+role: item
+symbolType: function
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: tsx-export-class
+language: Tsx
+role: item
+symbolType: class
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: class_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: tsx-class
+language: Tsx
+role: item
+symbolType: class
+rule:
+  kind: class_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: tsx-export-interface
+language: Tsx
+role: item
+symbolType: interface
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: interface_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: tsx-interface
+language: Tsx
+role: item
+symbolType: interface
+rule:
+  kind: interface_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: tsx-export-type
+language: Tsx
+role: item
+symbolType: struct
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: type_alias_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: tsx-type
+language: Tsx
+role: item
+symbolType: struct
+rule:
+  kind: type_alias_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: tsx-export-enum
+language: Tsx
+role: item
+symbolType: enum
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: enum_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: tsx-enum
+language: Tsx
+role: item
+symbolType: enum
+rule:
+  kind: enum_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+---
+id: tsx-export-const
+language: Tsx
+role: item
+symbolType: constant
+rule:
+  pattern: 'export const $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: tsx-export-const-typed
+language: Tsx
+role: item
+symbolType: constant
+rule:
+  pattern: 'export const $NAME: $TYPE = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: tsx-export-let
+language: Tsx
+role: item
+symbolType: variable
+rule:
+  pattern: 'export let $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: tsx-export-let-typed
+language: Tsx
+role: item
+symbolType: variable
+rule:
+  pattern: 'export let $NAME: $TYPE = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: tsx-top-level-arrow-function
+language: Tsx
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-top-level-const
+language: Tsx
+role: item
+symbolType: constant
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^const\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-top-level-const-typed
+language: Tsx
+role: item
+symbolType: constant
+rule:
+  all:
+    - pattern:
+        context: 'const $NAME: $TYPE = $VALUE;'
+        selector: variable_declarator
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-top-level-let-uninitialized
+language: Tsx
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - not:
+        has:
+          field: value
+          pattern: $VALUE
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-top-level-let
+language: Tsx
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-top-level-let-typed
+language: Tsx
+role: item
+symbolType: variable
+rule:
+  all:
+    - any:
+        - pattern:
+            context: 'let $NAME: $TYPE = $VALUE;'
+            selector: variable_declarator
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: tsx-class-constructor
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-class, tsx-class]
+symbolType: constructor
+rule:
+  pattern:
+    context: 'class A { constructor($$$ARGS) { $$$BODY } }'
+    selector: method_definition
+name: constructor
+isPublic: true
+---
+id: tsx-class-method
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-class, tsx-class]
+symbolType: method
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      kind: accessibility_modifier
+      regex: '^(private|protected)$'
+---
+id: tsx-class-field
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-class, tsx-class]
+symbolType: field
+rule:
+  kind: public_field_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      kind: accessibility_modifier
+      regex: '^(private|protected)$'
+---
+id: tsx-interface-method
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-interface, tsx-interface]
+symbolType: method
+rule:
+  kind: method_signature
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic: true
+---
+id: tsx-interface-property
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-interface, tsx-interface]
+symbolType: field
+rule:
+  kind: property_signature
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic: true
+---
+id: tsx-enum-member
+language: Tsx
+role: member
+parentRuleIds: [tsx-export-enum, tsx-enum]
+symbolType: enumMember
+rule:
+  pattern:
+    context: 'enum A { $NAME }'
+    selector: property_identifier
+name: $NAME
+isPublic: true

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -10,14 +10,18 @@ use ast_grep_config::{
   SerializableRule, SerializableRuleConfig, SerializableRuleCore, Severity,
 };
 use ast_grep_core::{
-  Language,
-  replacer::{TemplateFix, TemplateFixError},
+  Doc, Language, Node, NodeMatch,
+  matcher::MatcherExt,
+  replacer::{Replacer, TemplateFix, TemplateFixError},
+  source::Content,
 };
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Deserializer, Error as YamlError, with::singleton_map_recursive::deserialize};
 use thiserror::Error;
 
-use crate::model::SymbolType;
+use crate::model::{
+  EntryRole, OutlineEntry, OutlineItem, OutlineMember, SourcePosition, SourceRange, SymbolType,
+};
 
 /// Serializable outline extractor definition loaded from an outline rule YAML document.
 ///
@@ -192,6 +196,15 @@ enum OutlinePredicate {
   Rule(Rule),
 }
 
+impl OutlinePredicate {
+  fn evaluate<D: Doc>(&self, node_match: &NodeMatch<D>) -> bool {
+    match self {
+      Self::Literal(value) => *value,
+      Self::Rule(rule) => rule.match_node(node_match.get_node().clone()).is_some(),
+    }
+  }
+}
+
 fn compile_predicate<L: Language>(
   predicate: Option<SerializablePredicate>,
   default: bool,
@@ -237,6 +250,23 @@ impl<L: Language> ItemExtractor<L> {
       is_exported,
     })
   }
+
+  pub fn match_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+    self.common.rule.matcher.match_node(node)
+  }
+
+  pub fn extract<'tree, D: Doc>(
+    &self,
+    node_match: &NodeMatch<'tree, D>,
+    members: Vec<OutlineMember<'tree>>,
+  ) -> OutlineItem<'tree> {
+    OutlineItem {
+      entry: self.common.extract_entry(EntryRole::Item, node_match),
+      is_import: self.is_import.evaluate(node_match),
+      is_exported: self.is_exported.evaluate(node_match),
+      members,
+    }
+  }
 }
 
 /// Runnable member extractor for direct child structure under an item.
@@ -264,6 +294,72 @@ impl<L: Language> MemberExtractor<L> {
       parent_rule_ids,
       is_public,
     })
+  }
+
+  pub fn match_node<'tree, D: Doc>(&self, node: Node<'tree, D>) -> Option<NodeMatch<'tree, D>> {
+    self.common.rule.matcher.match_node(node)
+  }
+
+  pub fn extract<'tree, D: Doc>(&self, node_match: &NodeMatch<'tree, D>) -> OutlineMember<'tree> {
+    OutlineMember {
+      entry: self.common.extract_entry(EntryRole::Member, node_match),
+      is_public: self.is_public.evaluate(node_match),
+    }
+  }
+}
+
+impl<L: Language> ExtractorCommon<L> {
+  fn extract_entry<'tree, D: Doc>(
+    &self,
+    role: EntryRole,
+    node_match: &NodeMatch<'tree, D>,
+  ) -> OutlineEntry<'tree> {
+    let node = node_match.get_node();
+    OutlineEntry {
+      role,
+      symbol_type: self.symbol_type,
+      name: render_template(&self.name, node_match).into(),
+      range: source_range(node),
+      signature: self
+        .signature
+        .as_ref()
+        .map(|template| render_template(template, node_match))
+        .unwrap_or_else(|| default_signature(node))
+        .into(),
+      ast_kind: node.kind().into_owned().into(),
+    }
+  }
+}
+
+fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) -> String {
+  let bytes = template.generate_replacement(node_match);
+  <D::Source as Content>::encode_bytes(&bytes).to_string()
+}
+
+fn default_signature<D: Doc>(node: &Node<D>) -> String {
+  node
+    .text()
+    .lines()
+    .find_map(|line| {
+      let trimmed = line.trim();
+      (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+    .unwrap_or_default()
+}
+
+fn source_range<D: Doc>(node: &Node<D>) -> SourceRange {
+  let start = node.start_pos();
+  let end = node.end_pos();
+  SourceRange {
+    byte_offset: node.range(),
+    start: SourcePosition {
+      line: start.line(),
+      column: start.column(node),
+    },
+    end: SourcePosition {
+      line: end.line(),
+      column: end.column(node),
+    },
   }
 }
 

--- a/crates/outline/src/lib.rs
+++ b/crates/outline/src/lib.rs
@@ -1,8 +1,9 @@
 //! Code outline primitives for ast-grep.
 
-#[allow(dead_code)]
 mod default_rule;
 
 pub mod combined_extractor;
 pub mod extractor;
 pub mod model;
+
+pub use default_rule::DEFAULT_OUTLINE_RULES;

--- a/crates/outline/tests/common/mod.rs
+++ b/crates/outline/tests/common/mod.rs
@@ -1,0 +1,10 @@
+use ast_grep_language::SupportLang;
+use ast_grep_outline::{
+  DEFAULT_OUTLINE_RULES, combined_extractor::CombinedExtractors, extractor::parse_outline_rules,
+};
+
+pub fn combined() -> CombinedExtractors<SupportLang> {
+  let rules = parse_outline_rules::<SupportLang>(DEFAULT_OUTLINE_RULES)
+    .expect("builtin outline rules should deserialize");
+  CombinedExtractors::try_from(rules, &Default::default()).expect("builtin rules should compile")
+}

--- a/crates/outline/tests/jvm_swift_outline_rules.rs
+++ b/crates/outline/tests/jvm_swift_outline_rules.rs
@@ -1,0 +1,403 @@
+use ast_grep_language::{LanguageExt, SupportLang};
+use ast_grep_outline::{
+  combined_extractor::CombinedExtractors,
+  extractor::{SerializableOutlineRule, parse_outline_rules},
+  model::SymbolType,
+};
+
+fn compile(rules: &'static str) -> CombinedExtractors<SupportLang> {
+  let rules = parse_outline_rules::<SupportLang>(rules).expect("outline YAML should parse");
+  CombinedExtractors::try_from(rules, &Default::default()).expect("outline YAML should compile")
+}
+
+fn parse_all(rules: &'static str) {
+  let rules = parse_outline_rules::<SupportLang>(rules).expect("outline YAML should parse");
+  for rule in rules {
+    match rule {
+      SerializableOutlineRule::Item(item) => {
+        ast_grep_outline::extractor::ItemExtractor::try_from(item, &Default::default())
+          .expect("item rule should compile");
+      }
+      SerializableOutlineRule::Member(member) => {
+        ast_grep_outline::extractor::MemberExtractor::try_from(member, &Default::default())
+          .expect("member rule should compile");
+      }
+    }
+  }
+}
+
+#[test]
+fn kotlin_rules_parse_and_extract_okhttp_shapes() {
+  const RULES: &str = include_str!("../src/default_rules/kotlin.yml");
+  parse_all(RULES);
+
+  let combined = compile(RULES);
+  let grep = SupportLang::Kotlin.ast_grep(
+    r#"
+package okhttp3.sse
+
+import okhttp3.Request
+import java.io.IOException as IOE
+
+public interface Interceptor {
+  fun intercept(chain: Chain): Response
+}
+
+class RealInterceptorChain constructor(val call: Call) {
+  internal constructor(call: Call, index: Int) : this(call)
+  override fun proceed(request: Request): Response { return TODO() }
+  fun exchange(): Exchange = TODO()
+  val index: Int = 0
+  internal fun copy(index: Int = 0) = RealInterceptorChain(call)
+  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+    return copy()
+  }
+}
+
+public object EventSources {
+  fun createFactory(): Factory = TODO()
+}
+
+enum class Protocol { HTTP_1_1 }
+
+class RealCall {
+  override fun execute(): Response {
+    return getResponseWithInterceptorChain()
+  }
+  override fun isExecuted(): Boolean = TODO()
+  private fun callStart() {}
+  @Throws(IOException::class)
+  internal fun getResponseWithInterceptorChain(): Response {
+    val localResponse: Response = TODO()
+    var localCalls: Int = 0
+    return localResponse
+  }
+}
+
+class ScopeBox {
+  val direct: Int = 0
+  class Nested {
+    fun leaked(): Unit {}
+    val nestedValue: Int = 0
+  }
+  companion object {
+    fun companionLeak(): Unit {}
+    val companionValue: Int = 0
+  }
+  fun directFun() {}
+}
+"#,
+  );
+  let items = combined.extract(grep.root());
+
+  let names = items
+    .iter()
+    .map(|item| item.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(
+    names,
+    vec![
+      "okhttp3.Request",
+      "IOE",
+      "Interceptor",
+      "RealInterceptorChain",
+      "EventSources",
+      "Protocol",
+      "RealCall",
+      "ScopeBox"
+    ]
+  );
+
+  let chain = items
+    .iter()
+    .find(|item| item.entry.name == "RealInterceptorChain")
+    .expect("class should be outlined");
+  let member_names = chain
+    .members
+    .iter()
+    .map(|member| member.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(
+    member_names,
+    vec![
+      "constructor",
+      "proceed",
+      "exchange",
+      "index",
+      "copy",
+      "withConnectTimeout"
+    ]
+  );
+  let chain_members = chain
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.name.as_ref(),
+        member.entry.signature.as_ref(),
+        member.entry.symbol_type,
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    chain_members,
+    vec![
+      (
+        "constructor",
+        "internal constructor(call: Call, index: Int) : this(call)",
+        SymbolType::Constructor,
+        false,
+      ),
+      (
+        "proceed",
+        "override fun proceed(request: Request): Response { return TODO() }",
+        SymbolType::Method,
+        true,
+      ),
+      (
+        "exchange",
+        "fun exchange(): Exchange = TODO()",
+        SymbolType::Method,
+        true
+      ),
+      ("index", "val index: Int = 0", SymbolType::Property, true),
+      (
+        "copy",
+        "internal fun copy(index: Int = 0) = RealInterceptorChain(call)",
+        SymbolType::Method,
+        false
+      ),
+      (
+        "withConnectTimeout",
+        "override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {",
+        SymbolType::Method,
+        true,
+      ),
+    ]
+  );
+
+  let real_call = items
+    .iter()
+    .find(|item| item.entry.name == "RealCall")
+    .expect("RealCall should be outlined");
+  let real_call_members = real_call
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.name.as_ref(),
+        member.entry.signature.as_ref(),
+        member.entry.symbol_type,
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    real_call_members,
+    vec![
+      (
+        "execute",
+        "override fun execute(): Response {",
+        SymbolType::Method,
+        true
+      ),
+      (
+        "isExecuted",
+        "override fun isExecuted(): Boolean = TODO()",
+        SymbolType::Method,
+        true
+      ),
+      (
+        "callStart",
+        "private fun callStart() {}",
+        SymbolType::Method,
+        false
+      ),
+      (
+        "getResponseWithInterceptorChain",
+        "@Throws(IOException::class)",
+        SymbolType::Method,
+        false,
+      ),
+    ]
+  );
+
+  let scope_box = items
+    .iter()
+    .find(|item| item.entry.name == "ScopeBox")
+    .expect("ScopeBox should be outlined");
+  let scope_members = scope_box
+    .members
+    .iter()
+    .map(|member| (member.entry.name.as_ref(), member.entry.symbol_type))
+    .collect::<Vec<_>>();
+  assert_eq!(
+    scope_members,
+    vec![
+      ("direct", SymbolType::Property),
+      ("Nested", SymbolType::Class),
+      ("companion object", SymbolType::Object),
+      ("directFun", SymbolType::Method),
+    ]
+  );
+}
+
+#[test]
+fn java_rules_parse_and_extract_jvm_surface() {
+  const RULES: &str = include_str!("../src/default_rules/java.yml");
+  parse_all(RULES);
+
+  let combined = compile(RULES);
+  let grep = SupportLang::Java.ast_grep(
+    r#"
+package okhttp3;
+
+import okhttp3.Request;
+import static java.util.Collections.emptyList;
+
+public interface Interceptor {
+  Response intercept(Chain chain) throws IOException;
+}
+
+public final class RealInterceptorChain implements Interceptor {
+  private final int index;
+  public RealInterceptorChain(int index) { this.index = index; }
+  public Response proceed(Request request) throws IOException { return null; }
+  Response exchange() { return null; }
+}
+
+enum Protocol { HTTP_1_1 }
+"#,
+  );
+  let items = combined.extract(grep.root());
+
+  let names = items
+    .iter()
+    .map(|item| item.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(
+    names,
+    vec![
+      "okhttp3.Request",
+      "java.util.Collections.emptyList",
+      "Interceptor",
+      "RealInterceptorChain",
+      "Protocol"
+    ]
+  );
+
+  let chain = items
+    .iter()
+    .find(|item| item.entry.name == "RealInterceptorChain")
+    .expect("class should be outlined");
+  assert!(chain.is_exported);
+  let members = chain
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.name.as_ref(),
+        member.entry.symbol_type,
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    members,
+    vec![
+      (
+        "RealInterceptorChain",
+        ast_grep_outline::model::SymbolType::Constructor,
+        true,
+      ),
+      ("proceed", ast_grep_outline::model::SymbolType::Method, true),
+      (
+        "exchange",
+        ast_grep_outline::model::SymbolType::Method,
+        false
+      ),
+    ]
+  );
+}
+
+#[test]
+fn swift_rules_parse_and_extract_alamofire_shapes() {
+  const RULES: &str = include_str!("../src/default_rules/swift.yml");
+  parse_all(RULES);
+
+  let combined = compile(RULES);
+  let grep = SupportLang::Swift.ast_grep(
+    r#"
+import Foundation
+@preconcurrency import Dispatch
+
+public final class Session {
+  public init(configuration: URLSessionConfiguration) {}
+  open func request(_ convertible: any URLConvertible) -> DataRequest { fatalError() }
+}
+
+public protocol RequestInterceptor: Sendable {
+  func adapt(_ urlRequest: URLRequest) throws -> URLRequest
+}
+
+public enum AFError: Error {
+  case invalidURL(url: any URLConvertible)
+}
+
+public struct HTTPHeaders: Sendable {
+  public init(_ headers: [HTTPHeader]) {}
+}
+
+class InternalBox {
+  init() {}
+  func helper() -> Int { return 1 }
+}
+"#,
+  );
+  let items = combined.extract(grep.root());
+
+  let names = items
+    .iter()
+    .map(|item| item.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(
+    names,
+    vec![
+      "Foundation",
+      "Dispatch",
+      "Session",
+      "RequestInterceptor",
+      "AFError",
+      "HTTPHeaders",
+      "InternalBox"
+    ]
+  );
+
+  let session = items
+    .iter()
+    .find(|item| item.entry.name == "Session")
+    .expect("class should be outlined");
+  assert!(session.is_exported);
+  let member_names = session
+    .members
+    .iter()
+    .map(|member| member.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(member_names, vec!["init", "request"]);
+  assert!(session.members.iter().all(|member| member.is_public));
+
+  let internal = items
+    .iter()
+    .find(|item| item.entry.name == "InternalBox")
+    .expect("internal class should be outlined");
+  assert!(!internal.is_exported);
+  assert_eq!(
+    internal
+      .members
+      .iter()
+      .map(|member| (member.entry.name.as_ref(), member.is_public))
+      .collect::<Vec<_>>(),
+    vec![("init", false), ("helper", false)]
+  );
+}

--- a/crates/outline/tests/python_go_outline_rules.rs
+++ b/crates/outline/tests/python_go_outline_rules.rs
@@ -1,0 +1,200 @@
+use ast_grep_core::tree_sitter::LanguageExt;
+use ast_grep_language::SupportLang;
+use ast_grep_outline::{
+  combined_extractor::CombinedExtractors, extractor::parse_outline_rules, model::SymbolType,
+};
+
+fn combined(src: &str) -> CombinedExtractors<SupportLang> {
+  let rules = parse_outline_rules::<SupportLang>(src).expect("outline rules should deserialize");
+  CombinedExtractors::try_from(rules, &Default::default()).expect("outline rules should compile")
+}
+
+#[test]
+fn python_rules_extract_imports_classes_functions_and_methods() {
+  let combined = combined(include_str!("../src/default_rules/python.yml"));
+  let grep = SupportLang::Python.ast_grep(
+    r#"
+import functools
+from django.db import models
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+urlpatterns = []
+
+def module_helper(queryset):
+    local_count = queryset.count()
+    return queryset.count()
+
+async def fetch_related(queryset):
+    return [row async for row in queryset]
+
+class QuerySetRunner:
+    empty_result_set_value = None
+    query = models.Query()
+
+    @property
+    def db(self):
+        return self.query.db
+
+    class Meta:
+        app_label = "outline"
+
+    def __init__(self, queryset):
+        self.queryset = queryset
+
+    async def execute(self):
+        local_value = 1
+        return await self.queryset.afirst()
+"#,
+  );
+
+  let items = combined.extract(grep.root());
+  let names = items
+    .iter()
+    .map(|item| (item.entry.symbol_type, item.entry.name.as_ref()))
+    .collect::<Vec<_>>();
+
+  assert_eq!(
+    names,
+    vec![
+      (SymbolType::Module, "functools"),
+      (SymbolType::Module, "django.db.models"),
+      (SymbolType::Constant, "DEFAULT_AUTO_FIELD"),
+      (SymbolType::Variable, "urlpatterns"),
+      (SymbolType::Function, "module_helper"),
+      (SymbolType::Function, "fetch_related"),
+      (SymbolType::Class, "QuerySetRunner")
+    ]
+  );
+
+  let class = items
+    .iter()
+    .find(|item| item.entry.name == "QuerySetRunner")
+    .expect("class should be extracted");
+  let methods = class
+    .members
+    .iter()
+    .map(|member| (member.entry.symbol_type, member.entry.name.as_ref()))
+    .collect::<Vec<_>>();
+  assert_eq!(
+    methods,
+    vec![
+      (SymbolType::Field, "empty_result_set_value"),
+      (SymbolType::Field, "query"),
+      (SymbolType::Method, "db"),
+      (SymbolType::Class, "Meta"),
+      (SymbolType::Method, "__init__"),
+      (SymbolType::Method, "execute")
+    ]
+  );
+}
+
+#[test]
+fn go_rules_extract_imports_funcs_methods_types_consts_and_vars() {
+  let combined = combined(include_str!("../src/default_rules/go.yml"));
+  let grep = SupportLang::Go.ast_grep(
+    r#"
+package gin
+
+import (
+    "net/http"
+    "strings"
+)
+
+const defaultMultipartMemory = 32 << 20
+var defaultTrustedCIDRs = []*net.IPNet{}
+
+type HandlerFunc func(*Context)
+
+type Engine struct {
+    RouterGroup
+    trees methodTrees
+    maxParams uint16
+    Config struct {
+        Inner int
+    }
+}
+
+type RoutesInfo interface {
+    Last() RouteInfo
+    ByName(string) (RouteInfo, bool)
+    http.Handler
+}
+
+func New() *Engine {
+    return &Engine{}
+}
+
+func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
+    return engine
+}
+"#,
+  );
+
+  let items = combined.extract(grep.root());
+  let names = items
+    .iter()
+    .map(|item| (item.entry.symbol_type, item.entry.name.as_ref()))
+    .collect::<Vec<_>>();
+
+  assert_eq!(
+    names,
+    vec![
+      (SymbolType::Module, "net/http"),
+      (SymbolType::Module, "strings"),
+      (SymbolType::Constant, "defaultMultipartMemory"),
+      (SymbolType::Variable, "defaultTrustedCIDRs"),
+      (SymbolType::TypeParameter, "HandlerFunc"),
+      (SymbolType::Struct, "Engine"),
+      (SymbolType::Interface, "RoutesInfo"),
+      (SymbolType::Function, "New"),
+      (SymbolType::Method, "Use")
+    ]
+  );
+
+  let engine = items
+    .iter()
+    .find(|item| item.entry.name == "Engine")
+    .expect("struct should be extracted");
+  let fields = engine
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.symbol_type,
+        member.entry.name.as_ref(),
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    fields,
+    vec![
+      (SymbolType::Field, "trees", false),
+      (SymbolType::Field, "maxParams", false),
+      (SymbolType::Field, "Config", true)
+    ]
+  );
+
+  let routes = items
+    .iter()
+    .find(|item| item.entry.name == "RoutesInfo")
+    .expect("interface should be extracted");
+  let interface_methods = routes
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.symbol_type,
+        member.entry.name.as_ref(),
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    interface_methods,
+    vec![
+      (SymbolType::Method, "Last", true),
+      (SymbolType::Method, "ByName", true)
+    ]
+  );
+}

--- a/crates/outline/tests/typescript_outline_rules.rs
+++ b/crates/outline/tests/typescript_outline_rules.rs
@@ -1,0 +1,314 @@
+use ast_grep_core::tree_sitter::LanguageExt;
+use ast_grep_language::SupportLang;
+use ast_grep_outline::{
+  combined_extractor::CombinedExtractors,
+  extractor::{SerializableOutlineRule, parse_outline_rules},
+  model::SymbolType,
+};
+
+const TYPESCRIPT_RULES: &str = include_str!("../src/default_rules/typescript.yml");
+
+fn rules_for(lang: SupportLang) -> Vec<SerializableOutlineRule<SupportLang>> {
+  parse_outline_rules::<SupportLang>(TYPESCRIPT_RULES)
+    .expect("TypeScript outline rules should deserialize")
+    .into_iter()
+    .filter(|rule| rule.common().language == lang)
+    .collect()
+}
+
+fn compile_for(lang: SupportLang) -> CombinedExtractors<SupportLang> {
+  CombinedExtractors::try_from(rules_for(lang), &Default::default())
+    .expect("TypeScript outline rules should compile")
+}
+
+#[test]
+fn bundled_typescript_and_tsx_rules_compile() {
+  compile_for(SupportLang::TypeScript);
+  compile_for(SupportLang::Tsx);
+}
+
+#[test]
+fn extracts_typescript_outline_from_realistic_vscode_style_code() {
+  let combined = compile_for(SupportLang::TypeScript);
+  let grep = SupportLang::TypeScript.ast_grep(
+    r#"
+import * as DOM from '../../../../../../base/browser/dom.js';
+import { Lazy } from '../../../../../../base/common/lazy.js';
+import type { INotebookEditorContribution } from '../../notebookBrowser.js';
+
+export { NotebookFindFilters };
+export { INotebookFindScope } from '../../../common/notebookCommon.js';
+
+const FIND_SHOW_TRANSITION = 'find-show-transition';
+export const FIND_HIDE_TRANSITION = 'find-hide-transition';
+export let MAX_MATCHES_COUNT_WIDTH: number = 69;
+let validateIndicesThrottled: ReturnType<typeof throttleRAF>;
+const getNonDeletedElements = (elements: readonly ExcalidrawElement[]) => {
+  return elements.filter((element) => !element.isDeleted);
+};
+const hashSelectionOpts = ({ selectedElementIds }: { selectedElementIds: Readonly<Record<string, true>> }) => {
+  return Object.keys(selectedElementIds).join(',');
+};
+const noop = () => {}, _RPCProtocolSymbol = Symbol.for('rpc.protocol');
+
+export interface IShowNotebookFindWidgetOptions {
+  focus?: boolean;
+  findScope?: INotebookFindScope;
+  matchIndex?: number;
+}
+
+export type FindDirection = 'next' | 'previous';
+
+export enum MatchKind {
+  Exact,
+  Fuzzy = 'fuzzy',
+}
+
+export function createFindWidget(): NotebookFindWidget {
+  return new NotebookFindWidget();
+}
+
+function localHelper() {}
+
+setup(() => {
+  const callbackLocal = () => {};
+  let callbackState = 1;
+});
+
+export class NotebookFindContrib extends Disposable implements INotebookEditorContribution {
+  static readonly id: string = 'workbench.notebook.find';
+  private readonly _widget: Lazy<NotebookFindWidget>;
+
+  constructor(private readonly notebookEditor: INotebookEditor) {
+    super();
+  }
+
+  get widget(): NotebookFindWidget {
+    return this._widget.value;
+  }
+
+  hide() {
+    this._widget.rawValue?.hide();
+  }
+
+  private _reset(): void {}
+}
+
+class NotebookFindWidget extends SimpleFindReplaceWidget {
+  protected _findWidgetVisible: boolean = false;
+
+  show(initialInput?: string): Promise<void> {
+    return Promise.resolve();
+  }
+}
+"#,
+  );
+
+  let items = combined.extract(grep.root());
+  let names = items
+    .iter()
+    .map(|item| item.entry.name.as_ref())
+    .collect::<Vec<_>>();
+
+  assert!(items.iter().any(|item| {
+    item.is_import
+      && item
+        .entry
+        .name
+        .contains("../../../../../../base/browser/dom.js")
+  }));
+  assert!(
+    items
+      .iter()
+      .any(|item| { item.is_import && item.entry.name.contains("../../notebookBrowser.js") })
+  );
+  assert!(items.iter().any(|item| {
+    item.is_exported
+      && item
+        .entry
+        .name
+        .contains("../../../common/notebookCommon.js")
+  }));
+  assert!(names.contains(&"FIND_HIDE_TRANSITION"));
+  assert!(names.contains(&"MAX_MATCHES_COUNT_WIDTH"));
+  assert!(names.contains(&"IShowNotebookFindWidgetOptions"));
+  assert!(names.contains(&"FindDirection"));
+  assert!(names.contains(&"MatchKind"));
+  assert!(names.contains(&"createFindWidget"));
+  assert!(names.contains(&"localHelper"));
+  assert!(names.contains(&"NotebookFindContrib"));
+  assert!(names.contains(&"NotebookFindWidget"));
+  assert!(names.contains(&"FIND_SHOW_TRANSITION"));
+  assert!(names.contains(&"validateIndicesThrottled"));
+  assert!(names.contains(&"getNonDeletedElements"));
+  assert!(names.contains(&"hashSelectionOpts"));
+  assert!(names.contains(&"noop"));
+  assert!(names.contains(&"_RPCProtocolSymbol"));
+  assert!(!names.contains(&"callbackLocal"));
+  assert!(!names.contains(&"callbackState"));
+
+  let top_level_symbols = items
+    .iter()
+    .map(|item| {
+      (
+        item.entry.name.as_ref(),
+        item.entry.symbol_type,
+        item.is_exported,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert!(top_level_symbols.contains(&("FIND_SHOW_TRANSITION", SymbolType::Constant, false)));
+  assert!(top_level_symbols.contains(&("validateIndicesThrottled", SymbolType::Variable, false)));
+  assert!(top_level_symbols.contains(&("getNonDeletedElements", SymbolType::Function, false)));
+  assert!(top_level_symbols.contains(&("hashSelectionOpts", SymbolType::Function, false)));
+  assert!(top_level_symbols.contains(&("noop", SymbolType::Function, false)));
+  assert!(top_level_symbols.contains(&("_RPCProtocolSymbol", SymbolType::Constant, false)));
+
+  let options = items
+    .iter()
+    .find(|item| item.entry.name == "IShowNotebookFindWidgetOptions")
+    .expect("interface should be extracted");
+  let option_members = options
+    .members
+    .iter()
+    .map(|member| (member.entry.symbol_type, member.entry.name.as_ref()))
+    .collect::<Vec<_>>();
+  assert_eq!(
+    option_members,
+    vec![
+      (SymbolType::Field, "focus"),
+      (SymbolType::Field, "findScope"),
+      (SymbolType::Field, "matchIndex"),
+    ]
+  );
+
+  let match_kind = items
+    .iter()
+    .find(|item| item.entry.name == "MatchKind")
+    .expect("enum should be extracted");
+  let enum_members = match_kind
+    .members
+    .iter()
+    .map(|member| member.entry.name.as_ref())
+    .collect::<Vec<_>>();
+  assert_eq!(enum_members, vec!["Exact", "Fuzzy"]);
+
+  let contrib = items
+    .iter()
+    .find(|item| item.entry.name == "NotebookFindContrib")
+    .expect("class should be extracted");
+  let class_members = contrib
+    .members
+    .iter()
+    .map(|member| {
+      (
+        member.entry.symbol_type,
+        member.entry.name.as_ref(),
+        member.is_public,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    class_members,
+    vec![
+      (SymbolType::Field, "id", true),
+      (SymbolType::Field, "_widget", false),
+      (SymbolType::Constructor, "constructor", true),
+      (SymbolType::Method, "widget", true),
+      (SymbolType::Method, "hide", true),
+      (SymbolType::Method, "_reset", false),
+    ]
+  );
+
+  let widget = items
+    .iter()
+    .find(|item| item.entry.name == "NotebookFindWidget")
+    .expect("non-exported class should be extracted");
+  assert!(!widget.is_exported);
+  assert_eq!(
+    widget
+      .members
+      .iter()
+      .map(|member| (member.entry.name.as_ref(), member.is_public))
+      .collect::<Vec<_>>(),
+    vec![("_findWidgetVisible", false), ("show", true)]
+  );
+}
+
+#[test]
+fn extracts_tsx_outline_with_jsx_values() {
+  let combined = compile_for(SupportLang::Tsx);
+  let grep = SupportLang::Tsx.ast_grep(
+    r#"
+import React from 'react';
+
+export interface BadgeProps {
+  title: string;
+}
+
+export function Badge(props: BadgeProps) {
+  return <span>{props.title}</span>;
+}
+
+export class Panel extends React.Component<BadgeProps> {
+  render() {
+    return <Badge title="demo" />;
+  }
+}
+
+export const BadgeFactory = () => <Badge title="demo" />;
+
+const renderBadge = (title: string) => <Badge title={title} />;
+const renderElementShape = (element: ExcalidrawElement) => {
+  return <Badge title={element.id} />;
+};
+let currentRenderer: React.FC<BadgeProps>;
+"#,
+  );
+
+  let items = combined.extract(grep.root());
+  let names = items
+    .iter()
+    .map(|item| item.entry.name.as_ref())
+    .collect::<Vec<_>>();
+
+  assert!(
+    items
+      .iter()
+      .any(|item| item.is_import && item.entry.name == "'react'")
+  );
+  assert!(names.contains(&"BadgeProps"));
+  assert!(names.contains(&"Badge"));
+  assert!(names.contains(&"Panel"));
+  assert!(names.contains(&"BadgeFactory"));
+  assert!(names.contains(&"renderBadge"));
+  assert!(names.contains(&"renderElementShape"));
+  assert!(names.contains(&"currentRenderer"));
+
+  let top_level_symbols = items
+    .iter()
+    .map(|item| {
+      (
+        item.entry.name.as_ref(),
+        item.entry.symbol_type,
+        item.is_exported,
+      )
+    })
+    .collect::<Vec<_>>();
+  assert!(top_level_symbols.contains(&("renderBadge", SymbolType::Function, false)));
+  assert!(top_level_symbols.contains(&("renderElementShape", SymbolType::Function, false)));
+  assert!(top_level_symbols.contains(&("currentRenderer", SymbolType::Variable, false)));
+
+  let panel = items
+    .iter()
+    .find(|item| item.entry.name == "Panel")
+    .expect("TSX class should be extracted");
+  assert_eq!(
+    panel
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>(),
+    vec!["render"]
+  );
+}


### PR DESCRIPTION
Adds bundled outline rules and focused tests for TypeScript/TSX, Python, Go, Kotlin, Java, and Swift.\n\nStacked on the outline CLI execution PR.