### PR TITLE
feat: load custom language outline rules from config

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -59,6 +59,8 @@ pub struct ProjectConfig {
   pub project_dir: PathBuf,
   /// YAML rule directories
   pub rule_dirs: Vec<PathBuf>,
+  /// YAML outline rule files configured by custom languages
+  pub outline_rules: Vec<PathBuf>,
   /// test configurations
   pub test_configs: Option<Vec<TestConfig>>,
   /// util rules directories
@@ -97,9 +99,12 @@ impl ProjectConfig {
     let Some((project_dir, mut sg_config)) = Self::discover_project(config_path)? else {
       return Ok(Err(anyhow::anyhow!(EC::ProjectNotExist)));
     };
+    let outline_rules =
+      custom_language_outline_rules(&project_dir, sg_config.custom_languages.as_ref());
     let config = ProjectConfig {
       project_dir,
       rule_dirs: sg_config.rule_dirs.drain(..).collect(),
+      outline_rules,
       test_configs: sg_config.test_configs.take(),
       util_dirs: sg_config.util_dirs.take(),
     };
@@ -107,6 +112,18 @@ impl ProjectConfig {
     register_custom_language(&config.project_dir, sg_config)?;
     Ok(Ok(config))
   }
+}
+
+fn custom_language_outline_rules(
+  project_dir: &Path,
+  custom_languages: Option<&HashMap<String, CustomLang>>,
+) -> Vec<PathBuf> {
+  custom_languages
+    .into_iter()
+    .flat_map(HashMap::values)
+    .filter_map(|lang| lang.outline_rules.as_ref())
+    .map(|path| project_dir.join(path))
+    .collect()
 }
 
 fn register_custom_language(project_dir: &Path, sg_config: AstGrepConfig) -> Result<()> {
@@ -274,5 +291,29 @@ fn find_config_path_with_default(config_path: Option<PathBuf>) -> Result<Option<
     } else {
       break Ok(None);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn custom_language_outline_rules_are_project_relative() {
+    let config: AstGrepConfig = from_str(
+      r#"
+customLanguages:
+  blade:
+    libraryPath: parsers/blade.so
+    extensions: [blade.php]
+    outlineRules: outline/blade.yml
+"#,
+    )
+    .expect("config should parse");
+
+    let paths =
+      custom_language_outline_rules(Path::new("/project"), config.custom_languages.as_ref());
+
+    assert_eq!(paths, vec![PathBuf::from("/project/outline/blade.yml")]);
   }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -144,7 +144,7 @@ pub fn main_with_args(args: impl Iterator<Item = String>) -> Result<ExitCode> {
     Commands::Test(arg) => run_test_rule(arg, project),
     Commands::New(arg) => run_create_new(arg, project),
     Commands::Lsp(arg) => run_language_server(arg, project).map(|_| ExitCode::SUCCESS),
-    Commands::Outline(arg) => run_outline(arg),
+    Commands::Outline(arg) => run_outline(arg, project),
     Commands::Completions(arg) => run_shell_completion::<App>(arg),
     #[cfg(debug_assertions)]
     Commands::Docs => todo!("todo, generate rule docs based on current config"),

--- a/crates/cli/src/outline.rs
+++ b/crates/cli/src/outline.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use clap::{Args, ValueEnum};
 
+use crate::config::ProjectConfig;
 use crate::lang::SgLang;
 use crate::print::{ColorArg, JsonStyle};
 use crate::utils::InputArgs;
@@ -130,8 +131,16 @@ pub struct OutlineArg {
   input: InputArgs,
 }
 
-pub fn run_outline(arg: OutlineArg) -> Result<ExitCode> {
-  let rules = load_outline_rules(!arg.no_default_outline_rules, &arg.outline_rules)?;
+pub fn run_outline(arg: OutlineArg, project: Result<ProjectConfig>) -> Result<ExitCode> {
+  let config_outline_rules = project
+    .as_ref()
+    .map(|project| project.outline_rules.as_slice())
+    .unwrap_or(&[]);
+  let rules = load_outline_rules(
+    !arg.no_default_outline_rules,
+    config_outline_rules,
+    &arg.outline_rules,
+  )?;
   let style = OutlineStyle::from_arg(&arg);
   let extractors = Arc::new(OutlineExtractors::try_from_arg(rules, &arg)?);
   let stdout = io::stdout();

--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -97,7 +97,8 @@ impl OutlineExtractors {
 
 pub fn load_outline_rules(
   include_default: bool,
-  paths: &[PathBuf],
+  config_paths: &[PathBuf],
+  cli_paths: &[PathBuf],
 ) -> Result<Vec<SerializableOutlineRule<SgLang>>> {
   let mut rules = vec![];
   if include_default {
@@ -105,7 +106,7 @@ pub fn load_outline_rules(
       parse_outline_rules(DEFAULT_OUTLINE_RULES).context("Cannot parse builtin outline rules")?,
     );
   }
-  for path in paths {
+  for path in config_paths.iter().chain(cli_paths) {
     let source = std::fs::read_to_string(path)
       .with_context(|| format!("Cannot read outline rules {}", path.display()))?;
     rules.extend(
@@ -269,6 +270,7 @@ fn own_entry(entry: OutlineEntry<'_>) -> OutlineEntry<'static> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::fs;
   use tempfile::TempDir;
 
   #[test]
@@ -285,5 +287,47 @@ mod tests {
       extract_path(&path, None, &extractors).expect("empty file should not be an extraction error");
 
     assert!(file.is_none());
+  }
+
+  #[test]
+  fn load_outline_rules_reads_config_and_cli_paths() {
+    let dir = TempDir::new().expect("temp dir should be created");
+    let config_path = dir.path().join("config-outline.yml");
+    let cli_path = dir.path().join("cli-outline.yml");
+    fs::write(
+      &config_path,
+      r#"
+id: config-rust-function
+language: Rust
+role: item
+symbolType: function
+rule:
+  kind: function_item
+name: fn
+"#,
+    )
+    .expect("config outline file should be written");
+    fs::write(
+      &cli_path,
+      r#"
+id: cli-rust-struct
+language: Rust
+role: item
+symbolType: struct
+rule:
+  kind: struct_item
+name: struct
+"#,
+    )
+    .expect("cli outline file should be written");
+
+    let rules =
+      load_outline_rules(false, &[config_path], &[cli_path]).expect("outline rules should load");
+    let ids = rules
+      .iter()
+      .map(|rule| rule.common().id.as_str())
+      .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["config-rust-function", "cli-rust-struct"]);
   }
 }

--- a/crates/dynamic/src/custom_lang.rs
+++ b/crates/dynamic/src/custom_lang.rs
@@ -20,6 +20,8 @@ pub struct CustomLang {
   pub meta_var_char: Option<char>,
   pub expando_char: Option<char>,
   pub extensions: Vec<String>,
+  /// YAML file containing outline rules for this custom language.
+  pub outline_rules: Option<PathBuf>,
 }
 
 impl CustomLang {
@@ -69,10 +71,12 @@ mod test {
   fn test_custom_lang() {
     let yaml = r"
 libraryPath: a/b/c.so
+outlineRules: rules/outline.yml
 extensions: [d, e, f]";
     let cus: CustomLang = from_str(yaml).unwrap();
     assert_eq!(cus.language_symbol, None);
     assert_eq!(cus.extensions, vec!["d", "e", "f"]);
+    assert_eq!(cus.outline_rules, Some(PathBuf::from("rules/outline.yml")));
   }
   fn is_test_supported() -> bool {
     cfg!(all(target_os = "macos", target_arch = "aarch64"))

--- a/crates/pyo3/src/py_lang.rs
+++ b/crates/pyo3/src/py_lang.rs
@@ -35,6 +35,7 @@ impl From<CustomPyLang> for CustomLang {
       meta_var_char: c.meta_var_char,
       expando_char: c.expando_char,
       extensions: c.extensions,
+      outline_rules: None,
     }
   }
 }

--- a/schemas/project.json
+++ b/schemas/project.json
@@ -95,6 +95,10 @@
         "languageSymbol": {
           "type": "string",
           "description": "The dylib symbol to load ts-language, default is tree_sitter_{name}"
+        },
+        "outlineRules": {
+          "type": "string",
+          "description": "The path to the YAML file containing outline rules for this custom language."
         }
       },
       "required": ["libraryPath", "extensions"]


### PR DESCRIPTION
## Summary
- add `outlineRules` to custom language registration in sgconfig
- load config-provided outline YAML files alongside CLI `--outline-rules`
- update project schema and tests

## Test plan
- cargo test -p ast-grep --lib
- cargo test -p ast-grep-dynamic test_custom_lang
- cargo check -p ast-grep-napi
- cargo check -p ast-grep-py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom-language outline rule paths in project configuration.
  * Outline generation now combines rules from both project settings and command-line options.

* **Bug Fixes**
  * Fixed path handling so configured outline rule files are resolved relative to the project directory.
  * Preserved the expected loading order for outline rules from configuration and command-line sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->