### PR TITLE
fix: match Go outline types by declaration

### DIFF
--- a/crates/outline/src/default_rules/go.yml
+++ b/crates/outline/src/default_rules/go.yml
@@ -38,12 +38,15 @@ role: item
 symbolType: struct
 rule:
   all:
-    - kind: type_spec
+    - kind: type_declaration
     - has:
-        field: name
-        pattern: $NAME
-    - has:
-        kind: struct_type
+        all:
+          - kind: type_spec
+          - has:
+              field: name
+              pattern: $NAME
+          - has:
+              kind: struct_type
 name: $NAME
 ---
 id: go-interface-type
@@ -52,12 +55,15 @@ role: item
 symbolType: interface
 rule:
   all:
-    - kind: type_spec
+    - kind: type_declaration
     - has:
-        field: name
-        pattern: $NAME
-    - has:
-        kind: interface_type
+        all:
+          - kind: type_spec
+          - has:
+              field: name
+              pattern: $NAME
+          - has:
+              kind: interface_type
 name: $NAME
 ---
 id: go-struct-field
@@ -98,16 +104,19 @@ role: item
 symbolType: typeParameter
 rule:
   all:
-    - kind: type_spec
+    - kind: type_declaration
     - has:
-        field: name
-        pattern: $NAME
-    - not:
-        has:
-          kind: struct_type
-    - not:
-        has:
-          kind: interface_type
+        all:
+          - kind: type_spec
+          - has:
+              field: name
+              pattern: $NAME
+          - not:
+              has:
+                kind: struct_type
+          - not:
+              has:
+                kind: interface_type
 name: $NAME
 ---
 id: go-const

--- a/crates/outline/tests/python_go_outline_rules.rs
+++ b/crates/outline/tests/python_go_outline_rules.rs
@@ -168,6 +168,8 @@ package gin
 
 import "net/http"
 
+type HandlerFunc func(*Context)
+
 type Engine struct {
     RouterGroup
     maxParams uint16
@@ -188,9 +190,10 @@ func (engine *Engine) Use(middleware ...HandlerFunc) IRoutes {
 "#,
     r#"
 - Module import private net/http | "net/http"
-- Struct item exported Engine | Engine struct {
+- TypeParameter item exported HandlerFunc | type HandlerFunc func(*Context)
+- Struct item exported Engine | type Engine struct {
   - Field private maxParams | maxParams uint16
-- Interface item exported RoutesInfo | RoutesInfo interface {
+- Interface item exported RoutesInfo | type RoutesInfo interface {
   - Method public Last | Last() RouteInfo
   - Method private byName | byName(string) (RouteInfo, bool)
 - Function item exported New | func New() *Engine {


### PR DESCRIPTION
## Summary
- match Go struct/interface/alias outline items at `type_declaration` instead of `type_spec`
- keep name/type-shape predicates scoped to the nested `type_spec`
- update Go signature snapshot expectations to include the leading `type`

## Test
- cargo test -p ast-grep-outline --tests
- commit hooks: fmt, cargo check, clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Go code outline extraction for type declarations (structs, interfaces, and type parameters) through refined matching patterns.

* **Tests**
  * Updated test coverage to validate enhanced type definition handling in Go code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->