### PR TITLE
Add JavaScript outline rules and stream JSON files

### DIFF
--- a/crates/cli/src/outline/output/tests.rs
+++ b/crates/cli/src/outline/output/tests.rs
@@ -330,7 +330,9 @@ fn emitter_streams_json_lines_per_file() {
 
   assert_eq!(lines.len(), 2);
   for line in lines {
-    serde_json::from_str::<serde_json::Value>(line).expect("line should be json");
+    let value = serde_json::from_str::<serde_json::Value>(line).expect("line should be json");
+    assert!(value.get("symbol").is_none());
+    assert!(value["items"].is_array());
   }
 }
 

--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -69,6 +69,7 @@ impl<L: Language> CombinedExtractors<L> {
     options: OutlineExtractorOptions,
     globals: &GlobalRules,
   ) -> Result<Self, OutlineRuleError> {
+    validate_parent_rule_ids(&extractors)?;
     let mut item_extractors = Vec::with_capacity(extractors.len());
     let mut member_extractors = Vec::with_capacity(extractors.len());
     // NB: if member option is None, we won't pass any member extractors
@@ -238,6 +239,41 @@ impl<'a, 'tree, L: LanguageExt> OutlineItemIter<'a, 'tree, L> {
   }
 }
 
+fn validate_parent_rule_ids<L>(
+  extractors: &[SerializableOutlineRule<L>],
+) -> Result<(), OutlineRuleError> {
+  let mut rule_roles = HashMap::new();
+  for extractor in extractors {
+    rule_roles.insert(
+      extractor.common().id.as_str(),
+      matches!(extractor, SerializableOutlineRule::Item(_)),
+    );
+  }
+  for extractor in extractors {
+    let SerializableOutlineRule::Member(member) = extractor else {
+      continue;
+    };
+    for parent_id in &member.parent_rule_ids {
+      match rule_roles.get(parent_id.as_str()) {
+        Some(true) => {}
+        Some(false) => {
+          return Err(OutlineRuleError::InvalidParentRuleRole {
+            rule_id: member.common.id.clone(),
+            parent_id: parent_id.clone(),
+          });
+        }
+        None => {
+          return Err(OutlineRuleError::UnknownParentRuleId {
+            rule_id: member.common.id.clone(),
+            parent_id: parent_id.clone(),
+          });
+        }
+      }
+    }
+  }
+  Ok(())
+}
+
 fn collect_scoped_members<'a, 'tree, L: LanguageExt>(
   traversal: &mut Prune<'tree, L>,
   member_extractors: ScopedMemberExtractors<'a, L>,
@@ -365,6 +401,80 @@ name: other
     assert_eq!(item_extractors[0].common.rule.id, "ts-function");
     assert_eq!(identifier_members.len(), 1);
     assert_eq!(identifier_members[0].common.rule.id, "ts-member");
+  }
+
+  #[test]
+  fn rejects_unknown_member_parent_rule_id() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-member
+language: TypeScript
+role: member
+parentRuleIds: [missing-parent]
+symbolType: method
+rule:
+  kind: method_definition
+name: member
+"#,
+    )
+    .expect("extractors should deserialize");
+
+    let Err(err) = CombinedExtractors::try_from(extractors, &Default::default()) else {
+      panic!("unknown parent id should be rejected");
+    };
+
+    assert!(matches!(err, OutlineRuleError::UnknownParentRuleId { .. }));
+    assert_eq!(
+      err.to_string(),
+      "Member rule `ts-member` references unknown parent rule `missing-parent`"
+    );
+  }
+
+  #[test]
+  fn rejects_member_parent_rule_id_that_points_to_member_rule() {
+    let extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-parent-member
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+rule:
+  kind: method_definition
+name: parent
+---
+id: ts-member
+language: TypeScript
+role: member
+parentRuleIds: [ts-parent-member]
+symbolType: method
+rule:
+  kind: method_definition
+name: child
+---
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  pattern: class $NAME { $$$BODY }
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+
+    let Err(err) = CombinedExtractors::try_from(extractors, &Default::default()) else {
+      panic!("member parent ids should only reference item rules");
+    };
+
+    assert!(matches!(
+      err,
+      OutlineRuleError::InvalidParentRuleRole { .. }
+    ));
+    assert_eq!(
+      err.to_string(),
+      "Member rule `ts-member` cannot use member rule `ts-parent-member` as a parent"
+    );
   }
 
   #[test]

--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -9,6 +9,8 @@ pub const DEFAULT_OUTLINE_RULES: &str = concat!(
   "\n---\n",
   include_str!("default_rules/typescript.yml"),
   "\n---\n",
+  include_str!("default_rules/javascript.yml"),
+  "\n---\n",
   include_str!("default_rules/python.yml"),
   "\n---\n",
   include_str!("default_rules/go.yml"),

--- a/crates/outline/src/default_rules/javascript.yml
+++ b/crates/outline/src/default_rules/javascript.yml
@@ -1,0 +1,269 @@
+id: js-import
+language: JavaScript
+role: item
+symbolType: module
+rule:
+  kind: import_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: true
+isExported: false
+---
+id: js-export-from
+language: JavaScript
+role: item
+symbolType: module
+rule:
+  kind: export_statement
+  has:
+    field: source
+    pattern: $SOURCE
+name: $SOURCE
+isImport: false
+isExported: true
+---
+id: js-export-list
+language: JavaScript
+role: item
+symbolType: module
+rule:
+  pattern: 'export { $$$SPECIFIERS };'
+name: exports
+isImport: false
+isExported: true
+---
+id: js-export-function
+language: JavaScript
+role: item
+symbolType: function
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: function_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: js-function
+language: JavaScript
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        field: name
+        pattern: $NAME
+    - inside:
+        kind: program
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-export-class
+language: JavaScript
+role: item
+symbolType: class
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: class_declaration
+    has:
+      field: name
+      pattern: $NAME
+name: $NAME
+isExported: true
+---
+id: js-class
+language: JavaScript
+role: item
+symbolType: class
+rule:
+  all:
+    - kind: class_declaration
+    - has:
+        field: name
+        pattern: $NAME
+    - inside:
+        kind: program
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-export-const
+language: JavaScript
+role: item
+symbolType: constant
+rule:
+  pattern: 'export const $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: js-export-let
+language: JavaScript
+role: item
+symbolType: variable
+rule:
+  pattern: 'export let $NAME = $VALUE;'
+name: $NAME
+isExported: true
+---
+id: js-top-level-arrow-function
+language: JavaScript
+role: item
+symbolType: function
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-top-level-const
+language: JavaScript
+role: item
+symbolType: constant
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^const\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-top-level-let-uninitialized
+language: JavaScript
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - not:
+        has:
+          field: value
+          pattern: $VALUE
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-top-level-let
+language: JavaScript
+role: item
+symbolType: variable
+rule:
+  all:
+    - kind: variable_declarator
+    - has:
+        field: name
+        kind: identifier
+        pattern: $NAME
+    - has:
+        field: value
+        pattern: $VALUE
+    - not:
+        has:
+          field: value
+          kind: arrow_function
+    - inside:
+        all:
+          - kind: lexical_declaration
+          - regex: '^let\b'
+          - inside:
+              kind: program
+              stopBy: neighbor
+        stopBy: neighbor
+name: $NAME
+isExported: false
+---
+id: js-class-constructor
+language: JavaScript
+role: member
+parentRuleIds: [js-export-class, js-class]
+symbolType: constructor
+rule:
+  pattern:
+    context: 'class A { constructor($$$ARGS) { $$$BODY } }'
+    selector: method_definition
+name: constructor
+isPublic: true
+---
+id: js-class-method
+language: JavaScript
+role: member
+parentRuleIds: [js-export-class, js-class]
+symbolType: method
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      field: name
+      kind: private_property_identifier
+---
+id: js-class-field
+language: JavaScript
+role: member
+parentRuleIds: [js-export-class, js-class]
+symbolType: field
+rule:
+  kind: field_definition
+  has:
+    field: property
+    pattern: $NAME
+name: $NAME
+isPublic:
+  not:
+    has:
+      field: property
+      kind: private_property_identifier

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -152,6 +152,10 @@ pub enum OutlineRuleError {
   Predicate(#[from] RuleSerializeError),
   #[error(transparent)]
   Template(#[from] TemplateFixError),
+  #[error("Member rule `{rule_id}` references unknown parent rule `{parent_id}`")]
+  UnknownParentRuleId { rule_id: String, parent_id: String },
+  #[error("Member rule `{rule_id}` cannot use member rule `{parent_id}` as a parent")]
+  InvalidParentRuleRole { rule_id: String, parent_id: String },
 }
 
 impl<L: Language> ExtractorCommon<L> {

--- a/crates/outline/tests/default_outline_rules.rs
+++ b/crates/outline/tests/default_outline_rules.rs
@@ -9,6 +9,7 @@ fn bundled_outline_rules_compile_for_every_language() {
     SupportLang::Rust,
     SupportLang::TypeScript,
     SupportLang::Tsx,
+    SupportLang::JavaScript,
     SupportLang::Python,
     SupportLang::Go,
     SupportLang::Kotlin,

--- a/crates/outline/tests/javascript_outline_rules.rs
+++ b/crates/outline/tests/javascript_outline_rules.rs
@@ -1,0 +1,103 @@
+use ast_grep_language::SupportLang;
+
+mod common;
+
+const JAVASCRIPT_RULES: &str = include_str!("../src/default_rules/javascript.yml");
+
+#[test]
+fn extracts_javascript_outline_from_es_module_code() {
+  common::assert_outline_snapshot(
+    SupportLang::JavaScript,
+    JAVASCRIPT_RULES,
+    r#"
+import fs from 'fs';
+import { join as pathJoin } from 'path';
+
+export { localHelper };
+export { readFile as read } from './io.js';
+export * from './all.js';
+
+const LOCAL = 1;
+export const EXPORTED = 2;
+let state;
+let count = 0;
+const makeThing = () => ({});
+
+function localHelper() {}
+
+export function run() {}
+
+setup(() => {
+  const callbackLocal = () => {};
+  function nestedHelper() {}
+});
+
+class LocalBox {
+  static version = 1;
+  #secret = 2;
+
+  constructor(name) {
+    this.name = name;
+  }
+
+  get value() {
+    return this.#secret;
+  }
+
+  hide() {}
+  #reset() {}
+}
+
+export class Service extends Base {
+  start() {}
+}
+"#,
+    r#"
+- Module import private 'fs'
+- Module import private 'path'
+- Module item exported exports
+- Module item exported './io.js'
+- Module item exported './all.js'
+- Constant item private LOCAL
+- Constant item exported EXPORTED
+- Variable item private state
+- Variable item private count
+- Function item private makeThing
+- Function item private localHelper
+- Function item exported run
+- Class item private LocalBox
+  - Field public version
+  - Field private #secret
+  - Constructor public constructor
+  - Method public value
+  - Method public hide
+  - Method private #reset
+- Class item exported Service
+  - Method public start
+"#,
+  );
+}
+
+#[test]
+fn extracts_javascript_signatures() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::JavaScript,
+    JAVASCRIPT_RULES,
+    r#"
+export class Service {
+  constructor(name) {
+    this.name = name;
+  }
+
+  start() {}
+  #reset() {}
+}
+"#,
+    r#"
+- Class item exported Service | export class Service {
+  - Constructor public constructor | constructor(name) {
+  - Method public start | start() {}
+  - Method private #reset | #reset() {}
+"#,
+  );
+}

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -313,7 +313,7 @@ Text is the default output.
 default          text
 --json           pretty-printed JSON
 --json=compact   compact JSON
---json=stream    newline-delimited entries
+--json=stream    newline-delimited file objects
 ```
 
 Interactive agents should usually use text. They should request `--json` only when they
@@ -390,36 +390,12 @@ nothing found
 
 ### JSON Output
 
-`--json` returns grouped file output. `--json=stream` returns one independently useful
-entry per line. Text output uses one-based line numbers for display. JSON ranges use
-zero-based line and column numbers plus byte offsets, matching ast-grep's existing JSON
-range convention.
+`--json` returns grouped file output. `--json=stream` returns the same selected file
+object shape as one newline-delimited JSON object per emitted file. Text output uses
+one-based line numbers for display. JSON ranges use zero-based line and column numbers
+plus byte offsets, matching ast-grep's existing JSON range convention.
 
-Streamed entry shape:
-
-```json
-{
-  "path": "crates/cli/src/lib.rs",
-  "language": "Rust",
-  "symbol": {
-    "name": "Commands",
-    "symbolType": "enum",
-    "role": "item",
-    "isImport": false,
-    "isExported": false,
-    "range": {
-      "byteOffset": { "start": 1200, "end": 1700 },
-      "start": { "line": 48, "column": 0 },
-      "end": { "line": 67, "column": 1 }
-    },
-    "container": null,
-    "signature": "enum Commands",
-    "astKind": "enum_item"
-  }
-}
-```
-
-Grouped file shape:
+Streamed file shape:
 
 ```json
 {
@@ -467,7 +443,7 @@ Important properties:
 - `role` is always `item` or `member`.
 - `isImport` and `isExported` are present on top-level items.
 - `isPublic` is present on members and only meaningful there.
-- `container` is present in stream output for parent-symbol metadata.
+- Members remain nested under their parent item in grouped and stream JSON output.
 
 ## Agent Examples
 
@@ -530,8 +506,9 @@ structure and public surface of those changed files.
 sg outline crates --json=stream
 ```
 
-This is the machine-readable mode for ranking candidates by path, symbol type, name,
-item flags, and container. It is not the default interactive-agent mode.
+This is the machine-readable mode for incrementally processing file outlines by path,
+symbol type, name, item flags, and direct members. It is not the default
+interactive-agent mode.
 
 ## Data Model
 
@@ -582,62 +559,35 @@ Grouped item:
 
 ```rust
 pub struct OutlineItem {
-  pub name: Option<String>,
+  pub name: String,
   pub symbol_type: SymbolType,
   pub role: OutlineRole,
   pub is_import: bool,
   pub is_exported: bool,
   pub range: Range,
-  pub signature: Option<String>,
+  pub signature: String,
   pub ast_kind: String,
   pub members: Vec<OutlineMember>,
 }
 
 pub struct OutlineMember {
-  pub name: Option<String>,
+  pub name: String,
   pub symbol_type: SymbolType,
   pub role: OutlineRole,
-  pub is_public: Option<bool>,
+  pub is_public: bool,
   pub range: Range,
-  pub signature: Option<String>,
+  pub signature: String,
   pub ast_kind: String,
 }
 
 pub struct OutlineFile {
-  pub path: PathBuf,
-  pub language: SgLang,
+  pub path: String,
+  pub language: String,
   pub items: Vec<OutlineItem>,
 }
 ```
 
-Streamed entry:
-
-```rust
-pub struct OutlineEntry {
-  pub path: PathBuf,
-  pub language: SgLang,
-  pub symbol: OutlineFlatSymbol,
-}
-
-pub struct OutlineFlatSymbol {
-  pub name: Option<String>,
-  pub symbol_type: SymbolType,
-  pub role: OutlineRole,
-  pub is_import: Option<bool>,
-  pub is_exported: Option<bool>,
-  pub is_public: Option<bool>,
-  pub range: Range,
-  pub signature: Option<String>,
-  pub ast_kind: String,
-  pub container: Option<OutlineContainer>,
-}
-
-pub struct OutlineContainer {
-  pub name: Option<String>,
-  pub symbol_type: SymbolType,
-  pub range: Range,
-}
-```
+Streamed JSON uses the same `OutlineFile` object shape, emitted once per line.
 
 ### Item Flags
 
@@ -759,7 +709,7 @@ composition when they need presentation-level truncation:
 ```sh
 sg outline crates/cli/src | head -n 120
 sg outline crates/cli/src --items exports | head -n 80
-sg outline crates/cli/src --json=stream | jq 'select(.symbol.symbolType == "function")'
+sg outline crates/cli/src --json=stream | jq '.items[] | select(.symbolType == "function")'
 ```
 
 A future built-in limit may still be valuable as a safety guard against accidentally

--- a/docs/design/outline-command.md
+++ b/docs/design/outline-command.md
@@ -252,11 +252,6 @@ Structural members include:
 - interface, trait, type, impl, and extension members
 - declarations directly inside modules or namespaces
 
-For JavaScript and TypeScript only, named function declarations inside a function body
-are also members of the containing function. Large JS/TS files often use local helper
-functions as part of a function's navigable structure. Other function-body locals are
-not part of the file outline.
-
 Examples:
 
 ```sh
@@ -268,15 +263,15 @@ sg outline src/checker.ts --match checkTypeRelatedTo --view expanded
 
 ### Member Publicness
 
-Member publicness is intentionally simpler than a full visibility model. Members can
-carry `isPublic: true` when language-specific syntax says the member is part of the
-usable surface of its parent. Private members use `isPublic: false` when the extractor
-can determine that. Languages or rules without this knowledge may leave `isPublic`
-absent.
+Member publicness is intentionally simpler than a full visibility model. Members carry
+`isPublic: true` when language-specific syntax says the member is part of the usable
+surface of its parent. Private members use `isPublic: false` when the extractor can
+determine that. Languages or rules without this knowledge should omit `isPublic` in the
+rule; outline treats omitted member publicness as `true`.
 
 By default, member views display all extracted members. `digest` should list public
-members first inside each member symbol type group when `isPublic` is known, then list
-the remaining members. Each bucket keeps source order.
+members first inside each member symbol type group, then list the remaining members.
+Each bucket keeps source order.
 
 `--pub-members` narrows displayed members in `digest` and `expanded` views:
 
@@ -285,9 +280,8 @@ default         show all extracted members.
 --pub-members   show only members where isPublic is true.
 ```
 
-Members with absent `isPublic` are kept by default and removed by `--pub-members`.
-`expanded` should keep source order; when `--pub-members` is present, it filters
-members without reordering the survivors.
+`expanded` should keep source order; when `--pub-members` is present, it filters members
+without reordering the survivors.
 
 ### Ordering
 
@@ -325,8 +319,9 @@ default          text
 Interactive agents should usually use text. They should request `--json` only when they
 need to transform, extract, join, or programmatically compare outline entries.
 
-`--view` affects text output only. JSON output always emits the selected structured
-model after `--items`, `--match`, `--type`, and `--pub-members` filtering.
+`--view` affects both text presentation and JSON detail. JSON output emits the selected
+structured model after `--items`, `--match`, `--type`, and `--pub-members` filtering,
+but views that do not display signatures or members can omit that detail from JSON too.
 
 ## Output Contract
 
@@ -338,8 +333,8 @@ Color is only a reading aid:
 
 - `names` colors the symbol type label.
 - `signatures`, `digest`, and `expanded` color the entry name inside each signature line.
-- exported top-level item names are bold in `digest` and `expanded`, but not in
-  `signatures`.
+- exported top-level item names are bold in signature-bearing views unless
+  `--items exports` already selects only exports.
 - member digest lines are indented; plural labels like `fields:` use the member
   symbol type color.
 - private members are dimmed; their name keeps the member symbol type color.
@@ -396,14 +391,16 @@ nothing found
 ### JSON Output
 
 `--json` returns grouped file output. `--json=stream` returns one independently useful
-entry per line. JSON ranges use one-based line and column numbers, matching text output.
+entry per line. Text output uses one-based line numbers for display. JSON ranges use
+zero-based line and column numbers plus byte offsets, matching ast-grep's existing JSON
+range convention.
 
 Streamed entry shape:
 
 ```json
 {
   "path": "crates/cli/src/lib.rs",
-  "language": "rs",
+  "language": "Rust",
   "symbol": {
     "name": "Commands",
     "symbolType": "enum",
@@ -411,8 +408,9 @@ Streamed entry shape:
     "isImport": false,
     "isExported": false,
     "range": {
-      "start": { "line": 49, "column": 1, "byte": 1200 },
-      "end": { "line": 68, "column": 2, "byte": 1700 }
+      "byteOffset": { "start": 1200, "end": 1700 },
+      "start": { "line": 48, "column": 0 },
+      "end": { "line": 67, "column": 1 }
     },
     "container": null,
     "signature": "enum Commands",
@@ -426,7 +424,7 @@ Grouped file shape:
 ```json
 {
   "path": "src/parser.ts",
-  "language": "ts",
+  "language": "TypeScript",
   "items": [
     {
       "name": "Parser",
@@ -435,8 +433,9 @@ Grouped file shape:
       "isImport": false,
       "isExported": true,
       "range": {
-        "start": { "line": 40, "column": 1, "byte": 1200 },
-        "end": { "line": 98, "column": 2, "byte": 2500 }
+        "byteOffset": { "start": 1200, "end": 2500 },
+        "start": { "line": 39, "column": 0 },
+        "end": { "line": 97, "column": 1 }
       },
       "signature": "export class Parser",
       "astKind": "class_declaration",
@@ -447,8 +446,9 @@ Grouped file shape:
           "role": "member",
           "isPublic": true,
           "range": {
-            "start": { "line": 44, "column": 3, "byte": 1300 },
-            "end": { "line": 72, "column": 4, "byte": 1900 }
+            "byteOffset": { "start": 1300, "end": 1900 },
+            "start": { "line": 43, "column": 2 },
+            "end": { "line": 71, "column": 3 }
           },
           "signature": "parse(...)",
           "astKind": "method_definition"
@@ -466,8 +466,7 @@ Important properties:
 - `symbolType` uses LSP `SymbolKind` names serialized as lower camel case.
 - `role` is always `item` or `member`.
 - `isImport` and `isExported` are present on top-level items.
-- `isPublic` is optional and only meaningful for members; it is absent or null for
-  top-level items.
+- `isPublic` is present on members and only meaningful there.
 - `container` is present in stream output for parent-symbol metadata.
 
 ## Agent Examples

--- a/docs/design/outline-rule-extraction.md
+++ b/docs/design/outline-rule-extraction.md
@@ -79,8 +79,9 @@ signature   first non-empty source line of the matched syntax.
 astKind     tree-sitter node kind of the matched syntax.
 ```
 
-Top-level `item` entries can additionally carry `isImport` and `isExported`.
-Direct `member` entries can additionally carry `isPublic`.
+Top-level `item` entries carry `isImport` and `isExported`. Direct `member`
+entries carry `isPublic`; if a member rule omits `isPublic`, outline treats the
+member as public.
 
 These fields are output facts, not necessarily separate extractor types. For example,
 `pub use internal_mod as api;` is one top-level item with both `isImport` and
@@ -172,8 +173,9 @@ isPublic    Boolean or predicate for member publicness.
 `role`, `symbolType`, and `name` are required. `parentRuleIds` is required for
 `role: member` and ignored for `role: item`. `signature` is optional; when omitted,
 the extractor uses the first non-empty line of the matched node as the signature.
-`isImport`, `isExported`, and `isPublic` are omitted unless the extractor can derive
-them.
+`isImport`, `isExported`, and `isPublic` can be omitted from rules that rely on the
+runtime defaults: items default to `isImport: false` and `isExported: true`, while
+members default to `isPublic: true`.
 
 ### Text Field Extraction
 
@@ -533,12 +535,9 @@ source organization.
    - import syntax can set `isImport`.
    - top-level export syntax or language public-surface syntax can set `isExported`.
    - member syntax can set `isPublic`.
-7. Deduplicate entries by range, symbol type, and name.
-8. Merge duplicate top-level items by range, symbol type, and name, preserving
-   `isImport` and `isExported`.
-9. Attach direct members by syntax containment and `parentRuleIds`.
-10. Sort entries in source order.
-11. Pass the file model to CLI filtering and rendering.
+7. Attach direct members by syntax containment and `parentRuleIds`.
+8. Sort entries in source order.
+9. Pass the file model to CLI filtering and rendering.
 
 ## Rule Catalog Implications
 
@@ -600,6 +599,18 @@ sg outline src \
 
 Unsupported languages should return an empty outline and a successful exit
 status.
+
+## Future: Duplicate Entry Merge
+
+The current extractor relies on rule specificity and traversal order to avoid duplicate
+entries. A future refinement can add an explicit duplicate merge phase:
+
+1. Deduplicate entries by range, symbol type, and name.
+2. Merge duplicate top-level items by range, symbol type, and name, preserving
+   `isImport` and `isExported`.
+
+This should be designed with rule ordering and member attachment together, so the merge
+step does not hide ambiguous extractor definitions or accidentally drop members.
 
 ## Future: Rich Signatures
 


### PR DESCRIPTION
## Summary
- sync outline design docs with current implementation decisions
- validate outline member parentRuleIds during extractor construction
- document and test --json=stream as one file object per line
- add bundled JavaScript outline rules and snapshots

## Tests
- cargo test -p ast-grep --lib outline::output::tests::emitter_streams_json_lines_per_file
- cargo test -p ast-grep-outline --test javascript_outline_rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JavaScript/TypeScript outline extraction support with built-in language rules.

* **Improvements**
  * Strengthened validation of outline rule configurations with clearer error messages for invalid parent references.

* **Documentation**
  * Updated outline command and rule extraction pipeline documentation with refined output specifications and default behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->