### PR TITLE
fix: skip empty files in outline

### DIFF
--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -19,7 +19,7 @@ use ignore::WalkState;
 use serde::Serialize;
 
 use crate::lang::SgLang;
-use crate::utils::{InputArgs, read_file};
+use crate::utils::{EmptyFile, InputArgs, read_file};
 
 use super::OutlineArg;
 use super::options::{extractor_options_from_arg, show_empty_files};
@@ -220,8 +220,13 @@ fn extract_path(
   let Some(lang) = lang.or_else(|| SgLang::from_path(path)) else {
     return Ok(None);
   };
-  let source =
-    read_file(path).with_context(|| format!("Cannot extract outline from {}", path.display()))?;
+  let source = match read_file(path) {
+    Ok(source) => source,
+    Err(err) if err.downcast_ref::<EmptyFile>().is_some() => return Ok(None),
+    Err(err) => {
+      return Err(err).with_context(|| format!("Cannot extract outline from {}", path.display()));
+    }
+  };
   let grep = lang.ast_grep(source);
   let items = extractors.extract(lang, grep.root());
   if !extractors.show_empty_files && items.is_empty() {
@@ -258,5 +263,27 @@ fn own_entry(entry: OutlineEntry<'_>) -> OutlineEntry<'static> {
     range: entry.range,
     signature: Cow::Owned(entry.signature.into_owned()),
     ast_kind: Cow::Owned(entry.ast_kind.into_owned()),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use tempfile::TempDir;
+
+  #[test]
+  fn empty_files_are_skipped_without_error() {
+    let dir = TempDir::new().expect("temp dir should be created");
+    let path = dir.path().join("empty.rs");
+    std::fs::write(&path, "").expect("empty file should be written");
+    let extractors = OutlineExtractors {
+      by_lang: HashMap::new(),
+      show_empty_files: true,
+    };
+
+    let file =
+      extract_path(&path, None, &extractors).expect("empty file should not be an extraction error");
+
+    assert!(file.is_none());
   }
 }

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -30,6 +30,7 @@ use ast_grep_config::{Rule, RuleCollection};
 use ast_grep_core::{Matcher, tree_sitter::StrDoc};
 use ast_grep_language::{Language, LanguageExt};
 
+use std::fmt;
 use std::fs::read_to_string;
 use std::io::Write;
 use std::io::stdout;
@@ -96,6 +97,17 @@ pub fn prompt(prompt_text: &str, letters: &str, default: Option<char>) -> Result
   }
 }
 
+#[derive(Debug)]
+pub(crate) struct EmptyFile;
+
+impl fmt::Display for EmptyFile {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("File is empty")
+  }
+}
+
+impl std::error::Error for EmptyFile {}
+
 pub(crate) fn read_file(path: &Path) -> Result<String> {
   let file_content =
     read_to_string(path).with_context(|| format!("Cannot read file {}", path.to_string_lossy()))?;
@@ -103,7 +115,7 @@ pub(crate) fn read_file(path: &Path) -> Result<String> {
   if file_too_large(&file_content) {
     Err(anyhow!("File is too large"))
   } else if file_content.is_empty() {
-    Err(anyhow!("File is empty"))
+    Err(EmptyFile.into())
   } else {
     Ok(file_content)
   }


### PR DESCRIPTION
## Summary
- skip zero-byte files during outline extraction without printing an error
- keep other read failures, including oversized files, reported normally
- add a regression test for empty outline input files

## Test
- cargo test -p ast-grep --lib outline::extract
- cargo clippy -p ast-grep --lib --all-targets
- commit hooks: fmt, cargo check, clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty input files no longer cause outline extraction errors. The tool now gracefully handles empty files by returning no data instead of failing the extraction process.

* **Tests**
  * Added test coverage for extracting from empty files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->