### PR TITLE
feat: mark duplicate outline names

### DIFF
--- a/crates/cli/src/outline/output.rs
+++ b/crates/cli/src/outline/output.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Write;
 
@@ -253,39 +254,41 @@ fn line_number_width(file: &OutlineFile) -> usize {
 }
 
 #[derive(Clone)]
-struct StyledName {
-  text: String,
+struct StyledName<'a> {
+  text: &'a str,
+  overload_count: usize,
   is_import: bool,
   is_exported: bool,
   is_public: bool,
 }
 
-fn grouped_item_names(items: &[OutlineItem]) -> Vec<(SymbolType, Vec<StyledName>)> {
-  let mut groups = empty_symbol_groups();
+fn grouped_item_names<'a>(items: &'a [OutlineItem]) -> Vec<(SymbolType, Vec<StyledName<'a>>)> {
+  let mut groups = GroupedNames::new();
   for item in items {
-    push_grouped_name(
-      &mut groups,
+    groups.push(
       item.entry.symbol_type,
       StyledName {
-        text: item.entry.name.to_string(),
+        text: item.entry.name.as_ref(),
+        overload_count: 1,
         is_import: item.is_import,
         is_exported: item.is_exported,
         is_public: true,
       },
     );
   }
-  groups.retain(|(_, names)| !names.is_empty());
-  groups
+  groups.into_vec()
 }
 
-fn grouped_member_names(members: &[OutlineMember]) -> Vec<(SymbolType, Vec<StyledName>)> {
-  let mut groups = empty_symbol_groups();
+fn grouped_member_names<'a>(
+  members: &'a [OutlineMember],
+) -> Vec<(SymbolType, Vec<StyledName<'a>>)> {
+  let mut groups = GroupedNames::new();
   for member in members.iter().filter(|member| member.is_public) {
-    push_grouped_name(
-      &mut groups,
+    groups.push(
       member.entry.symbol_type,
       StyledName {
-        text: member.entry.name.to_string(),
+        text: member.entry.name.as_ref(),
+        overload_count: 1,
         is_import: false,
         is_exported: false,
         is_public: member.is_public,
@@ -293,37 +296,92 @@ fn grouped_member_names(members: &[OutlineMember]) -> Vec<(SymbolType, Vec<Style
     );
   }
   for member in members.iter().filter(|member| !member.is_public) {
-    push_grouped_name(
-      &mut groups,
+    groups.push(
       member.entry.symbol_type,
       StyledName {
-        text: member.entry.name.to_string(),
+        text: member.entry.name.as_ref(),
+        overload_count: 1,
         is_import: false,
         is_exported: false,
         is_public: member.is_public,
       },
     );
   }
-  groups.retain(|(_, names)| !names.is_empty());
-  groups
+  groups.into_vec()
 }
 
-fn empty_symbol_groups() -> Vec<(SymbolType, Vec<StyledName>)> {
-  SYMBOL_TYPE_ORDER
-    .iter()
-    .map(|&symbol_type| (symbol_type, vec![]))
-    .collect()
+struct GroupedNames<'a> {
+  groups: Vec<GroupedNameBucket<'a>>,
 }
 
-fn push_grouped_name(
-  groups: &mut Vec<(SymbolType, Vec<StyledName>)>,
+impl<'a> GroupedNames<'a> {
+  fn new() -> Self {
+    Self {
+      groups: SYMBOL_TYPE_ORDER
+        .iter()
+        .map(|&symbol_type| GroupedNameBucket::new(symbol_type))
+        .collect(),
+    }
+  }
+
+  fn push(&mut self, symbol_type: SymbolType, name: StyledName<'a>) {
+    let group_index = match self
+      .groups
+      .iter()
+      .position(|group| group.symbol_type == symbol_type)
+    {
+      Some(index) => index,
+      None => {
+        self.groups.push(GroupedNameBucket::new(symbol_type));
+        self.groups.len() - 1
+      }
+    };
+    self.groups[group_index].push(name);
+  }
+
+  fn into_vec(self) -> Vec<(SymbolType, Vec<StyledName<'a>>)> {
+    self
+      .groups
+      .into_iter()
+      .filter_map(|group| {
+        if group.names.is_empty() {
+          None
+        } else {
+          Some((group.symbol_type, group.names))
+        }
+      })
+      .collect()
+  }
+}
+
+struct GroupedNameBucket<'a> {
   symbol_type: SymbolType,
-  name: StyledName,
-) {
-  if let Some((_, names)) = groups.iter_mut().find(|(ty, _)| *ty == symbol_type) {
-    names.push(name);
-  } else {
-    groups.push((symbol_type, vec![name]));
+  names: Vec<StyledName<'a>>,
+  name_indices: HashMap<&'a str, usize>,
+}
+
+impl<'a> GroupedNameBucket<'a> {
+  fn new(symbol_type: SymbolType) -> Self {
+    Self {
+      symbol_type,
+      names: vec![],
+      name_indices: HashMap::new(),
+    }
+  }
+
+  fn push(&mut self, name: StyledName<'a>) {
+    if let Some(&index) = self.name_indices.get(name.text) {
+      let existing = &mut self.names[index];
+      existing.overload_count += 1;
+      existing.is_import |= name.is_import;
+      existing.is_exported |= name.is_exported;
+      existing.is_public |= name.is_public;
+      return;
+    }
+
+    let index = self.names.len();
+    self.name_indices.insert(name.text, index);
+    self.names.push(name);
   }
 }
 
@@ -499,7 +557,7 @@ impl OutlineTextStyle {
     if self.emphasize_exports && name.is_exported {
       style = style.bold();
     }
-    self.paint(style, &name.text)
+    self.grouped_name(name, style)
   }
 
   fn grouped_member_name(&self, name: &StyledName) -> String {
@@ -508,7 +566,15 @@ impl OutlineTextStyle {
     } else {
       ansi_term::Style::new().dimmed()
     };
-    self.paint(style, &name.text)
+    self.grouped_name(name, style)
+  }
+
+  fn grouped_name(&self, name: &StyledName, name_style: ansi_term::Style) -> String {
+    let text = self.paint(name_style, name.text);
+    if name.overload_count == 1 {
+      return text;
+    }
+    format!("{text} ×{}", name.overload_count)
   }
 
   fn paint(&self, style: ansi_term::Style, text: impl Display) -> String {

--- a/crates/cli/src/outline/output/tests.rs
+++ b/crates/cli/src/outline/output/tests.rs
@@ -77,6 +77,20 @@ fn outline_file() -> OutlineFile<'static> {
   }
 }
 
+fn item(
+  symbol_type: SymbolType,
+  name: &'static str,
+  signature: &'static str,
+  line: usize,
+) -> OutlineItem<'static> {
+  OutlineItem {
+    entry: entry(EntryRole::Item, symbol_type, name, signature, line),
+    is_import: false,
+    is_exported: false,
+    members: vec![],
+  }
+}
+
 #[test]
 fn renders_digest_like_design_doc() {
   let mut output = vec![];
@@ -87,6 +101,118 @@ fn renders_digest_like_design_doc() {
   assert_eq!(
     output,
     "src/parser.ts\n40: export class Parser\n      method: parse, recover\n"
+  );
+}
+
+#[test]
+fn digest_marks_duplicate_member_names_with_overload_count() {
+  let mut file = outline_file();
+  file.items[0].members = vec![
+    member(
+      SymbolType::Method,
+      "parse",
+      "parse(input: string): Node",
+      43,
+      true,
+    ),
+    member(
+      SymbolType::Method,
+      "parse",
+      "parse(input: Uint8Array): Node",
+      44,
+      true,
+    ),
+    member(SymbolType::Method, "recover", "recover(...)", 72, false),
+  ];
+  let mut output = vec![];
+  print_text_to(&mut output, &[file], &style(OutlineView::Digest)).expect("text should render");
+  let output = String::from_utf8(output).expect("output should be utf8");
+
+  assert_eq!(
+    output,
+    "src/parser.ts\n40: export class Parser\n      method: parse ×2, recover\n"
+  );
+}
+
+#[test]
+fn names_marks_duplicate_item_names_with_overload_count() {
+  let file = OutlineFile {
+    path: "src/parser.ts".to_string(),
+    language: "TypeScript".to_string(),
+    items: vec![
+      item(
+        SymbolType::Function,
+        "parse",
+        "parse(input: string): Node",
+        0,
+      ),
+      item(
+        SymbolType::Function,
+        "parse",
+        "parse(input: Uint8Array): Node",
+        1,
+      ),
+      item(SymbolType::Function, "print", "print(input: Node): void", 2),
+    ],
+  };
+  let mut output = vec![];
+  print_text_to(&mut output, &[file], &style(OutlineView::Names)).expect("text should render");
+  let output = String::from_utf8(output).expect("output should be utf8");
+
+  assert_eq!(output, "src/parser.ts\nfunction: parse ×2, print\n");
+}
+
+#[test]
+fn signatures_and_expanded_keep_duplicate_entries_separate() {
+  let file = OutlineFile {
+    path: "src/parser.ts".to_string(),
+    language: "TypeScript".to_string(),
+    items: vec![
+      item(
+        SymbolType::Function,
+        "parse",
+        "parse(input: string): Node",
+        0,
+      ),
+      item(
+        SymbolType::Function,
+        "parse",
+        "parse(input: Uint8Array): Node",
+        1,
+      ),
+    ],
+  };
+  let mut output = vec![];
+  print_text_to(&mut output, &[file], &style(OutlineView::Signatures)).expect("text should render");
+  let output = String::from_utf8(output).expect("output should be utf8");
+  assert_eq!(
+    output,
+    "src/parser.ts\n1: parse(input: string): Node\n2: parse(input: Uint8Array): Node\n"
+  );
+
+  let mut file = outline_file();
+  file.items[0].members = vec![
+    member(
+      SymbolType::Method,
+      "parse",
+      "parse(input: string): Node",
+      43,
+      true,
+    ),
+    member(
+      SymbolType::Method,
+      "parse",
+      "parse(input: Uint8Array): Node",
+      44,
+      true,
+    ),
+  ];
+  let mut output = vec![];
+  print_text_to(&mut output, &[file], &style(OutlineView::Expanded)).expect("text should render");
+  let output = String::from_utf8(output).expect("output should be utf8");
+  assert_eq!(
+    output,
+    "src/parser.ts\n40: export class Parser\n44:   parse(input: string): Node\n45:   parse(input: Uint8Array): Node\n"
   );
 }
 
@@ -324,13 +450,15 @@ fn suppresses_redundant_item_mode_styles() {
   let export_style = OutlineTextStyle::new(true, OutlineItems::Exports);
   let mixed_style = OutlineTextStyle::new(true, OutlineItems::All);
   let import_name = StyledName {
-    text: "std::fmt".to_string(),
+    text: "std::fmt",
+    overload_count: 1,
     is_import: true,
     is_exported: false,
     is_public: true,
   };
   let export_name = StyledName {
-    text: "api".to_string(),
+    text: "api",
+    overload_count: 1,
     is_import: false,
     is_exported: true,
     is_public: true,

--- a/crates/outline/tests/common/mod.rs
+++ b/crates/outline/tests/common/mod.rs
@@ -22,10 +22,31 @@ pub fn assert_outline_snapshot(lang: SupportLang, rules: &str, source: &str, exp
   assert_eq!(snapshot.trim(), expected.trim());
 }
 
+pub fn assert_outline_signature_snapshot(
+  lang: SupportLang,
+  rules: &str,
+  source: &str,
+  expected: &str,
+) {
+  let combined = compile_rules_for(lang, rules);
+  let grep = lang.ast_grep(source);
+  let items = combined.extract(grep.root()).collect::<Vec<_>>();
+  let snapshot = outline_signature_snapshot(&items);
+  assert_eq!(snapshot.trim(), expected.trim());
+}
+
 fn outline_snapshot(items: &[OutlineItem<'_>]) -> String {
   let mut output = String::new();
   for item in items {
     push_item(&mut output, item);
+  }
+  output
+}
+
+fn outline_signature_snapshot(items: &[OutlineItem<'_>]) -> String {
+  let mut output = String::new();
+  for item in items {
+    push_item_signature(&mut output, item);
   }
   output
 }
@@ -46,6 +67,22 @@ fn push_item(output: &mut String, item: &OutlineItem<'_>) {
   }
 }
 
+fn push_item_signature(output: &mut String, item: &OutlineItem<'_>) {
+  let role = if item.is_import { "import" } else { "item" };
+  let visibility = if item.is_exported {
+    "exported"
+  } else {
+    "private"
+  };
+  output.push_str(&format!(
+    "- {:?} {role} {visibility} {} | {}\n",
+    item.entry.symbol_type, item.entry.name, item.entry.signature
+  ));
+  for member in &item.members {
+    push_member_signature(output, member);
+  }
+}
+
 fn push_member(output: &mut String, member: &OutlineMember<'_>) {
   let visibility = if member.is_public {
     "public"
@@ -55,5 +92,17 @@ fn push_member(output: &mut String, member: &OutlineMember<'_>) {
   output.push_str(&format!(
     "  - {:?} {visibility} {}\n",
     member.entry.symbol_type, member.entry.name
+  ));
+}
+
+fn push_member_signature(output: &mut String, member: &OutlineMember<'_>) {
+  let visibility = if member.is_public {
+    "public"
+  } else {
+    "private"
+  };
+  output.push_str(&format!(
+    "  - {:?} {visibility} {} | {}\n",
+    member.entry.symbol_type, member.entry.name, member.entry.signature
   ));
 }

--- a/crates/outline/tests/jvm_swift_outline_rules.rs
+++ b/crates/outline/tests/jvm_swift_outline_rules.rs
@@ -105,6 +105,35 @@ class ScopeBox {
 }
 
 #[test]
+fn kotlin_rules_extract_signatures() {
+  const RULES: &str = include_str!("../src/default_rules/kotlin.yml");
+  common::assert_outline_signature_snapshot(
+    SupportLang::Kotlin,
+    RULES,
+    r#"
+package okhttp3.sse
+
+import okhttp3.Request
+import java.io.IOException as IOE
+
+class RealInterceptorChain constructor(val call: Call) {
+  internal constructor(call: Call, index: Int) : this(call)
+  override fun proceed(request: Request): Response { return TODO() }
+  val index: Int = 0
+}
+"#,
+    r#"
+- Module import private okhttp3.Request | import okhttp3.Request
+- Module import private IOE | import java.io.IOException as IOE
+- Class item exported RealInterceptorChain | class RealInterceptorChain constructor(val call: Call) {
+  - Constructor private constructor | internal constructor(call: Call, index: Int) : this(call)
+  - Method public proceed | override fun proceed(request: Request): Response { return TODO() }
+  - Property public index | val index: Int = 0
+"#,
+  );
+}
+
+#[test]
 fn java_rules_parse_and_extract_jvm_surface() {
   const RULES: &str = include_str!("../src/default_rules/java.yml");
   common::assert_outline_snapshot(
@@ -149,6 +178,36 @@ enum Protocol { HTTP_1_1 }
   - Method public proceed
   - Method private exchange
 - Enum item private Protocol
+"#,
+  );
+}
+
+#[test]
+fn java_rules_extract_duplicate_method_names_with_signatures() {
+  const RULES: &str = include_str!("../src/default_rules/java.yml");
+  common::assert_outline_signature_snapshot(
+    SupportLang::Java,
+    RULES,
+    r#"
+public class Parser {
+  public Node parse(String input) {
+    return null;
+  }
+
+  public Node parse(byte[] input) {
+    return null;
+  }
+
+  Node parse(int count) {
+    return null;
+  }
+}
+"#,
+    r#"
+- Class item exported Parser | public class Parser {
+  - Method public parse | public Node parse(String input) {
+  - Method public parse | public Node parse(byte[] input) {
+  - Method private parse | Node parse(int count) {
 "#,
   );
 }
@@ -227,6 +286,38 @@ class InternalBox {
 - Class item private InternalBox
   - Constructor private init
   - Method private helper
+"#,
+  );
+}
+
+#[test]
+fn swift_rules_extract_signatures() {
+  const RULES: &str = include_str!("../src/default_rules/swift.yml");
+  common::assert_outline_signature_snapshot(
+    SupportLang::Swift,
+    RULES,
+    r#"
+@preconcurrency import Dispatch
+
+public final class Session {
+  public init(configuration: URLSessionConfiguration) {}
+  open func request(_ convertible: any URLConvertible) -> DataRequest { fatalError() }
+}
+
+public protocol RequestInterceptor: Sendable {
+  func adapt(_ urlRequest: URLRequest) throws -> URLRequest
+}
+
+@MainActor public func makeSession() {}
+"#,
+    r#"
+- Module import private Dispatch | @preconcurrency import Dispatch
+- Class item exported Session | public final class Session {
+  - Constructor public init | public init(configuration: URLSessionConfiguration) {}
+  - Method public request | open func request(_ convertible: any URLConvertible) -> DataRequest { fatalError() }
+- Interface item exported RequestInterceptor | public protocol RequestInterceptor: Sendable {
+  - Method public adapt | func adapt(_ urlRequest: URLRequest) throws -> URLRequest
+- Function item exported makeSession | @MainActor public func makeSession() {}
 "#,
   );
 }

--- a/crates/outline/tests/python_go_outline_rules.rs
+++ b/crates/outline/tests/python_go_outline_rules.rs
@@ -2,11 +2,14 @@ use ast_grep_language::SupportLang;
 
 mod common;
 
+const PYTHON_RULES: &str = include_str!("../src/default_rules/python.yml");
+const GO_RULES: &str = include_str!("../src/default_rules/go.yml");
+
 #[test]
 fn python_rules_extract_imports_classes_functions_and_methods() {
   common::assert_outline_snapshot(
     SupportLang::Python,
-    include_str!("../src/default_rules/python.yml"),
+    PYTHON_RULES,
     r#"
 import functools
 from django.db import models
@@ -64,10 +67,42 @@ class AsyncOnly:
 }
 
 #[test]
+fn python_rules_extract_signatures() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::Python,
+    PYTHON_RULES,
+    r#"
+from django.db import models
+
+async def fetch_related(queryset):
+    return [row async for row in queryset]
+
+class QuerySetRunner:
+    query = models.Query()
+
+    @property
+    def db(self):
+        return self.query.db
+
+    async def execute(self):
+        return await self.queryset.afirst()
+"#,
+    r#"
+- Module import private django.db.models | from django.db import models
+- Function item exported fetch_related | async def fetch_related(queryset):
+- Class item exported QuerySetRunner | class QuerySetRunner:
+  - Field public query | query = models.Query()
+  - Method public db | def db(self):
+  - Method public execute | async def execute(self):
+"#,
+  );
+}
+
+#[test]
 fn go_rules_extract_imports_funcs_methods_types_consts_and_vars() {
   common::assert_outline_snapshot(
     SupportLang::Go,
-    include_str!("../src/default_rules/go.yml"),
+    GO_RULES,
     r#"
 package gin
 
@@ -119,6 +154,47 @@ func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
   - Method public ByName
 - Function item exported New
 - Method item exported Use
+"#,
+  );
+}
+
+#[test]
+fn go_rules_extract_signatures() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::Go,
+    GO_RULES,
+    r#"
+package gin
+
+import "net/http"
+
+type Engine struct {
+    RouterGroup
+    maxParams uint16
+}
+
+type RoutesInfo interface {
+    Last() RouteInfo
+    byName(string) (RouteInfo, bool)
+}
+
+func New() *Engine {
+    return &Engine{}
+}
+
+func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
+    return engine
+}
+"#,
+    r#"
+- Module import private net/http | "net/http"
+- Struct item exported Engine | Engine struct {
+  - Field private maxParams | maxParams uint16
+- Interface item exported RoutesInfo | RoutesInfo interface {
+  - Method public Last | Last() RouteInfo
+  - Method private byName | byName(string) (RouteInfo, bool)
+- Function item exported New | func New() *Engine {
+- Method item exported Use | func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
 "#,
   );
 }

--- a/crates/outline/tests/typescript_outline_rules.rs
+++ b/crates/outline/tests/typescript_outline_rules.rs
@@ -166,3 +166,24 @@ let typedRenderer: React.FC<BadgeProps> = () => <Badge title="typed" />;
 "#,
   );
 }
+
+#[test]
+fn extracts_typescript_duplicate_member_names_with_signatures() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::TypeScript,
+    TYPESCRIPT_RULES,
+    r#"
+export interface Parser {
+  parse(input: string): Node;
+  parse(input: Uint8Array): Node;
+  reset(): void;
+}
+"#,
+    r#"
+- Interface item exported Parser | export interface Parser {
+  - Method public parse | parse(input: string): Node
+  - Method public parse | parse(input: Uint8Array): Node
+  - Method public reset | reset(): void
+"#,
+  );
+}


### PR DESCRIPTION
## Summary
- group duplicate same-name outline entries in names/digest views with a `×N` suffix
- keep signatures and expanded views listing each entry separately
- avoid grouped-name string allocation and use indexed duplicate counting
- add CLI output coverage plus TypeScript/Java duplicate-name extraction tests

## Test
- cargo test -p ast-grep --lib outline::output
- cargo test -p ast-grep-outline --tests
- commit hooks: fmt, cargo check, clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Outline views now display overload multipliers for duplicate item/member names (e.g., `×3`), including overloaded signatures where applicable.
  * Added signature-based outline snapshot support to better verify extracted method and member definitions.

* **Tests**
  * Expanded signature extraction snapshot coverage across Kotlin, Java, Swift, TypeScript, Python, and Go, including overloaded/duplicate names and visibility differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->