### PR TITLE
refactor: map outline cli to core options

### DIFF
--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -133,8 +133,11 @@ pub struct OutlineArg {
 
 pub fn run_outline(arg: OutlineArg) -> Result<ExitCode> {
   let rules = load_outline_rules(!arg.no_default_outline_rules, &arg.outline_rules)?;
-  let extractors = Arc::new(OutlineExtractors::try_from(rules)?);
   let options = OutlineTextOptions::try_from_arg(&arg)?;
+  let extractors = Arc::new(OutlineExtractors::try_from(
+    rules,
+    &options.to_extractor_options(),
+  )?);
   let stdout = io::stdout();
   let mut emitter = OutlineEmitter::new(io::BufWriter::new(stdout.lock()), arg.json, &options);
   if arg.input.stdin {

--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -13,6 +13,7 @@ use ast_grep_outline::{
   combined_extractor::CombinedExtractors,
   extractor::{SerializableOutlineRule, parse_outline_rules},
   model::{OutlineEntry, OutlineItem, OutlineMember},
+  options::OutlineExtractorOptions,
 };
 use ignore::WalkState;
 use serde::Serialize;
@@ -21,7 +22,7 @@ use crate::lang::SgLang;
 use crate::utils::{InputArgs, read_file};
 
 use super::OutlineArg;
-use super::options::{OutlineTextOptions, matches_item_filters};
+use super::options::{OutlineTextOptions, matches_item_matcher};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,7 +40,10 @@ pub(super) struct OutlineExtractors {
 }
 
 impl OutlineExtractors {
-  pub(super) fn try_from(rules: Vec<SerializableOutlineRule<SgLang>>) -> Result<Self> {
+  pub(super) fn try_from(
+    rules: Vec<SerializableOutlineRule<SgLang>>,
+    options: &OutlineExtractorOptions,
+  ) -> Result<Self> {
     let mut rules_by_lang: HashMap<SgLang, Vec<SerializableOutlineRule<SgLang>>> = HashMap::new();
     for rule in rules {
       rules_by_lang
@@ -50,7 +54,7 @@ impl OutlineExtractors {
     let by_lang = rules_by_lang
       .into_iter()
       .map(|(lang, rules)| {
-        CombinedExtractors::try_from(rules, &Default::default())
+        CombinedExtractors::try_from_rules(rules, options.clone(), &Default::default())
           .map(|extractors| (lang, extractors))
       })
       .collect::<Result<_, _>>()?;
@@ -78,12 +82,7 @@ impl OutlineExtractors {
         extractors
           .extract(root)
           .into_iter()
-          .filter_map(|mut item| {
-            if options.pub_members {
-              item.members.retain(|member| member.is_public);
-            }
-            matches_item_filters(&item, options).then(|| own_item(item))
-          })
+          .filter_map(|item| matches_item_matcher(&item, options).then(|| own_item(item)))
           .collect()
       })
       .unwrap_or_default()

--- a/crates/cli/src/outline/options.rs
+++ b/crates/cli/src/outline/options.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result};
-use ast_grep_outline::model::{OutlineItem, SymbolType};
+use ast_grep_outline::{
+  model::{OutlineItem, SymbolType},
+  options::{OutlineEntryDetail, OutlineExtractorOptions, OutlineFlagFilter, OutlineMemberOptions},
+};
 use regex::Regex;
 
 use super::{OutlineArg, OutlineItems, OutlineView};
@@ -36,6 +39,52 @@ impl OutlineTextOptions {
       use_color: arg.color.should_use_color(),
       show_empty_files: arg.input.stdin || !has_directory_input,
     })
+  }
+
+  pub(super) fn to_extractor_options(&self) -> OutlineExtractorOptions {
+    OutlineExtractorOptions {
+      symbol_types: self.symbol_types.clone(),
+      imports: match self.items {
+        OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
+        OutlineItems::Structure => OutlineFlagFilter::No,
+        OutlineItems::Imports => OutlineFlagFilter::Yes,
+        OutlineItems::Exports | OutlineItems::All => OutlineFlagFilter::Any,
+      },
+      exported: match self.items {
+        OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
+        OutlineItems::Exports => OutlineFlagFilter::Yes,
+        OutlineItems::Structure | OutlineItems::Imports | OutlineItems::All => {
+          OutlineFlagFilter::Any
+        }
+      },
+      detail: if self.item_matcher.is_some() {
+        OutlineEntryDetail::Signature
+      } else {
+        match self.view {
+          OutlineView::Auto => unreachable!("outline view should be resolved"),
+          OutlineView::Names => OutlineEntryDetail::Name,
+          OutlineView::Signatures | OutlineView::Digest | OutlineView::Expanded => {
+            OutlineEntryDetail::Signature
+          }
+        }
+      },
+      members: matches!(self.view, OutlineView::Digest | OutlineView::Expanded).then(|| {
+        OutlineMemberOptions {
+          public: if self.pub_members {
+            OutlineFlagFilter::Yes
+          } else {
+            OutlineFlagFilter::Any
+          },
+          detail: match self.view {
+            OutlineView::Auto => unreachable!("outline view should be resolved"),
+            OutlineView::Names | OutlineView::Signatures | OutlineView::Digest => {
+              OutlineEntryDetail::Name
+            }
+            OutlineView::Expanded => OutlineEntryDetail::Signature,
+          },
+        }
+      }),
+    }
   }
 }
 
@@ -102,28 +151,8 @@ fn parse_symbol_type(raw: &str) -> Option<SymbolType> {
   })
 }
 
-pub(super) fn matches_item_filters(item: &OutlineItem, options: &OutlineTextOptions) -> bool {
-  matches_items_mode(item, options.items)
-    && matches_symbol_type(item, options.symbol_types.as_deref())
-    && matches_item_regex(item, options.item_matcher.as_ref())
-}
-
-fn matches_items_mode(item: &OutlineItem, items: OutlineItems) -> bool {
-  match items {
-    OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
-    OutlineItems::Structure => !item.is_import,
-    OutlineItems::Exports => item.is_exported,
-    OutlineItems::Imports => item.is_import,
-    OutlineItems::All => true,
-  }
-}
-
-fn matches_symbol_type(item: &OutlineItem, symbol_types: Option<&[SymbolType]>) -> bool {
-  symbol_types.is_none_or(|types| types.contains(&item.entry.symbol_type))
-}
-
-fn matches_item_regex(item: &OutlineItem, matcher: Option<&Regex>) -> bool {
-  matcher.is_none_or(|matcher| {
+pub(super) fn matches_item_matcher(item: &OutlineItem, options: &OutlineTextOptions) -> bool {
+  options.item_matcher.as_ref().is_none_or(|matcher| {
     matcher.is_match(&item.entry.name) || matcher.is_match(&item.entry.signature)
   })
 }


### PR DESCRIPTION
Stacked on #2746.\n\nThis PR maps CLI outline item/view/member settings into core outline extractor options and keeps regex matching in the CLI layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured outline command's option handling and extractor initialization to improve internal consistency and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->