### PR TITLE
feat: Support `*.bazel` files in python

### DIFF
--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -516,7 +516,7 @@ fn extensions(lang: SupportLang) -> &'static [&'static str] {
     Markdown => &["markdown", "md"],
     Nix => &["nix"],
     Php => &["php"],
-    Python => &["py", "py3", "pyi", "bzl"],
+    Python => &["py", "py3", "pyi", "bzl", "bazel"],
     Ruby => &["rb", "rbw", "gemspec"],
     Rust => &["rs"],
     Scala => &["scala", "sc", "sbt"],


### PR DESCRIPTION
Bazel projects contain both `.bzl` and `.bazel` files, with `.bazel` being used mainly for the `WORKSPACE.bazel` and `MODULE.bazel` files, but also `BUILD.bazel`.

This PR brings the support for `*.bazel` files, complementing the already existing support for `*.bzl`.

Closes: #2769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python file type detection so files with the `.bazel` extension are now recognized correctly along with existing Python-related extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->