### PR TITLE
perf: lazily render outline transforms

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -29,7 +29,7 @@ pub use rule_config::{
   Metadata, RuleConfig, RuleConfigError, SerializableRewriter, SerializableRuleConfig, Severity,
 };
 pub use rule_core::{RuleCore, RuleCoreError, SerializableRuleCore};
-pub use transform::Transformation;
+pub use transform::{Transform, TransformError, Transformation};
 
 pub fn from_str<'de, T: Deserialize<'de>>(s: &'de str) -> Result<T, YamlError> {
   let deserializer = Deserializer::from_str(s);

--- a/crates/config/src/rule_core.rs
+++ b/crates/config/src/rule_core.rs
@@ -157,6 +157,24 @@ impl RuleCore {
     DeserializeEnv::from_registration(lang, self.registration.clone())
   }
 
+  pub fn undefined_rewriter_in_transform<'a>(&self, transform: &'a Transform) -> Option<&'a str> {
+    let rewriters = self.registration.get_rewriters();
+    transform
+      .values()
+      .flat_map(|trans| trans.used_rewriters())
+      .find(|rewriter| !rewriters.contains_key(*rewriter))
+      .map(String::as_str)
+  }
+
+  pub fn apply_transform<'tree, D: Doc>(
+    &self,
+    env: &mut MetaVarEnv<'tree, D>,
+    transform: &Transform,
+  ) {
+    let enclosing = env.clone();
+    transform.apply_transform(env, self.registration.get_rewriters(), &enclosing);
+  }
+
   /// Get the meta variables that have real ast node matches
   /// that is, meta vars defined in the rules and constraints
   pub(crate) fn defined_node_vars(&self) -> HashSet<&str> {

--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -191,7 +191,7 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
     for &idx in self.indices_for_kind(node.kind_id()) {
       let extractor = &self.extractors[idx];
       if let Some(matched) = extractor.match_node(node) {
-        return Some(extractor.extract(&matched));
+        return Some(extractor.extract(matched));
       }
     }
     None
@@ -201,11 +201,21 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
 struct CombinedTraversal<'a, 'tree, L: LanguageExt> {
   combined: &'a CombinedExtractors<L>,
   traversal: Prune<'tree, L>,
-  pending: Option<PendingItem<'a, 'tree, L>>,
+  state: TraversalState<'a, 'tree, L>,
   items: Vec<OutlineItem<'tree>>,
 }
 
-struct PendingItem<'a, 'tree, L: LanguageExt> {
+// Keep the active member scope inline. The traverser owns exactly one state,
+// and boxing it would add one allocation for every item that can contain members.
+#[allow(clippy::large_enum_variant)]
+enum TraversalState<'a, 'tree, L: LanguageExt> {
+  /// File scope: match candidate nodes against item extractors.
+  Items,
+  /// Parent item scope: match descendants against only that item's member rules.
+  Members(MemberScope<'a, 'tree, L>),
+}
+
+struct MemberScope<'a, 'tree, L: LanguageExt> {
   extractor: &'a ItemExtractor<L>,
   node_match: NodeMatch<'tree, StrDoc<L>>,
   member_extractors: CombinedMemberExtractors<'a, L>,
@@ -218,7 +228,7 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
     Self {
       combined,
       traversal: Prune::new(&root),
-      pending: None,
+      state: TraversalState::Items,
       items: vec![],
     }
   }
@@ -226,16 +236,17 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
   fn extract(mut self) -> Vec<OutlineItem<'tree>> {
     while let Some(node) = self.traversal.current_node() {
       if self.finished_member_scope() {
-        self.finish_pending_item();
+        self.finish_member_scope();
         continue;
       }
-      if let Some(pending) = self.pending.as_mut() {
-        Self::visit_member(pending, node, &mut self.traversal, &self.combined.options);
-      } else {
-        self.visit_item(node);
+      match &mut self.state {
+        TraversalState::Items => self.visit_item(node),
+        TraversalState::Members(scope) => {
+          Self::visit_member(scope, node, &mut self.traversal, &self.combined.options);
+        }
       }
     }
-    self.finish_pending_item();
+    self.finish_member_scope();
     self.items
   }
 
@@ -249,11 +260,11 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
       .combined
       .member_extractors_for(&extractor.common.rule.id)
     else {
-      self.push_item(extractor.extract(&node_match, vec![]));
+      self.push_item(extractor.extract(node_match, vec![]));
       self.traversal.skip_subtree();
       return;
     };
-    self.pending = Some(PendingItem::new(
+    self.state = TraversalState::Members(MemberScope::new(
       extractor,
       node_match,
       member_extractors,
@@ -263,14 +274,14 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
   }
 
   fn visit_member(
-    pending: &mut PendingItem<'a, 'tree, L>,
+    scope: &mut MemberScope<'a, 'tree, L>,
     node: Node<'tree, StrDoc<L>>,
     traversal: &mut Prune<'tree, L>,
     options: &OutlineExtractorOptions,
   ) {
-    if let Some(member) = pending.member_extractors.extract_member(&node) {
+    if let Some(member) = scope.member_extractors.extract_member(&node) {
       if options.keep_member(&member) {
-        pending.members.push(member);
+        scope.members.push(member);
       }
       traversal.skip_subtree();
     } else {
@@ -279,15 +290,16 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
   }
 
   fn finished_member_scope(&self) -> bool {
-    self
-      .pending
-      .as_ref()
-      .is_some_and(|pending| self.traversal.has_left_subtree(pending.item_subtree))
+    match &self.state {
+      TraversalState::Items => false,
+      TraversalState::Members(scope) => self.traversal.has_left_subtree(scope.item_subtree),
+    }
   }
 
-  fn finish_pending_item(&mut self) {
-    if let Some(pending) = self.pending.take() {
-      self.push_item(pending.into_item());
+  fn finish_member_scope(&mut self) {
+    let state = std::mem::replace(&mut self.state, TraversalState::Items);
+    if let TraversalState::Members(scope) = state {
+      self.push_item(scope.into_item());
     }
   }
 
@@ -298,7 +310,7 @@ impl<'a, 'tree, L: LanguageExt> CombinedTraversal<'a, 'tree, L> {
   }
 }
 
-impl<'a, 'tree, L: LanguageExt> PendingItem<'a, 'tree, L> {
+impl<'a, 'tree, L: LanguageExt> MemberScope<'a, 'tree, L> {
   fn new(
     extractor: &'a ItemExtractor<L>,
     node_match: NodeMatch<'tree, StrDoc<L>>,
@@ -315,7 +327,7 @@ impl<'a, 'tree, L: LanguageExt> PendingItem<'a, 'tree, L> {
   }
 
   fn into_item(self) -> OutlineItem<'tree> {
-    self.extractor.extract(&self.node_match, self.members)
+    self.extractor.extract(self.node_match, self.members)
   }
 }
 

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -6,8 +6,9 @@
 //! `Outline*Rule` types, not on serde defaults or config parsing details.
 
 use ast_grep_config::{
-  GlobalRules, Rule, RuleConfig, RuleConfigError, RuleSerializeError, SerializableRewriter,
-  SerializableRule, SerializableRuleConfig, SerializableRuleCore, Severity,
+  DeserializeEnv, GlobalRules, Rule, RuleConfig, RuleConfigError, RuleSerializeError,
+  SerializableRewriter, SerializableRule, SerializableRuleConfig, SerializableRuleCore, Severity,
+  Transform, TransformError,
 };
 use ast_grep_core::{
   Doc, Language, Node, NodeMatch,
@@ -133,6 +134,8 @@ pub enum SerializablePredicate {
 pub struct ExtractorCommon<L: Language> {
   /// Parsed ast-grep rule config used to select candidate syntax.
   pub rule: RuleConfig<L>,
+  /// Lazily-applied transforms needed by output templates.
+  transform: Option<Transform>,
   /// LSP-compatible outline category produced by this extractor.
   pub symbol_type: SymbolType,
   /// Name template evaluated from metavariables or transformed metavariables.
@@ -152,6 +155,10 @@ pub enum OutlineRuleError {
   Predicate(#[from] RuleSerializeError),
   #[error(transparent)]
   Template(#[from] TemplateFixError),
+  #[error(transparent)]
+  Transform(#[from] TransformError),
+  #[error("Undefined rewriter `{0}` used in transform.")]
+  UndefinedRewriter(String),
 }
 
 impl<L: Language> ExtractorCommon<L> {
@@ -161,16 +168,34 @@ impl<L: Language> ExtractorCommon<L> {
     detail: OutlineEntryDetail,
   ) -> Result<Self, OutlineRuleError> {
     let symbol_type = common.symbol_type;
+    let language = common.language.clone();
     let transform_vars = transform_vars(&common.matcher);
-    let compile = |tmpl| compile_template(tmpl, &common.language, &transform_vars);
+    let compile = |tmpl| compile_template(tmpl, &language, &transform_vars);
     let name = compile(&common.name)?;
     let signature = match detail {
       OutlineEntryDetail::Name => None,
       OutlineEntryDetail::Signature => common.signature.as_deref().map(compile).transpose()?,
     };
-    let rule = RuleConfig::try_from(common.into_rule_config(), globals)?;
+    let mut rule_config = common.into_rule_config();
+    let transform = rule_config
+      .core
+      .transform
+      .take()
+      .filter(|_| uses_transform_vars(&name, signature.as_ref(), transform_vars.as_deref()));
+    let transform = transform
+      .as_ref()
+      .map(|transform| parse_transform(transform, &language, &rule_config.core, globals))
+      .transpose()?;
+    let rule = RuleConfig::try_from(rule_config, globals)?;
+    if let Some(rewriter) = transform
+      .as_ref()
+      .and_then(|transform| rule.matcher.undefined_rewriter_in_transform(transform))
+    {
+      return Err(OutlineRuleError::UndefinedRewriter(rewriter.to_string()));
+    }
     Ok(Self {
       rule,
+      transform,
       symbol_type,
       name,
       signature,
@@ -197,6 +222,32 @@ impl<L: Language> ExtractorCommon<L> {
     };
     Ok(ret)
   }
+}
+
+fn uses_transform_vars(
+  name: &TemplateFix,
+  signature: Option<&TemplateFix>,
+  transform_vars: Option<&[String]>,
+) -> bool {
+  let Some(transform_vars) = transform_vars else {
+    return false;
+  };
+  let uses_var = |var: &str| transform_vars.iter().any(|transform| transform == var);
+  name.used_vars().into_iter().any(uses_var)
+    || signature.is_some_and(|signature| signature.used_vars().into_iter().any(uses_var))
+}
+
+fn parse_transform<L: Language>(
+  transform: &std::collections::HashMap<String, ast_grep_config::Transformation>,
+  language: &L,
+  matcher: &SerializableRuleCore,
+  globals: &GlobalRules,
+) -> Result<Transform, OutlineRuleError> {
+  let mut env = DeserializeEnv::new(language.clone()).with_globals(globals);
+  if let Some(utils) = &matcher.utils {
+    env = env.with_utils(utils)?;
+  }
+  Ok(Transform::deserialize(transform, &env)?)
 }
 
 fn transform_vars(matcher: &SerializableRuleCore) -> Option<Vec<String>> {
@@ -273,13 +324,14 @@ impl<L: Language> ItemExtractor<L> {
 
   pub fn extract<'tree, D: Doc>(
     &self,
-    node_match: &NodeMatch<'tree, D>,
+    mut node_match: NodeMatch<'tree, D>,
     members: Vec<OutlineMember<'tree>>,
   ) -> OutlineItem<'tree> {
+    self.common.apply_transform(&mut node_match);
     OutlineItem {
-      entry: self.common.extract_entry(EntryRole::Item, node_match),
-      is_import: self.is_import.evaluate(node_match),
-      is_exported: self.is_exported.evaluate(node_match),
+      entry: self.common.extract_entry(EntryRole::Item, &node_match),
+      is_import: self.is_import.evaluate(&node_match),
+      is_exported: self.is_exported.evaluate(&node_match),
       members,
     }
   }
@@ -316,15 +368,28 @@ impl<L: Language> MemberExtractor<L> {
     self.common.rule.matcher.match_node(node.clone())
   }
 
-  pub fn extract<'tree, D: Doc>(&self, node_match: &NodeMatch<'tree, D>) -> OutlineMember<'tree> {
+  pub fn extract<'tree, D: Doc>(
+    &self,
+    mut node_match: NodeMatch<'tree, D>,
+  ) -> OutlineMember<'tree> {
+    self.common.apply_transform(&mut node_match);
     OutlineMember {
-      entry: self.common.extract_entry(EntryRole::Member, node_match),
-      is_public: self.is_public.evaluate(node_match),
+      entry: self.common.extract_entry(EntryRole::Member, &node_match),
+      is_public: self.is_public.evaluate(&node_match),
     }
   }
 }
 
 impl<L: Language> ExtractorCommon<L> {
+  fn apply_transform<D: Doc>(&self, node_match: &mut NodeMatch<D>) {
+    if let Some(transform) = &self.transform {
+      self
+        .rule
+        .matcher
+        .apply_transform(node_match.get_env_mut(), transform);
+    }
+  }
+
   fn extract_entry<'tree, D: Doc>(
     &self,
     role: EntryRole,
@@ -626,6 +691,77 @@ isImport: true
   }
 
   #[test]
+  fn applies_outline_transform_when_extracting_entry() {
+    let rule = parse_rule(
+      r#"
+id: rust-use
+language: Rust
+role: item
+symbolType: module
+rule:
+  pattern: use $TARGET;
+transform:
+  NAME:
+    replace:
+      source: $TARGET
+      replace: '^.*::'
+      by: ''
+name: $NAME
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Name)
+      .expect("item rule should parse");
+    let root = SupportLang::Rust.ast_grep("use foo::bar;");
+    let node_match = root
+      .root()
+      .find(&item.common.rule.matcher)
+      .expect("use should match item rule");
+    let outline = item.extract(node_match, vec![]);
+
+    assert!(item.common.transform.is_some());
+    assert_eq!(outline.entry.name.as_ref(), "bar");
+  }
+
+  #[test]
+  fn skips_signature_only_transform_for_name_detail() {
+    let rule = parse_rule(
+      r#"
+id: rust-function
+language: Rust
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: function_item
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  SIG:
+    replace:
+      source: $DECL
+      replace: '\s*\{[\s\S]*$'
+      by: ''
+name: $NAME
+signature: $SIG
+"#,
+    );
+
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Name)
+      .expect("item rule should parse");
+
+    assert!(item.common.transform.is_none());
+  }
+
+  #[test]
   fn predicate_rule_reuses_match_metavariables() {
     let rule = parse_rule(
       r#"
@@ -658,7 +794,7 @@ isExported:
     let node_match = item
       .match_node(&class_node)
       .expect("class should match item rule");
-    let outline = item.extract(&node_match, vec![]);
+    let outline = item.extract(node_match, vec![]);
 
     assert_eq!(outline.entry.name.as_ref(), "Foo");
     assert!(!outline.is_exported);


### PR DESCRIPTION
Summary:
- Parse outline transforms only when name/signature templates reference transform vars.
- Apply transforms lazily after a node match during extraction.
- Keep member traversal state inline with the PruneSubtree scope API.

Tests:
- cargo test -p ast-grep-outline --lib
- cargo test -p ast-grep-outline -p ast-grep --lib outline
- cargo test -p ast-grep-config --lib transform
- cargo clippy -p ast-grep-config -p ast-grep-outline --lib --all-targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying transforms to outline entry extraction with validation for undefined rewriters.

* **Refactor**
  * Restructured internal outline extraction traversal logic for improved architecture.
  * Enhanced rule processing with new transform validation and application methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->