### PR TITLE
Bound the outline file queue

### DIFF
--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -24,6 +24,8 @@ use crate::utils::{EmptyFile, InputArgs, read_file};
 use super::OutlineArg;
 use super::options::{extractor_options_from_arg, show_empty_files};
 
+const OUTLINE_QUEUE_BOUND: usize = 256;
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OutlineFile<'a> {
@@ -141,7 +143,7 @@ pub fn stream_paths(
     return Ok(());
   }
   let walker = outline_walk(&arg.input, arg.lang, &extractors)?;
-  let (tx, rx) = mpsc::channel();
+  let (tx, rx) = outline_channel();
   let lang = arg.lang;
   let producer = thread::spawn(move || {
     walker.run(|| {
@@ -174,6 +176,13 @@ pub fn stream_paths(
     .join()
     .map_err(|_| anyhow::anyhow!("outline walker thread panicked"))?;
   result
+}
+
+fn outline_channel() -> (
+  mpsc::SyncSender<OutlineFile<'static>>,
+  mpsc::Receiver<OutlineFile<'static>>,
+) {
+  mpsc::sync_channel(OUTLINE_QUEUE_BOUND)
 }
 
 fn outline_walk(
@@ -329,5 +338,28 @@ name: struct
       .collect::<Vec<_>>();
 
     assert_eq!(ids, vec!["config-rust-function", "cli-rust-struct"]);
+  }
+
+  #[test]
+  fn outline_channel_applies_backpressure_at_bound() {
+    let (tx, _rx) = outline_channel();
+    for i in 0..OUTLINE_QUEUE_BOUND {
+      tx.try_send(OutlineFile {
+        path: format!("file-{i}.rs"),
+        language: "Rust".to_string(),
+        items: vec![],
+      })
+      .expect("queue should accept files below the bound");
+    }
+
+    let err = tx
+      .try_send(OutlineFile {
+        path: "overflow.rs".to_string(),
+        language: "Rust".to_string(),
+        items: vec![],
+      })
+      .expect_err("queue should apply backpressure at the bound");
+
+    assert!(matches!(err, mpsc::TrySendError::Full(_)));
   }
 }


### PR DESCRIPTION
Large `ast-grep outline` runs could queue extracted file payloads faster than the emitter wrote output, because the parallel walker handed files through an unbounded channel. The handoff now uses a bounded `sync_channel` with a 256-file queue, applying backpressure without changing the walker, extraction, or emit flow.

The extractor backpressure case and outline CLI coverage passed, followed by `cargo fmt --all -- --check`, `cargo test -p ast-grep outline::extract`, `cargo test -p ast-grep test_outline`, full `cargo test`, and `git diff --check`. Fixes #2741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outline processing reliability by limiting queued work, helping prevent runaway memory growth during heavy or slow operations.
  * Added safeguards so outline extraction now handles backpressure more gracefully under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->