### PR TITLE
feat: apply outline extractor options

### DIFF
--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 
 use crate::extractor::{ItemExtractor, MemberExtractor, OutlineRuleError, SerializableOutlineRule};
 use crate::model::{OutlineItem, OutlineMember};
+use crate::options::OutlineExtractorOptions;
 
 /// Runtime outline extractors organized for a shared item traversal.
 pub struct CombinedExtractors<L: Language> {
@@ -34,6 +35,8 @@ pub struct CombinedExtractors<L: Language> {
   member_extractors: Vec<MemberExtractor<L>>,
   /// Parent item extractor id to member extractors that may run inside it.
   member_mapping: HashMap<String, CombinedMemberExtractorGroup>,
+  /// Runtime filters and detail level requested by the caller.
+  options: OutlineExtractorOptions,
 }
 
 pub struct CombinedMemberExtractors<'a, L: Language> {
@@ -54,24 +57,58 @@ impl<L: Language> CombinedExtractors<L> {
     extractors: Vec<SerializableOutlineRule<L>>,
     globals: &GlobalRules,
   ) -> Result<Self, OutlineRuleError> {
-    let mut item_extractors = vec![];
-    let mut member_extractors = vec![];
+    Self::try_from_rules(extractors, OutlineExtractorOptions::default(), globals)
+  }
+
+  pub fn try_from_rules(
+    extractors: Vec<SerializableOutlineRule<L>>,
+    options: OutlineExtractorOptions,
+    globals: &GlobalRules,
+  ) -> Result<Self, OutlineRuleError> {
+    let mut item_extractors = Vec::with_capacity(extractors.len());
+    let mut member_extractors = Vec::with_capacity(extractors.len());
+    // NB: if member option is None, we won't pass any member extractors
+    // so this is safe to fallback to default as we won't use it
+    let member_options = options.members.clone().unwrap_or_default();
     for extractor in extractors {
+      if !options.retain_rule(&extractor) {
+        continue;
+      }
       match extractor {
         SerializableOutlineRule::Item(item) => {
-          item_extractors.push(ItemExtractor::try_from(item, globals)?);
+          item_extractors.push(ItemExtractor::try_from(item, globals, options.detail)?);
         }
         SerializableOutlineRule::Member(member) => {
-          member_extractors.push(MemberExtractor::try_from(member, globals)?);
+          member_extractors.push(MemberExtractor::try_from(
+            member,
+            globals,
+            member_options.detail,
+          )?);
         }
       }
     }
-    Ok(Self::new(item_extractors, member_extractors))
+    Ok(Self::new_with_options(
+      item_extractors,
+      member_extractors,
+      options,
+    ))
   }
 
   pub fn new(
     item_extractors: Vec<ItemExtractor<L>>,
     member_extractors: Vec<MemberExtractor<L>>,
+  ) -> Self {
+    Self::new_with_options(
+      item_extractors,
+      member_extractors,
+      OutlineExtractorOptions::default(),
+    )
+  }
+
+  pub fn new_with_options(
+    item_extractors: Vec<ItemExtractor<L>>,
+    member_extractors: Vec<MemberExtractor<L>>,
+    options: OutlineExtractorOptions,
   ) -> Self {
     let item_kind_mapping = item_kind_mapping(&item_extractors);
     let member_mapping = member_mapping(&member_extractors);
@@ -80,6 +117,7 @@ impl<L: Language> CombinedExtractors<L> {
       item_kind_mapping,
       member_extractors,
       member_mapping,
+      options,
     }
   }
 
@@ -109,8 +147,12 @@ impl<L: Language> CombinedExtractors<L> {
     let matcher = ItemTraversalMatcher { combined: self };
     for matched in Visitor::new(matcher).reentrant(false).visit(root) {
       if let Some((extractor, node_match)) = self.match_item(matched.get_node()) {
-        let members = self.extract_members(extractor, node_match.get_node());
-        items.push(extractor.extract(&node_match, members));
+        let mut members = self.extract_members(extractor, node_match.get_node());
+        members.retain(|member| self.options.keep_member(member));
+        let item = extractor.extract(&node_match, members);
+        if self.options.keep_item(&item) {
+          items.push(item);
+        }
       }
     }
     items
@@ -263,6 +305,7 @@ fn member_mapping<L: Language>(
 mod tests {
   use super::*;
   use crate::extractor::parse_outline_rules;
+  use crate::options::{OutlineEntryDetail, OutlineExtractorOptions, OutlineFlagFilter};
   use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_language::SupportLang;
 
@@ -401,5 +444,96 @@ function standalone() {}
     assert_eq!(items[0].members.len(), 1);
     assert_eq!(items[0].members[0].entry.name, "parse");
     assert_eq!(items[0].members[0].entry.signature, "parse()");
+  }
+
+  #[test]
+  fn compile_options_disable_members_and_name_only_signatures() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  pattern: class $NAME { $$$BODY }
+name: $NAME
+signature: class $NAME
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+rule:
+  pattern:
+    context: class A { $NAME() { $$$BODY } }
+    selector: method_definition
+name: $NAME
+signature: $NAME()
+"#,
+    )
+    .expect("extractors should deserialize");
+    let options = OutlineExtractorOptions {
+      members: None,
+      detail: OutlineEntryDetail::Name,
+      ..Default::default()
+    };
+    let combined = CombinedExtractors::try_from_rules(extractors, options, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep("class Box { parse() {} }");
+
+    let items = combined.extract(grep.root());
+
+    assert!(combined.member_extractors.is_empty());
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].entry.name, "Box");
+    assert!(items[0].entry.signature.is_empty());
+    assert!(items[0].members.is_empty());
+  }
+
+  #[test]
+  fn compile_options_filter_rules_and_runtime_flags() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-import
+language: TypeScript
+role: item
+symbolType: module
+rule:
+  kind: import_statement
+name: import
+isImport: true
+isExported: false
+---
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  pattern: function $NAME() { $$$BODY }
+name: $NAME
+isImport: false
+"#,
+    )
+    .expect("extractors should deserialize");
+    let options = OutlineExtractorOptions {
+      imports: OutlineFlagFilter::Yes,
+      ..Default::default()
+    };
+    let combined = CombinedExtractors::try_from_rules(extractors, options, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(
+      r#"
+import { readFile } from 'node:fs';
+function local() {}
+"#,
+    );
+
+    let items = combined.extract(grep.root());
+
+    assert_eq!(combined.item_extractors.len(), 1);
+    assert_eq!(combined.item_extractors[0].common.rule.id, "ts-import");
+    assert_eq!(items.len(), 1);
+    assert!(items[0].is_import);
   }
 }

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 use crate::model::{
   EntryRole, OutlineEntry, OutlineItem, OutlineMember, SourcePosition, SourceRange, SymbolType,
 };
+use crate::options::OutlineEntryDetail;
 
 /// Serializable outline extractor definition loaded from an outline rule YAML document.
 ///
@@ -138,6 +139,8 @@ pub struct ExtractorCommon<L: Language> {
   pub name: TemplateFix,
   /// Optional source-like signature template.
   pub signature: Option<TemplateFix>,
+  /// Requested text detail for this entry.
+  detail: OutlineEntryDetail,
 }
 
 #[derive(Debug, Error)]
@@ -155,18 +158,23 @@ impl<L: Language> ExtractorCommon<L> {
   pub fn try_from(
     common: SerializableOutlineCommon<L>,
     globals: &GlobalRules,
+    detail: OutlineEntryDetail,
   ) -> Result<Self, OutlineRuleError> {
     let symbol_type = common.symbol_type;
     let transform_vars = transform_vars(&common.matcher);
     let compile = |tmpl| compile_template(tmpl, &common.language, &transform_vars);
     let name = compile(&common.name)?;
-    let signature = common.signature.as_deref().map(compile).transpose()?;
+    let signature = match detail {
+      OutlineEntryDetail::Name => None,
+      OutlineEntryDetail::Signature => common.signature.as_deref().map(compile).transpose()?,
+    };
     let rule = RuleConfig::try_from(common.into_rule_config(), globals)?;
     Ok(Self {
       rule,
       symbol_type,
       name,
       signature,
+      detail,
     })
   }
 
@@ -242,13 +250,14 @@ impl<L: Language> ItemExtractor<L> {
   pub fn try_from(
     item: SerializableItemRule<L>,
     globals: &GlobalRules,
+    detail: OutlineEntryDetail,
   ) -> Result<Self, OutlineRuleError> {
     let SerializableItemRule {
       common,
       is_import,
       is_exported,
     } = item;
-    let common = ExtractorCommon::try_from(common, globals)?;
+    let common = ExtractorCommon::try_from(common, globals, detail)?;
     let is_import = common.compile_predicate(is_import, false)?;
     let is_exported = common.compile_predicate(is_exported, true)?;
     Ok(Self {
@@ -287,13 +296,14 @@ impl<L: Language> MemberExtractor<L> {
   pub fn try_from(
     member: SerializableMemberRule<L>,
     globals: &GlobalRules,
+    detail: OutlineEntryDetail,
   ) -> Result<Self, OutlineRuleError> {
     let SerializableMemberRule {
       common,
       parent_rule_ids,
       is_public,
     } = member;
-    let common = ExtractorCommon::try_from(common, globals)?;
+    let common = ExtractorCommon::try_from(common, globals, detail)?;
     let is_public = common.compile_predicate(is_public, true)?;
     Ok(Self {
       common,
@@ -326,13 +336,19 @@ impl<L: Language> ExtractorCommon<L> {
       symbol_type: self.symbol_type,
       name: render_template(&self.name, node_match).into(),
       range: source_range(node),
-      signature: self
+      signature: self.render_signature(node_match).into(),
+      ast_kind: node.kind().into_owned().into(),
+    }
+  }
+
+  fn render_signature<'tree, D: Doc>(&self, node_match: &NodeMatch<'tree, D>) -> String {
+    match self.detail {
+      OutlineEntryDetail::Name => String::new(),
+      OutlineEntryDetail::Signature => self
         .signature
         .as_ref()
         .map(|template| render_template(template, node_match))
-        .unwrap_or_else(|| default_signature(node))
-        .into(),
-      ast_kind: node.kind().into_owned().into(),
+        .unwrap_or_else(|| default_signature(node_match.get_node())),
     }
   }
 }
@@ -565,8 +581,12 @@ signature: function $NAME()
     let SerializableOutlineRule::Item(item) = rule else {
       panic!("expected item rule");
     };
-    let common = ExtractorCommon::try_from(item.common, &Default::default())
-      .expect("common rule should parse");
+    let common = ExtractorCommon::try_from(
+      item.common,
+      &Default::default(),
+      OutlineEntryDetail::Signature,
+    )
+    .expect("common rule should parse");
 
     assert_eq!(common.rule.id, "ts-function");
     assert_eq!(common.symbol_type, SymbolType::Function);
@@ -597,7 +617,8 @@ isImport: true
     let SerializableOutlineRule::Item(item) = rule else {
       panic!("expected item rule");
     };
-    let item = ItemExtractor::try_from(item, &Default::default()).expect("item rule should parse");
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Signature)
+      .expect("item rule should parse");
 
     assert_eq!(item.common.rule.id, "ts-function");
     assert!(matches!(item.is_import, OutlinePredicate::Literal(true)));
@@ -626,7 +647,8 @@ isExported:
     let SerializableOutlineRule::Item(item) = rule else {
       panic!("expected item rule");
     };
-    let item = ItemExtractor::try_from(item, &Default::default()).expect("item rule should parse");
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Signature)
+      .expect("item rule should parse");
     let root = SupportLang::TypeScript.ast_grep("class Foo { bar() {} }");
     let class_node = root
       .root()
@@ -661,7 +683,8 @@ name: member
       panic!("expected member rule");
     };
     let member =
-      MemberExtractor::try_from(member, &Default::default()).expect("member rule should parse");
+      MemberExtractor::try_from(member, &Default::default(), OutlineEntryDetail::Signature)
+        .expect("member rule should parse");
 
     assert_eq!(member.common.rule.id, "ts-member");
     assert_eq!(member.parent_rule_ids, vec!["ts-interface"]);


### PR DESCRIPTION
Stacked on #2745.\n\nThis PR wires outline extractor options into rule compilation and extraction, including safe rule pruning, runtime filtering, and name-only signature detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable extraction options to control whether items and members are compiled and retained during outline processing.
  * Introduced an entry “detail” mode to switch output between name-only and full signature rendering.

* **Enhancements**
  * Extraction now applies option-driven filtering consistently, so only matching rules are compiled and extracted (including correct import/export classification).
  * Items and members are included or suppressed according to the selected retention settings.

* **Tests**
  * Updated and expanded unit tests to cover member/item suppression, detail-driven signature behavior, and import/export filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->