### PR TITLE
fix: include const in TypeScript outline signatures

### DIFF
--- a/crates/outline/src/default_rules/typescript.yml
+++ b/crates/outline/src/default_rules/typescript.yml
@@ -174,16 +174,22 @@ language: TypeScript
 role: item
 symbolType: constant
 rule:
-  pattern: 'export const $NAME = $VALUE;'
-name: $NAME
-isExported: true
----
-id: ts-export-const-typed
-language: TypeScript
-role: item
-symbolType: constant
-rule:
-  pattern: 'export const $NAME: $TYPE = $VALUE;'
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - has:
+              field: kind
+              regex: '^const$'
+          - inside:
+              kind: export_statement
+              stopBy: neighbor
+        stopBy: neighbor
 name: $NAME
 isExported: true
 ---
@@ -240,9 +246,6 @@ rule:
         field: name
         kind: identifier
         pattern: $NAME
-    - has:
-        field: value
-        pattern: $VALUE
     - not:
         has:
           field: value
@@ -250,30 +253,9 @@ rule:
     - inside:
         all:
           - kind: lexical_declaration
-          - regex: '^const\b'
-          - inside:
-              kind: program
-              stopBy: neighbor
-        stopBy: neighbor
-name: $NAME
-isExported: false
----
-id: ts-top-level-const-typed
-language: TypeScript
-role: item
-symbolType: constant
-rule:
-  all:
-    - pattern:
-        context: 'const $NAME: $TYPE = $VALUE;'
-        selector: variable_declarator
-    - not:
-        has:
-          field: value
-          kind: arrow_function
-    - inside:
-        all:
-          - kind: lexical_declaration
+          - has:
+              field: kind
+              regex: '^const$'
           - inside:
               kind: program
               stopBy: neighbor
@@ -620,16 +602,22 @@ language: Tsx
 role: item
 symbolType: constant
 rule:
-  pattern: 'export const $NAME = $VALUE;'
-name: $NAME
-isExported: true
----
-id: tsx-export-const-typed
-language: Tsx
-role: item
-symbolType: constant
-rule:
-  pattern: 'export const $NAME: $TYPE = $VALUE;'
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - has:
+              field: kind
+              regex: '^const$'
+          - inside:
+              kind: export_statement
+              stopBy: neighbor
+        stopBy: neighbor
 name: $NAME
 isExported: true
 ---
@@ -686,9 +674,6 @@ rule:
         field: name
         kind: identifier
         pattern: $NAME
-    - has:
-        field: value
-        pattern: $VALUE
     - not:
         has:
           field: value
@@ -696,30 +681,9 @@ rule:
     - inside:
         all:
           - kind: lexical_declaration
-          - regex: '^const\b'
-          - inside:
-              kind: program
-              stopBy: neighbor
-        stopBy: neighbor
-name: $NAME
-isExported: false
----
-id: tsx-top-level-const-typed
-language: Tsx
-role: item
-symbolType: constant
-rule:
-  all:
-    - pattern:
-        context: 'const $NAME: $TYPE = $VALUE;'
-        selector: variable_declarator
-    - not:
-        has:
-          field: value
-          kind: arrow_function
-    - inside:
-        all:
-          - kind: lexical_declaration
+          - has:
+              field: kind
+              regex: '^const$'
           - inside:
               kind: program
               stopBy: neighbor

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -359,14 +359,41 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
 }
 
 fn default_signature<D: Doc>(node: &Node<D>) -> String {
-  node
-    .text()
-    .lines()
-    .find_map(|line| {
-      let trimmed = line.trim();
-      (!trimmed.is_empty()).then(|| trimmed.to_string())
-    })
+  if let Some(signature) = variable_declarator_signature(node) {
+    return signature;
+  }
+  first_non_empty_line(&node.text())
     .unwrap_or_default()
+    .to_string()
+}
+
+fn variable_declarator_signature<D: Doc>(node: &Node<D>) -> Option<String> {
+  if node.kind().as_ref() != "variable_declarator" {
+    return None;
+  }
+  let declaration = node.parent()?;
+  if declaration.kind().as_ref() != "lexical_declaration" {
+    return None;
+  }
+  let keyword = declaration.field_children("kind").next()?.text();
+  let keyword = keyword.trim();
+  if !matches!(keyword, "const" | "let") {
+    return None;
+  }
+  let declarator = node.text();
+  let declarator = first_non_empty_line(&declarator)?;
+  let export = declaration
+    .parent()
+    .is_some_and(|parent| parent.kind().as_ref() == "export_statement");
+  let prefix = if export { "export " } else { "" };
+  Some(format!("{prefix}{keyword} {declarator}"))
+}
+
+fn first_non_empty_line(text: &str) -> Option<&str> {
+  text.lines().find_map(|line| {
+    let trimmed = line.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+  })
 }
 
 fn source_range<D: Doc>(node: &Node<D>) -> SourceRange {

--- a/crates/outline/tests/typescript_outline_rules.rs
+++ b/crates/outline/tests/typescript_outline_rules.rs
@@ -168,6 +168,49 @@ let typedRenderer: React.FC<BadgeProps> = () => <Badge title="typed" />;
 }
 
 #[test]
+fn extracts_const_signatures_with_const_keyword() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::TypeScript,
+    TYPESCRIPT_RULES,
+    r#"
+export const FIND_HIDE_TRANSITION = 'find-hide-transition';
+export const MAX_WIDTH: number = 69;
+export const MULTI_A = 1, MULTI_B: string = 'b';
+const FIND_SHOW_TRANSITION = 'find-show-transition';
+const MAX_MATCHES_COUNT_WIDTH: number = 69;
+const noop = () => {}, _RPCProtocolSymbol = Symbol.for('rpc.protocol');
+let renderLater = () => {};
+"#,
+    r#"
+- Constant item exported FIND_HIDE_TRANSITION | export const FIND_HIDE_TRANSITION = 'find-hide-transition'
+- Constant item exported MAX_WIDTH | export const MAX_WIDTH: number = 69
+- Constant item exported MULTI_A | export const MULTI_A = 1
+- Constant item exported MULTI_B | export const MULTI_B: string = 'b'
+- Constant item private FIND_SHOW_TRANSITION | const FIND_SHOW_TRANSITION = 'find-show-transition'
+- Constant item private MAX_MATCHES_COUNT_WIDTH | const MAX_MATCHES_COUNT_WIDTH: number = 69
+- Function item private noop | const noop = () => {}
+- Constant item private _RPCProtocolSymbol | const _RPCProtocolSymbol = Symbol.for('rpc.protocol')
+- Function item private renderLater | let renderLater = () => {}
+"#,
+  );
+
+  common::assert_outline_signature_snapshot(
+    SupportLang::Tsx,
+    TYPESCRIPT_RULES,
+    r#"
+export const BadgeFactory = () => <Badge title="demo" />;
+const renderBadge = () => <Badge title="demo" />;
+const label = <span>demo</span>;
+"#,
+    r#"
+- Constant item exported BadgeFactory | export const BadgeFactory = () => <Badge title="demo" />
+- Function item private renderBadge | const renderBadge = () => <Badge title="demo" />
+- Constant item private label | const label = <span>demo</span>
+"#,
+  );
+}
+
+#[test]
 fn extracts_typescript_duplicate_member_names_with_signatures() {
   common::assert_outline_signature_snapshot(
     SupportLang::TypeScript,


### PR DESCRIPTION
## Summary
- add explicit const signatures for TypeScript and TSX const outline items
- keep per-declarator extraction while rendering const in signatures
- cover exported, typed, arrow-function, and TSX const signatures

## Tests
- cargo test -p ast-grep-outline --test typescript_outline_rules
- cargo test -p ast-grep-outline --test default_outline_rules
- cargo test -p ast-grep-outline --tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Improved detection of top-level `const` and `export const` declarations in TypeScript and TSX using more precise AST-based matching.
  * Signature extraction is now more consistent for `const` variables, including exported vs private cases and handling of arrow-function, JSX, typed/string, and complex initializers.
* **Tests**
  * Added a new snapshot-based test to verify signature extraction for `const`/`export const` scenarios across TypeScript and TSX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->