### PR TITLE
perf: cache transform replace regexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "regex",
  "schemars",
  "serde",
+ "serde_regex",
  "serde_yaml",
  "thiserror 2.0.18",
  "tree-sitter-typescript",
@@ -1640,6 +1641,16 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bit-set = { version = "0.10.0" }
 ignore = { version = "0.4.22" }
 regex = { version = "1.10.4" }
 serde = { version = "1.0.200", features = ["derive"] }
+serde_regex = "1.2.0"
 serde_yaml = "0.9.33"
 tree-sitter = { version = "0.26.3" }
 thiserror = "2.0.0"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,6 +21,7 @@ bit-set.workspace = true
 globset = "0.4.14"
 regex.workspace = true
 serde.workspace = true
+serde_regex.workspace = true
 serde_yaml = "0.9.33"
 thiserror.workspace = true
 schemars.workspace = true

--- a/crates/config/src/transform/parse.rs
+++ b/crates/config/src/transform/parse.rs
@@ -1,6 +1,7 @@
 use super::Trans;
 use super::rewrite::Rewrite;
 use super::trans::{Convert, Replace, Substring};
+use regex::Regex;
 use serde_yaml::from_str as yaml_from_str;
 use std::str::FromStr;
 use thiserror::Error;
@@ -17,6 +18,8 @@ pub enum ParseTransError {
   RequiredArg(&'static str),
   #[error("Invalid argument value.")]
   ArgValue(#[from] serde_yaml::Error),
+  #[error("Invalid regex.")]
+  Regex(#[from] regex::Error),
 }
 
 impl FromStr for Trans<String> {
@@ -109,9 +112,10 @@ fn to_replace(decomposed: DecomposedTransString) -> Result<Replace<String>, Pars
   }
   let replace = replace.ok_or(ParseTransError::RequiredArg("replace"))?;
   let by = by.ok_or(ParseTransError::RequiredArg("by"))?;
+  let replace: String = serde_yaml::from_str(replace)?;
   Ok(Replace {
     source: decomposed.source.to_string(),
-    replace: serde_yaml::from_str(replace)?,
+    replace: Regex::new(&replace)?,
     by: serde_yaml::from_str(by)?,
   })
 }
@@ -222,7 +226,7 @@ mod test {
       panic!("Expected Replace transformation");
     };
     assert_eq!(replace.source, "$A");
-    assert_eq!(replace.replace, "^.+");
+    assert_eq!(replace.replace.as_str(), "^.+");
     assert_eq!(replace.by, ", ");
   }
 

--- a/crates/config/src/transform/trans.rs
+++ b/crates/config/src/transform/trans.rs
@@ -68,15 +68,16 @@ pub struct Replace<T> {
   /// source meta variable to be transformed
   pub source: T,
   /// a regex to find substring to be replaced
-  pub replace: String,
+  #[serde(with = "serde_regex")]
+  #[schemars(with = "String")]
+  pub replace: Regex,
   /// the replacement string
   pub by: String,
 }
 impl Replace<MetaVariable> {
   fn compute<D: Doc>(&self, ctx: &mut Ctx<'_, '_, D>) -> Option<String> {
     let text = get_text_from_env(&self.source, ctx)?;
-    let re = Regex::new(&self.replace).unwrap();
-    Some(re.replace_all(&text, &self.by).into_owned())
+    Some(self.replace.replace_all(&text, &self.by).into_owned())
   }
 }
 


### PR DESCRIPTION
## Summary
- compile transform replace regexes during transform parsing/deserialization
- use serde_regex so YAML keeps the existing string representation
- avoid per-match Regex::new in replace transforms

## Benchmark
Release-mode outline benchmark against main (all benchmark repos):
- names/exports: 1.23x faster
- signatures/exports: 1.24x faster
- expanded/structure: 1.32x faster
- digest/structure: 1.30x faster

## Test
- cargo test -p ast-grep-config transform --lib
- cargo clippy -p ast-grep-config --lib --all-targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation in transformation configuration parsing to detect invalid patterns earlier, improving system reliability and preventing runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->