### PR TITLE
fix: extract Python from-import modules in outline

### DIFF
--- a/crates/outline/src/default_rules/python.yml
+++ b/crates/outline/src/default_rules/python.yml
@@ -14,7 +14,7 @@ role: item
 symbolType: module
 rule:
   pattern: from $MODULE import $NAME
-name: $MODULE.$NAME
+name: $MODULE
 isImport: true
 isExported: false
 ---

--- a/crates/outline/tests/python_go_outline_rules.rs
+++ b/crates/outline/tests/python_go_outline_rules.rs
@@ -48,7 +48,7 @@ class AsyncOnly:
 "#,
     r#"
 - Module import private functools
-- Module import private django.db.models
+- Module import private django.db
 - Constant item exported DEFAULT_AUTO_FIELD
 - Variable item exported urlpatterns
 - Function item exported module_helper
@@ -88,7 +88,7 @@ class QuerySetRunner:
         return await self.queryset.afirst()
 "#,
     r#"
-- Module import private django.db.models | from django.db import models
+- Module import private django.db | from django.db import models
 - Function item exported fetch_related | async def fetch_related(queryset):
 - Class item exported QuerySetRunner | class QuerySetRunner:
   - Field public query | query = models.Query()


### PR DESCRIPTION
## Summary
- make Python `from MODULE import NAME` outline entries use the imported module as the entry name
- keep Python imports consistent with other language import rules that extract imported modules/paths
- update Python outline snapshots from `django.db.models` to `django.db`

## Test
- cargo test -p ast-grep-outline --test python_go_outline_rules python_rules
- cargo test -p ast-grep-outline --test default_outline_rules
- commit hooks: fmt, cargo check, clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified how Python import symbols are named in code outlines. The naming convention now displays only the module path, simplifying symbol representation in results from Python `import` statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->