### PR TITLE
refactor: split outline extract options and style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "ast-grep-config",
  "ast-grep-core",
  "ast-grep-language",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -15,8 +15,8 @@ mod options;
 mod output;
 
 use extract::{OutlineExtractors, extract_stdin, load_outline_rules, stream_paths};
-use options::OutlineTextOptions;
-use output::OutlineEmitter;
+use options::OutlineExtractOptions;
+use output::{OutlineEmitter, OutlineStyle};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum OutlineItems {
@@ -133,17 +133,20 @@ pub struct OutlineArg {
 
 pub fn run_outline(arg: OutlineArg) -> Result<ExitCode> {
   let rules = load_outline_rules(!arg.no_default_outline_rules, &arg.outline_rules)?;
-  let options = OutlineTextOptions::try_from_arg(&arg)?;
+  let extract_options = OutlineExtractOptions::try_from_arg(&arg)?;
+  let style = OutlineStyle::from_arg(&arg);
   let extractors = Arc::new(OutlineExtractors::try_from(
     rules,
-    options.to_extractor_options(),
+    extract_options.extractor.clone(),
   )?);
   let stdout = io::stdout();
-  let mut emitter = OutlineEmitter::new(io::BufWriter::new(stdout.lock()), arg.json, &options);
+  let mut emitter = OutlineEmitter::new(io::BufWriter::new(stdout.lock()), arg.json, style);
   if arg.input.stdin {
-    emitter.emit(extract_stdin(&arg, &extractors, &options)?)?;
+    emitter.emit(extract_stdin(&arg, &extractors)?)?;
   } else {
-    stream_paths(&arg, extractors, &options, |file| emitter.emit(file))?;
+    stream_paths(&arg, extractors, &extract_options, |file| {
+      emitter.emit(file)
+    })?;
   }
   emitter.finish()?;
   Ok(ExitCode::SUCCESS)

--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -22,7 +22,7 @@ use crate::lang::SgLang;
 use crate::utils::{InputArgs, read_file};
 
 use super::OutlineArg;
-use super::options::{OutlineTextOptions, matches_item_matcher};
+use super::options::OutlineExtractOptions;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,18 +73,11 @@ impl OutlineExtractors {
     &self,
     lang: SgLang,
     root: ast_grep_core::Node<'tree, ast_grep_core::tree_sitter::StrDoc<SgLang>>,
-    options: &OutlineTextOptions,
   ) -> Vec<OutlineItem<'static>> {
     self
       .by_lang
       .get(&lang)
-      .map(|extractors| {
-        extractors
-          .extract(root)
-          .into_iter()
-          .filter_map(|item| matches_item_matcher(&item, options).then(|| own_item(item)))
-          .collect()
-      })
+      .map(|extractors| extractors.extract(root).into_iter().map(own_item).collect())
       .unwrap_or_default()
   }
 }
@@ -113,12 +106,11 @@ pub fn load_outline_rules(
 pub fn extract_stdin(
   arg: &OutlineArg,
   extractors: &OutlineExtractors,
-  options: &OutlineTextOptions,
 ) -> Result<OutlineFile<'static>> {
   let lang = arg.lang.expect("required by clap");
   let source = io::read_to_string(io::stdin())?;
   let grep = lang.ast_grep(source);
-  let items = extractors.extract(lang, grep.root(), options);
+  let items = extractors.extract(lang, grep.root());
   Ok(OutlineFile {
     path: "STDIN".to_string(),
     language: lang.to_string(),
@@ -129,7 +121,7 @@ pub fn extract_stdin(
 pub fn stream_paths(
   arg: &OutlineArg,
   extractors: Arc<OutlineExtractors>,
-  options: &OutlineTextOptions,
+  options: &OutlineExtractOptions,
   mut emit: impl FnMut(OutlineFile<'static>) -> Result<()>,
 ) -> Result<()> {
   if arg.lang.is_none() && extractors.is_empty() {
@@ -200,7 +192,7 @@ fn extract_path_or_report(
   path: &Path,
   lang: Option<SgLang>,
   extractors: &OutlineExtractors,
-  options: &OutlineTextOptions,
+  options: &OutlineExtractOptions,
 ) -> Option<OutlineFile<'static>> {
   match extract_path(path, lang, extractors, options) {
     Ok(file) => file,
@@ -215,7 +207,7 @@ fn extract_path(
   path: &Path,
   lang: Option<SgLang>,
   extractors: &OutlineExtractors,
-  options: &OutlineTextOptions,
+  options: &OutlineExtractOptions,
 ) -> Result<Option<OutlineFile<'static>>> {
   let Some(lang) = lang.or_else(|| SgLang::from_path(path)) else {
     return Ok(None);
@@ -223,7 +215,7 @@ fn extract_path(
   let source =
     read_file(path).with_context(|| format!("Cannot extract outline from {}", path.display()))?;
   let grep = lang.ast_grep(source);
-  let items = extractors.extract(lang, grep.root(), options);
+  let items = extractors.extract(lang, grep.root());
   if !options.show_empty_files && items.is_empty() {
     return Ok(None);
   }

--- a/crates/cli/src/outline/options.rs
+++ b/crates/cli/src/outline/options.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use ast_grep_outline::{
-  model::{OutlineItem, SymbolType},
+  model::SymbolType,
   options::{OutlineEntryDetail, OutlineExtractorOptions, OutlineFlagFilter, OutlineMemberOptions},
 };
 use regex::Regex;
@@ -8,87 +8,92 @@ use regex::Regex;
 use super::{OutlineArg, OutlineItems, OutlineView};
 
 #[derive(Clone)]
-pub struct OutlineTextOptions {
-  pub items: OutlineItems,
-  pub view: OutlineView,
-  pub symbol_types: Option<Vec<SymbolType>>,
-  pub item_matcher: Option<Regex>,
-  pub pub_members: bool,
-  pub use_color: bool,
+pub struct OutlineExtractOptions {
+  pub extractor: OutlineExtractorOptions,
   pub show_empty_files: bool,
 }
 
-impl OutlineTextOptions {
+impl OutlineExtractOptions {
   pub fn try_from_arg(arg: &OutlineArg) -> Result<Self> {
-    let has_directory_input = !arg.input.stdin && arg.input.paths.iter().any(|path| path.is_dir());
+    let has_directory_input = has_directory_input(arg);
+    let items = resolve_items(arg.items, has_directory_input);
+    let view = resolve_view(arg.view, has_directory_input);
+    let symbol_types = arg
+      .symbol_type
+      .as_deref()
+      .map(parse_symbol_types)
+      .transpose()?;
+    let item_regex = arg
+      .match_item
+      .as_deref()
+      .map(Regex::new)
+      .transpose()
+      .context("Cannot parse outline item matcher")?;
+    let extractor = extractor_options(items, view, symbol_types, item_regex, arg.pub_members);
     Ok(Self {
-      items: resolve_items(arg.items, has_directory_input),
-      view: resolve_view(arg.view, has_directory_input),
-      symbol_types: arg
-        .symbol_type
-        .as_deref()
-        .map(parse_symbol_types)
-        .transpose()?,
-      item_matcher: arg
-        .match_item
-        .as_deref()
-        .map(Regex::new)
-        .transpose()
-        .context("Cannot parse outline item matcher")?,
-      pub_members: arg.pub_members,
-      use_color: arg.color.should_use_color(),
+      extractor,
       show_empty_files: arg.input.stdin || !has_directory_input,
     })
   }
+}
 
-  pub fn to_extractor_options(&self) -> OutlineExtractorOptions {
-    OutlineExtractorOptions {
-      symbol_types: self.symbol_types.clone(),
-      imports: match self.items {
-        OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
-        OutlineItems::Structure => OutlineFlagFilter::No,
-        OutlineItems::Imports => OutlineFlagFilter::Yes,
-        OutlineItems::Exports | OutlineItems::All => OutlineFlagFilter::Any,
-      },
-      exported: match self.items {
-        OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
-        OutlineItems::Exports => OutlineFlagFilter::Yes,
-        OutlineItems::Structure | OutlineItems::Imports | OutlineItems::All => {
-          OutlineFlagFilter::Any
-        }
-      },
-      detail: if self.item_matcher.is_some() {
+fn extractor_options(
+  items: OutlineItems,
+  view: OutlineView,
+  symbol_types: Option<Vec<SymbolType>>,
+  item_regex: Option<Regex>,
+  pub_members: bool,
+) -> OutlineExtractorOptions {
+  let detail = if item_regex.is_some() {
+    OutlineEntryDetail::Signature
+  } else {
+    match view {
+      OutlineView::Auto => unreachable!("outline view should be resolved"),
+      OutlineView::Names => OutlineEntryDetail::Name,
+      OutlineView::Signatures | OutlineView::Digest | OutlineView::Expanded => {
         OutlineEntryDetail::Signature
-      } else {
-        match self.view {
-          OutlineView::Auto => unreachable!("outline view should be resolved"),
-          OutlineView::Names => OutlineEntryDetail::Name,
-          OutlineView::Signatures | OutlineView::Digest | OutlineView::Expanded => {
-            OutlineEntryDetail::Signature
-          }
-        }
-      },
-      members: matches!(self.view, OutlineView::Digest | OutlineView::Expanded).then(|| {
-        OutlineMemberOptions {
-          public: if self.pub_members {
-            OutlineFlagFilter::Yes
-          } else {
-            OutlineFlagFilter::Any
-          },
-          detail: match self.view {
-            OutlineView::Auto => unreachable!("outline view should be resolved"),
-            OutlineView::Names | OutlineView::Signatures | OutlineView::Digest => {
-              OutlineEntryDetail::Name
-            }
-            OutlineView::Expanded => OutlineEntryDetail::Signature,
-          },
-        }
-      }),
+      }
     }
+  };
+  OutlineExtractorOptions {
+    symbol_types,
+    item_regex,
+    imports: match items {
+      OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
+      OutlineItems::Structure => OutlineFlagFilter::No,
+      OutlineItems::Imports => OutlineFlagFilter::Yes,
+      OutlineItems::Exports | OutlineItems::All => OutlineFlagFilter::Any,
+    },
+    exported: match items {
+      OutlineItems::Auto => unreachable!("outline item mode should be resolved"),
+      OutlineItems::Exports => OutlineFlagFilter::Yes,
+      OutlineItems::Structure | OutlineItems::Imports | OutlineItems::All => OutlineFlagFilter::Any,
+    },
+    detail,
+    members: matches!(view, OutlineView::Digest | OutlineView::Expanded).then(|| {
+      OutlineMemberOptions {
+        public: if pub_members {
+          OutlineFlagFilter::Yes
+        } else {
+          OutlineFlagFilter::Any
+        },
+        detail: match view {
+          OutlineView::Auto => unreachable!("outline view should be resolved"),
+          OutlineView::Names | OutlineView::Signatures | OutlineView::Digest => {
+            OutlineEntryDetail::Name
+          }
+          OutlineView::Expanded => OutlineEntryDetail::Signature,
+        },
+      }
+    }),
   }
 }
 
-fn resolve_items(items: OutlineItems, has_directory_input: bool) -> OutlineItems {
+pub(super) fn has_directory_input(arg: &OutlineArg) -> bool {
+  !arg.input.stdin && arg.input.paths.iter().any(|path| path.is_dir())
+}
+
+pub(super) fn resolve_items(items: OutlineItems, has_directory_input: bool) -> OutlineItems {
   match (items, has_directory_input) {
     (OutlineItems::Auto, true) => OutlineItems::Exports,
     (OutlineItems::Auto, false) => OutlineItems::Structure,
@@ -96,7 +101,7 @@ fn resolve_items(items: OutlineItems, has_directory_input: bool) -> OutlineItems
   }
 }
 
-fn resolve_view(view: OutlineView, has_directory_input: bool) -> OutlineView {
+pub(super) fn resolve_view(view: OutlineView, has_directory_input: bool) -> OutlineView {
   match (view, has_directory_input) {
     (OutlineView::Auto, true) => OutlineView::Names,
     (OutlineView::Auto, false) => OutlineView::Digest,
@@ -148,11 +153,5 @@ fn parse_symbol_type(raw: &str) -> Option<SymbolType> {
     "operator" => SymbolType::Operator,
     "typeparameter" => SymbolType::TypeParameter,
     _ => return None,
-  })
-}
-
-pub fn matches_item_matcher(item: &OutlineItem, options: &OutlineTextOptions) -> bool {
-  options.item_matcher.as_ref().is_none_or(|matcher| {
-    matcher.is_match(&item.entry.name) || matcher.is_match(&item.entry.signature)
   })
 }

--- a/crates/cli/src/outline/output.rs
+++ b/crates/cli/src/outline/output.rs
@@ -7,28 +7,47 @@ use ast_grep_outline::model::{OutlineEntry, OutlineItem, OutlineMember, SymbolTy
 use crate::print::JsonStyle;
 
 use super::extract::OutlineFile;
-use super::options::OutlineTextOptions;
-use super::{OutlineItems, OutlineView};
+use super::options::{has_directory_input, resolve_items, resolve_view};
+use super::{OutlineArg, OutlineItems, OutlineView};
 
 #[cfg(test)]
 mod tests;
 
-pub struct OutlineEmitter<'a, W> {
+pub struct OutlineStyle {
+  view: OutlineView,
+  text: OutlineTextStyle,
+}
+
+impl OutlineStyle {
+  pub fn from_arg(arg: &OutlineArg) -> Self {
+    let has_directory_input = has_directory_input(arg);
+    let items = resolve_items(arg.items, has_directory_input);
+    let view = resolve_view(arg.view, has_directory_input);
+    Self::new(view, arg.color.should_use_color(), items)
+  }
+
+  fn new(view: OutlineView, use_color: bool, items: OutlineItems) -> Self {
+    Self {
+      view,
+      text: OutlineTextStyle::new(use_color, items),
+    }
+  }
+}
+
+pub struct OutlineEmitter<W> {
   out: W,
   json: Option<JsonStyle>,
-  options: &'a OutlineTextOptions,
-  text_style: OutlineTextStyle,
+  style: OutlineStyle,
   is_first: bool,
   emitted_any: bool,
 }
 
-impl<'a, W: Write> OutlineEmitter<'a, W> {
-  pub fn new(out: W, json: Option<JsonStyle>, options: &'a OutlineTextOptions) -> Self {
+impl<W: Write> OutlineEmitter<W> {
+  pub fn new(out: W, json: Option<JsonStyle>, style: OutlineStyle) -> Self {
     Self {
       out,
       json,
-      options,
-      text_style: OutlineTextStyle::new(options.use_color, options.items),
+      style,
       is_first: true,
       emitted_any: false,
     }
@@ -42,13 +61,7 @@ impl<'a, W: Write> OutlineEmitter<'a, W> {
         serde_json::to_writer(&mut self.out, &file)?;
         writeln!(self.out)?;
       }
-      None => print_text_file_to(
-        &mut self.out,
-        &file,
-        self.options,
-        &self.text_style,
-        self.is_first,
-      )?,
+      None => print_text_file_to(&mut self.out, &file, &self.style, self.is_first)?,
     }
     self.is_first = false;
     self.emitted_any = true;
@@ -110,15 +123,14 @@ impl<'a, W: Write> OutlineEmitter<'a, W> {
 fn print_text_to(
   mut out: &mut impl Write,
   files: &[OutlineFile],
-  options: &OutlineTextOptions,
+  style: &OutlineStyle,
 ) -> Result<()> {
-  let style = OutlineTextStyle::new(options.use_color, options.items);
   if files.is_empty() {
     writeln!(out, "nothing found")?;
     return Ok(());
   }
   for (idx, file) in files.iter().enumerate() {
-    print_text_file_to(&mut out, file, options, &style, idx == 0)?;
+    print_text_file_to(&mut out, file, style, idx == 0)?;
   }
   Ok(())
 }
@@ -126,24 +138,24 @@ fn print_text_to(
 fn print_text_file_to(
   mut out: &mut impl Write,
   file: &OutlineFile,
-  options: &OutlineTextOptions,
-  style: &OutlineTextStyle,
+  style: &OutlineStyle,
   is_first: bool,
 ) -> Result<()> {
   if !is_first {
     writeln!(out)?;
   }
-  writeln!(out, "{}", style.file(&file.path))?;
+  let text_style = &style.text;
+  writeln!(out, "{}", text_style.file(&file.path))?;
   if file.items.is_empty() {
     writeln!(out, "nothing found")?;
   } else {
     let line_number_width = line_number_width(file);
-    match options.view {
+    match style.view {
       OutlineView::Auto => unreachable!("outline view should be resolved"),
-      OutlineView::Names => print_names(&mut out, file, style)?,
-      OutlineView::Signatures => print_signatures(&mut out, file, style, line_number_width)?,
-      OutlineView::Digest => print_digest(&mut out, file, style, line_number_width)?,
-      OutlineView::Expanded => print_expanded(&mut out, file, style, line_number_width)?,
+      OutlineView::Names => print_names(&mut out, file, text_style)?,
+      OutlineView::Signatures => print_signatures(&mut out, file, text_style, line_number_width)?,
+      OutlineView::Digest => print_digest(&mut out, file, text_style, line_number_width)?,
+      OutlineView::Expanded => print_expanded(&mut out, file, text_style, line_number_width)?,
     }
   }
   Ok(())

--- a/crates/cli/src/outline/output/tests.rs
+++ b/crates/cli/src/outline/output/tests.rs
@@ -9,16 +9,12 @@ use crate::print::JsonStyle;
 use super::*;
 use crate::outline::{OutlineItems, OutlineView};
 
-fn options(view: OutlineView) -> OutlineTextOptions {
-  OutlineTextOptions {
-    items: OutlineItems::All,
-    view,
-    symbol_types: None,
-    item_matcher: None,
-    pub_members: false,
-    use_color: false,
-    show_empty_files: true,
-  }
+fn style(view: OutlineView) -> OutlineStyle {
+  OutlineStyle::new(view, false, OutlineItems::All)
+}
+
+fn color_style(view: OutlineView) -> OutlineStyle {
+  OutlineStyle::new(view, true, OutlineItems::All)
 }
 
 fn range(line: usize) -> SourceRange {
@@ -84,12 +80,8 @@ fn outline_file() -> OutlineFile<'static> {
 #[test]
 fn renders_digest_like_design_doc() {
   let mut output = vec![];
-  print_text_to(
-    &mut output,
-    &[outline_file()],
-    &options(OutlineView::Digest),
-  )
-  .expect("text should render");
+  print_text_to(&mut output, &[outline_file()], &style(OutlineView::Digest))
+    .expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert_eq!(
@@ -104,7 +96,7 @@ fn renders_expanded_members_like_design_doc() {
   print_text_to(
     &mut output,
     &[outline_file()],
-    &options(OutlineView::Expanded),
+    &style(OutlineView::Expanded),
   )
   .expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
@@ -125,7 +117,7 @@ fn aligns_line_numbers_to_file_width() {
     members: vec![],
   });
   let mut output = vec![];
-  print_text_to(&mut output, &[file], &options(OutlineView::Expanded)).expect("text should render");
+  print_text_to(&mut output, &[file], &style(OutlineView::Expanded)).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert_eq!(
@@ -141,7 +133,7 @@ fn aligns_line_numbers_to_file_width() {
     members: vec![],
   });
   let mut output = vec![];
-  print_text_to(&mut output, &[file], &options(OutlineView::Digest)).expect("text should render");
+  print_text_to(&mut output, &[file], &style(OutlineView::Digest)).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert!(output.contains("\n       method: parse, recover\n"));
@@ -155,7 +147,7 @@ fn renders_empty_direct_file_block() {
     language: "TypeScript".to_string(),
     items: vec![],
   };
-  print_text_to(&mut output, &[file], &options(OutlineView::Digest)).expect("text should render");
+  print_text_to(&mut output, &[file], &style(OutlineView::Digest)).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert_eq!(output, "src/empty.ts\nnothing found\n");
@@ -170,7 +162,7 @@ fn separates_file_blocks_with_blank_line() {
   print_text_to(
     &mut output,
     &[first, second],
-    &options(OutlineView::Signatures),
+    &style(OutlineView::Signatures),
   )
   .expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
@@ -180,10 +172,10 @@ fn separates_file_blocks_with_blank_line() {
 
 #[test]
 fn emitter_streams_text_file_blocks() {
-  let options = options(OutlineView::Signatures);
+  let style = style(OutlineView::Signatures);
   let mut output = vec![];
   {
-    let mut emitter = OutlineEmitter::new(&mut output, None, &options);
+    let mut emitter = OutlineEmitter::new(&mut output, None, style);
     emitter.emit(outline_file()).expect("file should emit");
     let mut second = outline_file();
     second.path = "src/checker.ts".to_string();
@@ -197,10 +189,10 @@ fn emitter_streams_text_file_blocks() {
 
 #[test]
 fn emitter_streams_json_lines_per_file() {
-  let options = options(OutlineView::Signatures);
+  let style = style(OutlineView::Signatures);
   let mut output = vec![];
   {
-    let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Stream), &options);
+    let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Stream), style);
     emitter.emit(outline_file()).expect("file should emit");
     let mut second = outline_file();
     second.path = "src/checker.ts".to_string();
@@ -218,10 +210,10 @@ fn emitter_streams_json_lines_per_file() {
 
 #[test]
 fn emitter_streams_valid_compact_json_array() {
-  let options = options(OutlineView::Signatures);
+  let style = style(OutlineView::Signatures);
   let mut output = vec![];
   {
-    let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Compact), &options);
+    let mut emitter = OutlineEmitter::new(&mut output, Some(JsonStyle::Compact), style);
     emitter.emit(outline_file()).expect("file should emit");
     let mut second = outline_file();
     second.path = "src/checker.ts".to_string();
@@ -236,10 +228,9 @@ fn emitter_streams_valid_compact_json_array() {
 
 #[test]
 fn signature_view_styles_exported_items() {
-  let mut options = options(OutlineView::Signatures);
-  options.use_color = true;
+  let style = color_style(OutlineView::Signatures);
   let mut output = vec![];
-  print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+  print_text_to(&mut output, &[outline_file()], &style).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert!(output.contains("export class \u{1b}[1;34mParser\u{1b}[0m"));
@@ -306,19 +297,18 @@ fn styles_outline_flags_with_ansi() {
 
 #[test]
 fn keeps_digest_and_names_entries_uncolored() {
-  let mut options = options(OutlineView::Names);
-  options.use_color = true;
+  let style = color_style(OutlineView::Names);
   let mut output = vec![];
-  print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+  print_text_to(&mut output, &[outline_file()], &style).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert!(output.contains("Parser"));
   assert!(!output.contains("\u{1b}[34mParser"));
   assert!(output.contains("\u{1b}[1mParser"));
 
-  options.view = OutlineView::Digest;
+  let style = color_style(OutlineView::Digest);
   let mut output = vec![];
-  print_text_to(&mut output, &[outline_file()], &options).expect("text should render");
+  print_text_to(&mut output, &[outline_file()], &style).expect("text should render");
   let output = String::from_utf8(output).expect("output should be utf8");
 
   assert!(output.contains("parse"));

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -17,6 +17,7 @@ ast-grep-config.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 ast-grep-language.workspace = true

--- a/crates/outline/src/options.rs
+++ b/crates/outline/src/options.rs
@@ -5,12 +5,15 @@
 
 use crate::extractor::{SerializableOutlineRule, SerializablePredicate};
 use crate::model::{OutlineItem, OutlineMember, SymbolType};
+use regex::Regex;
 
 /// Options for compiling and extracting an outline.
 #[derive(Clone, Debug)]
 pub struct OutlineExtractorOptions {
   /// Top-level item symbol types to include. `None` accepts every symbol type.
   pub symbol_types: Option<Vec<SymbolType>>,
+  /// Regex matched against top-level item names and signatures.
+  pub item_regex: Option<Regex>,
   /// Filter for whether a top-level item is an import.
   pub imports: OutlineFlagFilter,
   /// Filter for whether a top-level item is exported.
@@ -25,6 +28,7 @@ impl Default for OutlineExtractorOptions {
   fn default() -> Self {
     Self {
       symbol_types: None,
+      item_regex: None,
       imports: OutlineFlagFilter::Any,
       exported: OutlineFlagFilter::Any,
       detail: OutlineEntryDetail::Signature,
@@ -103,6 +107,7 @@ impl OutlineExtractorOptions {
   /// Returns whether a concrete extracted item should be returned.
   pub fn keep_item(&self, item: &OutlineItem) -> bool {
     matches_symbol_type(item.entry.symbol_type, self.symbol_types.as_deref())
+      && matches_item_regex(item, self.item_regex.as_ref())
       && self.imports.matches_value(item.is_import)
       && self.exported.matches_value(item.is_exported)
   }
@@ -138,6 +143,12 @@ impl OutlineFlagFilter {
 
 fn matches_symbol_type(symbol_type: SymbolType, filters: Option<&[SymbolType]>) -> bool {
   filters.is_none_or(|filters| filters.contains(&symbol_type))
+}
+
+fn matches_item_regex(item: &OutlineItem, matcher: Option<&Regex>) -> bool {
+  matcher.is_none_or(|matcher| {
+    matcher.is_match(&item.entry.name) || matcher.is_match(&item.entry.signature)
+  })
 }
 
 #[cfg(test)]
@@ -253,9 +264,24 @@ isPublic: false
       }),
       ..Default::default()
     };
+    let matching_name_options = OutlineExtractorOptions {
+      item_regex: Some(Regex::new("name").expect("regex should compile")),
+      ..Default::default()
+    };
+    let matching_signature_options = OutlineExtractorOptions {
+      item_regex: Some(Regex::new("signature").expect("regex should compile")),
+      ..Default::default()
+    };
+    let missing_match_options = OutlineExtractorOptions {
+      item_regex: Some(Regex::new("missing").expect("regex should compile")),
+      ..Default::default()
+    };
 
     assert!(exported_options.keep_item(&exported_function));
     assert!(!import_options.keep_item(&exported_function));
+    assert!(matching_name_options.keep_item(&exported_function));
+    assert!(matching_signature_options.keep_item(&exported_function));
+    assert!(!missing_match_options.keep_item(&exported_function));
     assert!(!public_member_options.keep_member(&private_member));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an extraction-time item filter option (`item_regex`) to include only items whose name or signature matches a provided regex.

* **Refactor**
  * Streamlined outline extraction and output rendering by consolidating configuration into unified extraction and style settings, and simplifying how items are emitted across stdin and path streaming modes.

* **Tests**
  * Updated outline rendering and emitter tests to use the new unified style and extraction configuration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->