### PR TITLE
fix: cover async rust outline rules

### DIFF
--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -392,10 +392,174 @@ impl<T: Future> CoreStage<T> {
       vec![
         (
           "with_mut",
-          "pub(super) fn with_mut<R>(&self, f: impl FnOnce(*mut Stage<T>) -> R) -> R {",
+          "pub(super) fn with_mut<R>(&self, f: impl FnOnce(*mut Stage<T>) -> R) -> R",
           true
         ),
         ("with_core", "fn with_core<F, R>(&self, f: F) -> R", false),
+      ]
+    );
+  }
+
+  #[test]
+  fn rust_builtin_rules_extract_async_functions_and_methods() {
+    let combined = rust_combined();
+    let grep = SupportLang::Rust.ast_grep(
+      r#"
+pub async fn exported_async() -> usize { 1 }
+
+async fn private_async<T: Send>(input: T)
+where
+  T: Clone,
+{
+  todo!()
+}
+
+mod api {
+  pub async fn nested_async() {}
+  async fn hidden_async() {}
+}
+
+struct Client;
+
+impl Client {
+  pub async fn connect<T>(&self, item: T) -> Result<(), ()>
+  where
+    T: Send,
+  {
+    Ok(())
+  }
+
+  async fn close(&self) {}
+}
+
+trait Service {
+  async fn poll(&self);
+  async fn defaulted<T>(&self) -> usize
+  where
+    T: Send,
+  {
+    1
+  }
+}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+    let item_shapes = items
+      .iter()
+      .map(|item| {
+        (
+          item.entry.symbol_type,
+          item.entry.name.as_ref(),
+          item.entry.signature.as_ref(),
+          item.is_exported,
+        )
+      })
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      item_shapes,
+      vec![
+        (
+          SymbolType::Function,
+          "exported_async",
+          "pub async fn exported_async() -> usize",
+          true
+        ),
+        (
+          SymbolType::Function,
+          "private_async",
+          "async fn private_async<T: Send>(input: T)",
+          false
+        ),
+        (SymbolType::Module, "api", "mod api", false),
+        (SymbolType::Struct, "Client", "struct Client", false),
+        (SymbolType::Object, "Client", "impl Client", false),
+        (SymbolType::Interface, "Service", "trait Service", false),
+      ]
+    );
+
+    let api = items
+      .iter()
+      .find(|item| item.entry.name == "api")
+      .expect("module should be extracted");
+    let module_functions = api
+      .members
+      .iter()
+      .map(|member| {
+        (
+          member.entry.symbol_type,
+          member.entry.name.as_ref(),
+          member.entry.signature.as_ref(),
+          member.is_public,
+        )
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      module_functions,
+      vec![
+        (
+          SymbolType::Function,
+          "nested_async",
+          "pub async fn nested_async()",
+          true
+        ),
+        (
+          SymbolType::Function,
+          "hidden_async",
+          "async fn hidden_async()",
+          false
+        ),
+      ]
+    );
+
+    let implementation = items
+      .iter()
+      .find(|item| item.entry.signature == "impl Client")
+      .expect("impl should be extracted");
+    let impl_methods = implementation
+      .members
+      .iter()
+      .map(|member| {
+        (
+          member.entry.name.as_ref(),
+          member.entry.signature.as_ref(),
+          member.is_public,
+        )
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      impl_methods,
+      vec![
+        (
+          "connect",
+          "pub async fn connect<T>(&self, item: T) -> Result<(), ()>",
+          true
+        ),
+        ("close", "async fn close(&self)", false),
+      ]
+    );
+
+    let service = items
+      .iter()
+      .find(|item| item.entry.name == "Service")
+      .expect("trait should be extracted");
+    let trait_methods = service
+      .members
+      .iter()
+      .map(|member| {
+        (
+          member.entry.name.as_ref(),
+          member.entry.signature.as_ref(),
+          member.is_public,
+        )
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      trait_methods,
+      vec![
+        ("poll", "async fn poll(&self)", true),
+        ("defaulted", "async fn defaulted<T>(&self) -> usize", true),
       ]
     );
   }

--- a/crates/outline/src/default_rules/rust.yml
+++ b/crates/outline/src/default_rules/rust.yml
@@ -18,412 +18,175 @@ name: '$PATH'
 isImport: true
 isExported: false
 ---
-id: rust-mod-public
-language: Rust
-role: item
-symbolType: module
-rule:
-  pattern: 'pub mod $NAME;'
-name: '$NAME'
-signature: 'pub mod $NAME'
-isExported: true
----
 id: rust-mod
 language: Rust
 role: item
 symbolType: module
 rule:
-  pattern: 'mod $NAME;'
-name: '$NAME'
-signature: 'mod $NAME'
-isExported: false
----
-id: rust-mod-inline-public
-language: Rust
-role: item
-symbolType: module
-rule:
-  pattern: 'pub mod $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'pub mod $NAME'
-isExported: true
----
-id: rust-mod-inline
-language: Rust
-role: item
-symbolType: module
-rule:
-  pattern: 'mod $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'mod $NAME'
-isExported: false
----
-id: rust-function-visible
-language: Rust
-role: item
-symbolType: function
-rule:
   all:
-    - kind: function_item
-    - regex: '^pub\('
+    - kind: mod_item
+    - pattern: $DECL
     - has:
         field: name
         pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$|;\s*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-isExported: true
----
-id: rust-function-public-generic-return-where
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isExported: true
----
-id: rust-function-generic-return-where
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isExported: false
----
-id: rust-function-public-generic-where
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
-isExported: true
----
-id: rust-function-generic-where
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
-isExported: false
----
-id: rust-function-public-generic-return
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isExported: true
----
-id: rust-function-generic-return
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isExported: false
----
-id: rust-function-public-generic
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
-isExported: true
----
-id: rust-function-generic
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
-isExported: false
----
-id: rust-function-public
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME($$$ARGS) { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS)'
-isExported: true
+signature: '$SIG'
+isExported:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-function
 language: Rust
 role: item
 symbolType: function
 rule:
-  pattern: 'fn $NAME($$$ARGS) { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS)'
-isExported: false
----
-id: rust-function-public-return
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'pub fn $NAME($$$ARGS) -> $RET { $$$BODY }'
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS) -> $RET'
-isExported: true
----
-id: rust-function-return
-language: Rust
-role: item
-symbolType: function
-rule:
-  pattern: 'fn $NAME($$$ARGS) -> $RET { $$$BODY }'
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS) -> $RET'
-isExported: false
----
-id: rust-struct-visible
-language: Rust
-role: item
-symbolType: struct
-rule:
   all:
-    - kind: struct_item
-    - regex: '^pub\('
+    - kind: function_item
+    - pattern: $DECL
     - has:
         field: name
         pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-isExported: true
----
-id: rust-struct-public-any
-language: Rust
-role: item
-symbolType: struct
-rule:
-  all:
-    - kind: struct_item
-    - regex: '^pub\s+struct'
-    - has:
-        field: name
-        pattern: $NAME
-name: '$NAME'
-isExported: true
----
-id: rust-struct-any
-language: Rust
-role: item
-symbolType: struct
-rule:
-  all:
-    - kind: struct_item
-    - has:
-        field: name
-        pattern: $NAME
-name: '$NAME'
-isExported: false
----
-id: rust-struct-public
-language: Rust
-role: item
-symbolType: struct
-rule:
-  pattern: 'pub struct $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'pub struct $NAME'
-isExported: true
+signature: '$SIG'
+isExported:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-struct
 language: Rust
 role: item
 symbolType: struct
 rule:
-  pattern: 'struct $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'struct $NAME'
-isExported: false
----
-id: rust-enum-visible
-language: Rust
-role: item
-symbolType: enum
-rule:
   all:
-    - kind: enum_item
-    - regex: '^pub\('
+    - kind: struct_item
+    - pattern: $DECL
     - has:
         field: name
         pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$|;\s*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-isExported: true
----
-id: rust-enum-public-any
-language: Rust
-role: item
-symbolType: enum
-rule:
-  all:
-    - kind: enum_item
-    - regex: '^pub\s+enum'
-    - has:
-        field: name
-        pattern: $NAME
-name: '$NAME'
-isExported: true
----
-id: rust-enum-any
-language: Rust
-role: item
-symbolType: enum
-rule:
-  all:
-    - kind: enum_item
-    - has:
-        field: name
-        pattern: $NAME
-name: '$NAME'
-isExported: false
----
-id: rust-enum-public
-language: Rust
-role: item
-symbolType: enum
-rule:
-  pattern: 'pub enum $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'pub enum $NAME'
-isExported: true
+signature: '$SIG'
+isExported:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-enum
 language: Rust
 role: item
 symbolType: enum
 rule:
-  pattern: 'enum $NAME { $$$BODY }'
+  all:
+    - kind: enum_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'enum $NAME'
-isExported: false
----
-id: rust-trait-public
-language: Rust
-role: item
-symbolType: interface
-rule:
-  pattern: 'pub trait $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'pub trait $NAME'
-isExported: true
+signature: '$SIG'
+isExported:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-trait
 language: Rust
 role: item
 symbolType: interface
 rule:
-  pattern: 'trait $NAME { $$$BODY }'
+  all:
+    - kind: trait_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'trait $NAME'
-isExported: false
----
-id: rust-trait-method-signature-return
-language: Rust
-role: member
-parentRuleIds: [rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'trait A { fn $NAME($$$ARGS) -> $RET; }'
-    selector: function_signature_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS) -> $RET'
-isPublic: true
----
-id: rust-trait-method-signature
-language: Rust
-role: member
-parentRuleIds: [rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'trait A { fn $NAME($$$ARGS); }'
-    selector: function_signature_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS)'
-isPublic: true
----
-id: rust-trait-method-default-return
-language: Rust
-role: member
-parentRuleIds: [rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'trait A { fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS) -> $RET'
-isPublic: true
----
-id: rust-trait-method-default
-language: Rust
-role: member
-parentRuleIds: [rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'trait A { fn $NAME($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS)'
-isPublic: true
----
-id: rust-impl-trait-generic
-language: Rust
-role: item
-symbolType: object
-rule:
-  pattern: 'impl<$$$GENERICS> $TRAIT for $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'impl<$$$GENERICS> $TRAIT for $NAME'
-isExported: false
----
-id: rust-impl-trait
-language: Rust
-role: item
-symbolType: object
-rule:
-  pattern: 'impl $TRAIT for $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'impl $TRAIT for $NAME'
-isExported: false
----
-id: rust-impl-generic
-language: Rust
-role: item
-symbolType: object
-rule:
-  pattern: 'impl<$$$GENERICS> $NAME { $$$BODY }'
-name: '$NAME'
-signature: 'impl<$$$GENERICS> $NAME'
-isExported: false
+signature: '$SIG'
+isExported:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-impl
 language: Rust
 role: item
 symbolType: object
 rule:
-  pattern: 'impl $NAME { $$$BODY }'
+  all:
+    - kind: impl_item
+    - pattern: $DECL
+    - has:
+        field: type
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'impl $NAME'
+signature: '$SIG'
 isExported: false
 ---
 id: rust-const-public
@@ -469,302 +232,233 @@ isExported: false
 id: rust-field
 language: Rust
 role: member
-parentRuleIds: [rust-struct-visible, rust-struct-public-any, rust-struct-any, rust-struct-public, rust-struct]
+parentRuleIds: [rust-struct]
 symbolType: field
 rule:
-  kind: field_declaration
-  has:
-    field: name
-    pattern: $NAME
+  all:
+    - kind: field_declaration
+    - has:
+        field: name
+        pattern: $NAME
 name: '$NAME'
 isPublic:
-  regex: '^pub\b'
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-enum-variant
 language: Rust
 role: member
-parentRuleIds: [rust-enum-visible, rust-enum-public-any, rust-enum-any, rust-enum-public, rust-enum]
+parentRuleIds: [rust-enum]
 symbolType: enumMember
 rule:
-  kind: enum_variant
-  has:
-    field: name
-    pattern: $NAME
+  all:
+    - kind: enum_variant
+    - has:
+        field: name
+        pattern: $NAME
 name: '$NAME'
 signature: '$NAME'
-isPublic: true
----
-id: rust-mod-member-function-public
-language: Rust
-role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
-symbolType: function
-rule:
-  pattern:
-    context: 'mod A { pub fn $NAME($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS)'
 isPublic: true
 ---
 id: rust-mod-member-function
 language: Rust
 role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+parentRuleIds: [rust-mod]
 symbolType: function
 rule:
-  pattern:
-    context: 'mod A { fn $NAME($$$ARGS) { $$$BODY } }'
-    selector: function_item
+  all:
+    - kind: function_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+    - not:
+        inside:
+          kind: impl_item
+          stopBy: end
+    - not:
+        inside:
+          kind: trait_item
+          stopBy: end
+    - not:
+        inside:
+          kind: block
+          stopBy: end
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'fn $NAME($$$ARGS)'
-isPublic: false
----
-id: rust-mod-member-function-public-return
-language: Rust
-role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
-symbolType: function
-rule:
-  pattern:
-    context: 'mod A { pub fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS) -> $RET'
-isPublic: true
----
-id: rust-mod-member-function-return
-language: Rust
-role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
-symbolType: function
-rule:
-  pattern:
-    context: 'mod A { fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS) -> $RET'
-isPublic: false
----
-id: rust-mod-member-struct-public
-language: Rust
-role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
-symbolType: struct
-rule:
-  pattern:
-    context: 'mod A { pub struct $NAME { $$$BODY } }'
-    selector: struct_item
-name: '$NAME'
-signature: 'pub struct $NAME'
-isPublic: true
+signature: '$SIG'
+isPublic:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-mod-member-struct
 language: Rust
 role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+parentRuleIds: [rust-mod]
 symbolType: struct
 rule:
-  pattern:
-    context: 'mod A { struct $NAME { $$$BODY } }'
-    selector: struct_item
+  all:
+    - kind: struct_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+    - not:
+        inside:
+          kind: block
+          stopBy: end
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$|;\s*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'struct $NAME'
-isPublic: false
----
-id: rust-mod-member-enum-public
-language: Rust
-role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
-symbolType: enum
-rule:
-  pattern:
-    context: 'mod A { pub enum $NAME { $$$BODY } }'
-    selector: enum_item
-name: '$NAME'
-signature: 'pub enum $NAME'
-isPublic: true
+signature: '$SIG'
+isPublic:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
 id: rust-mod-member-enum
 language: Rust
 role: member
-parentRuleIds: [rust-mod-inline-public, rust-mod-inline]
+parentRuleIds: [rust-mod]
 symbolType: enum
 rule:
-  pattern:
-    context: 'mod A { enum $NAME { $$$BODY } }'
-    selector: enum_item
+  all:
+    - kind: enum_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+    - not:
+        inside:
+          kind: block
+          stopBy: end
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'enum $NAME'
-isPublic: false
+signature: '$SIG'
+isPublic:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
 ---
-id: rust-method-public
+id: rust-impl-method
 language: Rust
 role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { pub fn $NAME($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS)'
-isPublic: true
----
-id: rust-method
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS)'
-isPublic: false
----
-id: rust-method-public-return
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { pub fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME($$$ARGS) -> $RET'
-isPublic: true
----
-id: rust-method-return
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME($$$ARGS) -> $RET'
-isPublic: false
----
-id: rust-method-visible
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+parentRuleIds: [rust-impl]
 symbolType: method
 rule:
   all:
     - kind: function_item
-    - regex: '^pub\('
+    - pattern: $DECL
     - has:
         field: name
         pattern: $NAME
+    - not:
+        inside:
+          kind: block
+          stopBy: end
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
+signature: '$SIG'
+isPublic:
+  has:
+    kind: visibility_modifier
+    regex: '^pub'
+---
+id: rust-trait-method-signature
+language: Rust
+role: member
+parentRuleIds: [rust-trait]
+symbolType: method
+rule:
+  all:
+    - kind: function_signature_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: ';\s*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
+name: '$NAME'
+signature: '$SIG'
 isPublic: true
 ---
-id: rust-method-public-generic-return-where
+id: rust-trait-method-default
 language: Rust
 role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
+parentRuleIds: [rust-trait]
 symbolType: method
 rule:
-  pattern:
-    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY } }'
-    selector: function_item
+  all:
+    - kind: function_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+    - not:
+        inside:
+          kind: block
+          stopBy: end
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+  SIG:
+    replace:
+      source: $BODYLESS
+      replace: '\n[\s\S]*$'
+      by: ''
 name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
+signature: '$SIG'
 isPublic: true
----
-id: rust-method-generic-return-where
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) -> $RET where $$$WHERE { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isPublic: false
----
-id: rust-method-public-generic-where
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
-isPublic: true
----
-id: rust-method-generic-where
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) where $$$WHERE { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
-isPublic: false
----
-id: rust-method-public-generic
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS)'
-isPublic: true
----
-id: rust-method-generic
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS)'
-isPublic: false
----
-id: rust-method-public-generic-return
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'pub fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isPublic: true
----
-id: rust-method-generic-return
-language: Rust
-role: member
-parentRuleIds: [rust-impl-trait-generic, rust-impl-trait, rust-impl-generic, rust-impl, rust-trait-public, rust-trait]
-symbolType: method
-rule:
-  pattern:
-    context: 'impl A { fn $NAME<$$$GENERICS>($$$ARGS) -> $RET { $$$BODY } }'
-    selector: function_item
-name: '$NAME'
-signature: 'fn $NAME<$$$GENERICS>($$$ARGS) -> $RET'
-isPublic: false


### PR DESCRIPTION
fix #2742 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Rust outline extraction rules by consolidating multiple specialized rules into fewer, more general declaration-based rules.

* **Tests**
  * Added comprehensive test coverage for async function and method extraction, including async trait methods and generic declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->