### PR TITLE
refactor: make outline extract return iterator

### DIFF
--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -90,7 +90,7 @@ impl OutlineExtractors {
     self
       .by_lang
       .get(&lang)
-      .map(|extractors| extractors.extract_iter(root).map(own_item).collect())
+      .map(|extractors| extractors.extract(root).map(own_item).collect())
       .unwrap_or_default()
   }
 }

--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -40,7 +40,7 @@ pub struct CombinedExtractors<L: Language> {
   options: OutlineExtractorOptions,
 }
 
-pub struct CombinedMemberExtractors<'a, L: Language> {
+struct CombinedMemberExtractors<'a, L: Language> {
   /// Shared member extractor storage owned by `CombinedExtractors`.
   extractors: &'a [MemberExtractor<L>],
   /// Parent-scoped index that selects members relevant to one matched item rule.
@@ -95,18 +95,7 @@ impl<L: Language> CombinedExtractors<L> {
     ))
   }
 
-  pub fn new(
-    item_extractors: Vec<ItemExtractor<L>>,
-    member_extractors: Vec<MemberExtractor<L>>,
-  ) -> Self {
-    Self::new_with_options(
-      item_extractors,
-      member_extractors,
-      OutlineExtractorOptions::default(),
-    )
-  }
-
-  pub fn new_with_options(
+  fn new_with_options(
     item_extractors: Vec<ItemExtractor<L>>,
     member_extractors: Vec<MemberExtractor<L>>,
     options: OutlineExtractorOptions,
@@ -122,7 +111,7 @@ impl<L: Language> CombinedExtractors<L> {
     }
   }
 
-  pub fn member_extractors_for(&self, parent_id: &str) -> Option<CombinedMemberExtractors<'_, L>> {
+  fn member_extractors_for(&self, parent_id: &str) -> Option<CombinedMemberExtractors<'_, L>> {
     self
       .member_mapping
       .get(parent_id)
@@ -132,25 +121,17 @@ impl<L: Language> CombinedExtractors<L> {
       })
   }
 
-  pub fn item_extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &ItemExtractor<L>> {
+  fn item_extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &ItemExtractor<L>> {
     self
-      .item_indices_for_kind(kind)
+      .item_kind_mapping
+      .get(kind as usize)
+      .map(Vec::as_slice)
+      .unwrap_or(&[])
       .iter()
       .map(|&idx| &self.item_extractors[idx])
   }
 
-  fn item_indices_for_kind(&self, kind: u16) -> &[usize] {
-    indices_for_kind(&self.item_kind_mapping, kind)
-  }
-
-  pub fn extract<'tree>(&self, root: Node<'tree, StrDoc<L>>) -> Vec<OutlineItem<'tree>>
-  where
-    L: LanguageExt,
-  {
-    self.extract_iter(root).collect()
-  }
-
-  pub fn extract_iter<'tree>(&self, root: Node<'tree, StrDoc<L>>) -> OutlineItemIter<'_, 'tree, L>
+  pub fn extract<'tree>(&self, root: Node<'tree, StrDoc<L>>) -> OutlineItemIter<'_, 'tree, L>
   where
     L: LanguageExt,
   {
@@ -167,8 +148,7 @@ impl<L: Language> CombinedExtractors<L> {
   where
     L: LanguageExt,
   {
-    for &idx in self.item_indices_for_kind(node.kind_id()) {
-      let extractor = &self.item_extractors[idx];
+    for extractor in self.item_extractors_for_kind(node.kind_id()) {
       if let Some(matched) = extractor.match_node(node) {
         return Some((extractor, matched));
       }
@@ -178,7 +158,7 @@ impl<L: Language> CombinedExtractors<L> {
 }
 
 impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
-  pub fn extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &MemberExtractor<L>> {
+  fn extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &MemberExtractor<L>> {
     self
       .indices_for_kind(kind)
       .iter()
@@ -198,8 +178,7 @@ impl<'a, L: Language> CombinedMemberExtractors<'a, L> {
   where
     L: LanguageExt,
   {
-    for &idx in self.indices_for_kind(node.kind_id()) {
-      let extractor = &self.extractors[idx];
+    for extractor in self.extractors_for_kind(node.kind_id()) {
       if let Some(matched) = extractor.match_node(node) {
         return Some(extractor.extract(&matched));
       }
@@ -279,10 +258,6 @@ fn collect_members<'a, 'tree, L: LanguageExt>(
     }
   }
   members
-}
-
-fn indices_for_kind(mapping: &[Vec<usize>], kind: u16) -> &[usize] {
-  mapping.get(kind as usize).map(Vec::as_slice).unwrap_or(&[])
 }
 
 fn push_kind_mapping(mapping: &mut Vec<Vec<usize>>, kind: usize, idx: usize) {
@@ -410,7 +385,7 @@ function after() {}
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
     let names = items
       .iter()
       .map(|item| item.entry.name.as_ref())
@@ -459,7 +434,7 @@ function standalone() {}
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
 
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].entry.name, "Box");
@@ -512,7 +487,7 @@ function after() {}
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
 
     let names = items
       .iter()
@@ -560,7 +535,7 @@ signature: $NAME()
       .expect("extractors should parse");
     let grep = SupportLang::TypeScript.ast_grep("class Box { parse() {} }");
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
 
     assert!(combined.member_extractors.is_empty());
     assert_eq!(items.len(), 1);
@@ -607,7 +582,7 @@ function local() {}
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
 
     assert_eq!(combined.item_extractors.len(), 1);
     assert_eq!(combined.item_extractors[0].common.rule.id, "ts-import");

--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -89,7 +89,7 @@ mod tests {
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
     let names = items
       .iter()
       .map(|item| item.entry.name.as_ref())
@@ -199,7 +199,7 @@ impl Rewrite<String> {
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
     let names = items
       .iter()
       .map(|item| item.entry.name.as_ref())
@@ -334,7 +334,7 @@ impl<T: Future> CoreStage<T> {
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
     let item_shapes = items
       .iter()
       .map(|item| {
@@ -444,7 +444,7 @@ trait Service {
 "#,
     );
 
-    let items = combined.extract(grep.root());
+    let items = combined.extract(grep.root()).collect::<Vec<_>>();
     let item_shapes = items
       .iter()
       .map(|item| {

--- a/crates/outline/tests/common/mod.rs
+++ b/crates/outline/tests/common/mod.rs
@@ -17,7 +17,8 @@ fn compile_rules_for(lang: SupportLang, src: &str) -> CombinedExtractors<Support
 pub fn assert_outline_snapshot(lang: SupportLang, rules: &str, source: &str, expected: &str) {
   let combined = compile_rules_for(lang, rules);
   let grep = lang.ast_grep(source);
-  let snapshot = outline_snapshot(&combined.extract(grep.root()));
+  let items = combined.extract(grep.root()).collect::<Vec<_>>();
+  let snapshot = outline_snapshot(&items);
   assert_eq!(snapshot.trim(), expected.trim());
 }
 


### PR DESCRIPTION
Summary:
- Rename the iterator-returning `extract_iter` API to `extract`.
- Remove the old collecting `extract` wrapper.
- Make call sites that need a `Vec` collect explicitly.

Tests:
- cargo test -p ast-grep-outline --lib
- cargo test -p ast-grep-outline -p ast-grep --lib outline
- cargo clippy -p ast-grep-outline -p ast-grep --lib --all-targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated outline extraction to return a lazy, on-demand iterator rather than eagerly collecting results.
  * Adjusted CLI outline processing to use the updated extraction flow while keeping output ownership behavior the same.
* **Tests**
  * Updated unit tests and snapshot helpers to collect extracted outline items into a `Vec` before performing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->