### PR TITLE
fix(core): cap display_context walk distance to avoid output blowup on minified files

### DIFF
--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -61,6 +61,7 @@ pub struct ColoredPrinter<W: WriteColor> {
   styles: PrintStyles,
   heading: Heading,
   context: (u16, u16),
+  max_context_bytes: usize,
 }
 
 impl<W: WriteColor> ColoredPrinter<W> {
@@ -71,6 +72,7 @@ impl<W: WriteColor> ColoredPrinter<W> {
       config: term::Config::default(),
       heading: Heading::Auto,
       context: (0, 0),
+      max_context_bytes: ast_grep_core::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE,
     }
   }
 
@@ -101,6 +103,11 @@ impl<W: WriteColor> ColoredPrinter<W> {
     self.config.end_context_lines = context.1 as usize;
     self
   }
+
+  pub fn max_context_bytes(mut self, max_context_bytes: usize) -> Self {
+    self.max_context_bytes = max_context_bytes;
+    self
+  }
 }
 
 impl<W: WriteColor> Printer for ColoredPrinter<W> {
@@ -116,6 +123,7 @@ impl<W: WriteColor> Printer for ColoredPrinter<W> {
       styles: self.styles.clone(),
       heading: self.heading,
       context: self.context,
+      max_context_bytes: self.max_context_bytes,
       markdown,
     }
   }
@@ -171,6 +179,7 @@ pub struct ColoredProcessor {
   heading: Heading,
   markdown: Markdown,
   context: (u16, u16),
+  max_context_bytes: usize,
 }
 
 impl ColoredProcessor {
@@ -339,7 +348,7 @@ fn print_matches_with_heading(
   };
   let source = first_match.root().get_text();
 
-  let mut merger = MatchMerger::new(&first_match, printer.context);
+  let mut merger = MatchMerger::new(&first_match, printer.context, printer.max_context_bytes);
 
   let display = merger.display(&first_match);
   let mut ret = display.leading.to_string();
@@ -389,7 +398,7 @@ fn print_matches_with_prefix(
   };
   let source = first_match.root().get_text();
 
-  let mut merger = MatchMerger::new(&first_match, printer.context);
+  let mut merger = MatchMerger::new(&first_match, printer.context, printer.max_context_bytes);
   let display = merger.display(&first_match);
   let mut ret = display.leading.to_string();
   styles.push_matched_to_ret(&mut ret, &display.matched)?;

--- a/crates/cli/src/print/colored_print/match_merger.rs
+++ b/crates/cli/src/print/colored_print/match_merger.rs
@@ -9,11 +9,12 @@ pub struct MatchMerger<'a> {
   pub last_trailing: &'a str,
   pub last_end_offset: usize,
   pub context: (u16, u16),
+  pub max_context_bytes: usize,
 }
 
 impl<'a> MatchMerger<'a> {
-  pub fn new(nm: &NodeMatch<'a>, (before, after): (u16, u16)) -> Self {
-    let display = nm.display_context(before as usize, after as usize);
+  pub fn new(nm: &NodeMatch<'a>, (before, after): (u16, u16), max_context_bytes: usize) -> Self {
+    let display = nm.display_context(before as usize, after as usize, max_context_bytes);
     let last_start_line = display.start_line + 1;
     let last_end_line = nm.end_pos().line() + 1;
     let last_trailing = display.trailing;
@@ -24,6 +25,7 @@ impl<'a> MatchMerger<'a> {
       last_end_offset,
       last_trailing,
       context: (before, after),
+      max_context_bytes,
     }
   }
 
@@ -66,6 +68,6 @@ impl<'a> MatchMerger<'a> {
 
   pub fn display(&self, nm: &NodeMatch<'a>) -> DisplayContext<'a> {
     let (before, after) = self.context;
-    nm.display_context(before as usize, after as usize)
+    nm.display_context(before as usize, after as usize, self.max_context_bytes)
   }
 }

--- a/crates/cli/src/print/json_print.rs
+++ b/crates/cli/src/print/json_print.rs
@@ -149,8 +149,8 @@ fn get_range(n: &Node<'_, SgLang>) -> Range {
 }
 
 impl<'t, 'b> MatchJSON<'t, 'b> {
-  fn new(nm: NodeMatch<'t>, path: &'b str, context: (u16, u16)) -> Self {
-    let display = nm.display_context(context.0 as usize, context.1 as usize);
+  fn new(nm: NodeMatch<'t>, path: &'b str, context: (u16, u16), max_context_bytes: usize) -> Self {
+    let display = nm.display_context(context.0 as usize, context.1 as usize, max_context_bytes);
     let lines = format!("{}{}{}", display.leading, display.matched, display.trailing);
     MatchJSON {
       file: Cow::Borrowed(path),
@@ -168,8 +168,13 @@ impl<'t, 'b> MatchJSON<'t, 'b> {
     }
   }
 
-  fn diff(diff: Diff<'t>, path: &'b str, context: (u16, u16)) -> Self {
-    let mut ret = Self::new(diff.node_match, path, context);
+  fn diff(
+    diff: Diff<'t>,
+    path: &'b str,
+    context: (u16, u16),
+    max_context_bytes: usize,
+  ) -> Self {
+    let mut ret = Self::new(diff.node_match, path, context, max_context_bytes);
     ret.replacement = Some(diff.replacement);
     ret.replacement_offsets = Some(diff.range);
     ret
@@ -222,10 +227,16 @@ struct RuleMatchJSON<'t, 'b> {
   metadata: Option<Cow<'b, Metadata>>,
 }
 impl<'t, 'b> RuleMatchJSON<'t, 'b> {
-  fn new(nm: NodeMatch<'t>, path: &'b str, rule: &'b RuleConfig<SgLang>, metadata: bool) -> Self {
+  fn new(
+    nm: NodeMatch<'t>,
+    path: &'b str,
+    rule: &'b RuleConfig<SgLang>,
+    metadata: bool,
+    max_context_bytes: usize,
+  ) -> Self {
     let message = rule.get_message(&nm);
     let labels = get_labels(rule, &nm);
-    let matched = MatchJSON::new(nm, path, (0, 0));
+    let matched = MatchJSON::new(nm, path, (0, 0), max_context_bytes);
     let metadata = if metadata {
       rule.metadata.as_ref().map(Cow::Borrowed)
     } else {
@@ -241,11 +252,17 @@ impl<'t, 'b> RuleMatchJSON<'t, 'b> {
       metadata,
     }
   }
-  fn diff(diff: Diff<'t>, path: &'b str, rule: &'b RuleConfig<SgLang>, metadata: bool) -> Self {
+  fn diff(
+    diff: Diff<'t>,
+    path: &'b str,
+    rule: &'b RuleConfig<SgLang>,
+    metadata: bool,
+    max_context_bytes: usize,
+  ) -> Self {
     let nm = &diff.node_match;
     let message = rule.get_message(nm);
     let labels = get_labels(rule, nm);
-    let matched = MatchJSON::diff(diff, path, (0, 0));
+    let matched = MatchJSON::diff(diff, path, (0, 0), max_context_bytes);
     let metadata = if metadata {
       rule.metadata.as_ref().map(Cow::Borrowed)
     } else {
@@ -282,6 +299,7 @@ pub struct JSONPrinter<W: Write> {
   output: W,
   style: JsonStyle,
   context: (u16, u16),
+  max_context_bytes: usize,
   include_metadata: bool,
   // indicate if any matches happened
   matched: bool,
@@ -300,12 +318,18 @@ impl<W: Write> JSONPrinter<W> {
       output,
       include_metadata: false,
       context: (0, 0),
+      max_context_bytes: ast_grep_core::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE,
       matched: false,
     }
   }
 
   pub fn context(mut self, context: (u16, u16)) -> Self {
     self.context = context;
+    self
+  }
+
+  pub fn max_context_bytes(mut self, max_context_bytes: usize) -> Self {
+    self.max_context_bytes = max_context_bytes;
     self
   }
 
@@ -323,6 +347,7 @@ impl<W: Write> Printer for JSONPrinter<W> {
     JSONProcessor {
       style: self.style,
       context: self.context,
+      max_context_bytes: self.max_context_bytes,
       include_metadata: self.include_metadata,
     }
   }
@@ -374,6 +399,7 @@ pub struct JSONProcessor {
   style: JsonStyle,
   include_metadata: bool,
   context: (u16, u16),
+  max_context_bytes: usize,
 }
 
 impl JSONProcessor {
@@ -420,27 +446,30 @@ impl PrintProcessor<Buffer> for JSONProcessor {
     rule: &RuleConfig<SgLang>,
   ) -> Result<Buffer> {
     let path = file.name();
-    let jsons = matches
-      .into_iter()
-      .map(|nm| RuleMatchJSON::new(nm, path, rule, self.include_metadata));
+    let max_context_bytes = self.max_context_bytes;
+    let jsons = matches.into_iter().map(|nm| {
+      RuleMatchJSON::new(nm, path, rule, self.include_metadata, max_context_bytes)
+    });
     self.print_docs(jsons)
   }
 
   fn print_matches(&self, matches: Vec<NodeMatch>, path: &Path) -> Result<Buffer> {
     let path = path.to_string_lossy();
     let context = self.context;
+    let max_context_bytes = self.max_context_bytes;
     let jsons = matches
       .into_iter()
-      .map(|nm| MatchJSON::new(nm, &path, context));
+      .map(|nm| MatchJSON::new(nm, &path, context, max_context_bytes));
     self.print_docs(jsons)
   }
 
   fn print_diffs(&self, diffs: Vec<Diff>, path: &Path) -> Result<Buffer> {
     let path = path.to_string_lossy();
     let context = self.context;
+    let max_context_bytes = self.max_context_bytes;
     let jsons = diffs
       .into_iter()
-      .map(|diff| MatchJSON::diff(diff, &path, context));
+      .map(|diff| MatchJSON::diff(diff, &path, context, max_context_bytes));
     self.print_docs(jsons)
   }
   fn print_rule_diffs(
@@ -449,9 +478,10 @@ impl PrintProcessor<Buffer> for JSONProcessor {
     path: &Path,
   ) -> Result<Buffer> {
     let path = path.to_string_lossy();
-    let jsons = diffs
-      .into_iter()
-      .map(|(diff, rule)| RuleMatchJSON::diff(diff, &path, rule, self.include_metadata));
+    let max_context_bytes = self.max_context_bytes;
+    let jsons = diffs.into_iter().map(|(diff, rule)| {
+      RuleMatchJSON::diff(diff, &path, rule, self.include_metadata, max_context_bytes)
+    });
     self.print_docs(jsons)
   }
 }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -199,12 +199,15 @@ pub fn run_with_pattern(arg: RunArg, project: Result<ProjectConfig>) -> Result<E
     return run_pattern_with_printer(arg, printer);
   }
   if let Some(json) = arg.output.json {
-    let printer = JSONPrinter::stdout(json).context(context);
+    let printer = JSONPrinter::stdout(json)
+      .context(context)
+      .max_context_bytes(arg.context.max_context_bytes);
     return run_pattern_with_printer(arg, printer);
   }
   let printer = ColoredPrinter::stdout(arg.output.color)
     .heading(arg.heading)
-    .context(context);
+    .context(context)
+    .max_context_bytes(arg.context.max_context_bytes);
   let interactive = arg.output.needs_interactive();
   if interactive {
     let from_stdin = arg.input.stdin;
@@ -481,6 +484,7 @@ mod test {
         before: 0,
         after: 0,
         context: 0,
+        max_context_bytes: ast_grep_core::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE,
       },
     }
   }

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -98,12 +98,15 @@ pub fn run_with_config(arg: ScanArg, project: Result<ProjectConfig>) -> Result<E
     return run_scan(arg, printer, project);
   }
   if let Some(json) = arg.output.json {
-    let printer = JSONPrinter::stdout(json).include_metadata(arg.include_metadata);
+    let printer = JSONPrinter::stdout(json)
+      .include_metadata(arg.include_metadata)
+      .max_context_bytes(arg.context.max_context_bytes);
     return run_scan(arg, printer, project);
   }
   let printer = ColoredPrinter::stdout(arg.output.color)
     .style(arg.report_style)
-    .context(context);
+    .context(context)
+    .max_context_bytes(arg.context.max_context_bytes);
   let interactive = arg.output.needs_interactive();
   if interactive {
     let from_stdin = arg.input.stdin;
@@ -494,6 +497,7 @@ rule:
         before: 0,
         after: 0,
         context: 0,
+        max_context_bytes: ast_grep_core::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE,
       },
       format: None,
       max_results: None,

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -213,6 +213,20 @@ pub struct ContextArgs {
   /// It conflicts with both the -B/--before and -A/--after flags.
   #[clap(short = 'C', long, default_value = "0", value_name = "NUM")]
   pub context: u16,
+
+  /// Cap, in bytes, on how far ast-grep looks for a line boundary when
+  /// building the context shown around a match, per line of -A/-B/-C context
+  /// requested.
+  ///
+  /// Minified/bundled files can have a single "line" spanning the entire
+  /// file; without a cap, showing context for a match in such a file walks
+  /// (and prints) the whole file for every single match. The default is
+  /// generous for genuine source code, which essentially never has lines
+  /// anywhere close to this length. Raise this if you deliberately want more
+  /// context on a file with unusually long lines; lower it to bound output
+  /// size more aggressively.
+  #[clap(long, default_value_t = ast_grep_core::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE, value_name = "NUM")]
+  pub max_context_bytes: usize,
 }
 
 impl ContextArgs {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -442,7 +442,8 @@ if (a) {
     for [src, matcher, lead, trail] in cases {
       let root = Tsx.ast_grep(src);
       let node = root.root().find(matcher).expect("should match");
-      let display = node.display_context(0, 0);
+      let display =
+        node.display_context(0, 0, crate::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE);
       assert_eq!(display.leading, lead);
       assert_eq!(display.trailing, trail);
     }
@@ -458,7 +459,8 @@ if (a) {
     for [src, matcher, lead, trail] in cases {
       let root = Tsx.ast_grep(src);
       let node = root.root().find(matcher).expect("should match");
-      let display = node.display_context(1, 1);
+      let display =
+        node.display_context(1, 1, crate::tree_sitter::DEFAULT_MAX_CONTEXT_BYTES_PER_LINE);
       assert_eq!(display.leading, lead);
       assert_eq!(display.trailing, trail);
     }

--- a/crates/core/src/tree_sitter/mod.rs
+++ b/crates/core/src/tree_sitter/mod.rs
@@ -387,31 +387,44 @@ pub struct DisplayContext<'r> {
   pub start_line: usize,
 }
 
-/// Per requested context line, hard cap in bytes on how far `display_context`
-/// will walk looking for a line boundary (scaled by `before`/`after` so
-/// legitimate multi-line `-A`/`-B`/`-C` requests on normal code aren't cut
-/// short). Minified/bundled source files routinely have a single "line"
-/// spanning the entire file (no `\n` at all); without this cap, the walk below
-/// degenerates to O(file size) per match, and a file with many matches on such
-/// a line (a very common real-world case for tools that scan
-/// `node_modules`/vendored bundles) produces `lines` context output that is
-/// O(matches × file size) — observed ballooning a single ~2MB minified line
-/// with a few thousand matches into a multi-gigabyte JSON report. Genuine
-/// source lines are essentially never anywhere close to this length, so the
-/// cap is a no-op for the intended use case (short, human-authored lines).
-const MAX_CONTEXT_BYTES_PER_LINE: usize = 1000;
+/// Default per-requested-context-line cap (in bytes) used by callers that
+/// don't need to override it — see `display_context`'s `max_bytes_per_line`
+/// parameter for the full rationale. Exposed so callers (and the CLI's
+/// `--max-context-bytes` flag) can share this default instead of repeating
+/// the magic number.
+pub const DEFAULT_MAX_CONTEXT_BYTES_PER_LINE: usize = 1000;
 
 /// these methods are only for `StrDoc`
 impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
   #[doc(hidden)]
-  pub fn display_context(&self, before: usize, after: usize) -> DisplayContext<'r> {
+  /// `max_bytes_per_line`: per requested context line, hard cap in bytes on
+  /// how far this walks looking for a line boundary (scaled by
+  /// `before`/`after` so legitimate multi-line `-A`/`-B`/`-C` requests on
+  /// normal code aren't cut short). Minified/bundled source files routinely
+  /// have a single "line" spanning the entire file (no `\n` at all); without
+  /// this cap, the walk below degenerates to O(file size) per match, and a
+  /// file with many matches on such a line (a very common real-world case
+  /// for tools that scan `node_modules`/vendored bundles) produces `lines`
+  /// context output that is O(matches × file size) — observed ballooning a
+  /// single ~2MB minified line with a few thousand matches into a
+  /// multi-gigabyte JSON report. Genuine source lines are essentially never
+  /// anywhere close to `DEFAULT_MAX_CONTEXT_BYTES_PER_LINE`, so using the
+  /// default is a no-op for the intended use case (short, human-authored
+  /// lines); pass a larger value if you have an unusual reason to want more
+  /// context on files with very long lines.
+  pub fn display_context(
+    &self,
+    before: usize,
+    after: usize,
+    max_bytes_per_line: usize,
+  ) -> DisplayContext<'r> {
     let source = self.root.doc.get_source().as_str();
     let bytes = source.as_bytes();
     let start = self.inner.start_byte();
     let end = self.inner.end_byte();
     let (mut leading, mut trailing) = (start, end);
     let mut lines_before = before + 1;
-    let leading_limit = start.saturating_sub(MAX_CONTEXT_BYTES_PER_LINE * (before + 1));
+    let leading_limit = start.saturating_sub(max_bytes_per_line * (before + 1));
     while leading > leading_limit {
       if bytes[leading - 1] == b'\n' {
         lines_before -= 1;
@@ -431,7 +444,7 @@ impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
     // tree-sitter will append line ending to source so trailing can be out of bound
     trailing = trailing.min(bytes.len());
     let trailing_limit = end
-      .saturating_add(MAX_CONTEXT_BYTES_PER_LINE * (after + 1))
+      .saturating_add(max_bytes_per_line * (after + 1))
       .min(bytes.len());
     while trailing < trailing_limit {
       if bytes[trailing] == b'\n' {

--- a/crates/core/src/tree_sitter/mod.rs
+++ b/crates/core/src/tree_sitter/mod.rs
@@ -387,6 +387,20 @@ pub struct DisplayContext<'r> {
   pub start_line: usize,
 }
 
+/// Per requested context line, hard cap in bytes on how far `display_context`
+/// will walk looking for a line boundary (scaled by `before`/`after` so
+/// legitimate multi-line `-A`/`-B`/`-C` requests on normal code aren't cut
+/// short). Minified/bundled source files routinely have a single "line"
+/// spanning the entire file (no `\n` at all); without this cap, the walk below
+/// degenerates to O(file size) per match, and a file with many matches on such
+/// a line (a very common real-world case for tools that scan
+/// `node_modules`/vendored bundles) produces `lines` context output that is
+/// O(matches × file size) — observed ballooning a single ~2MB minified line
+/// with a few thousand matches into a multi-gigabyte JSON report. Genuine
+/// source lines are essentially never anywhere close to this length, so the
+/// cap is a no-op for the intended use case (short, human-authored lines).
+const MAX_CONTEXT_BYTES_PER_LINE: usize = 1000;
+
 /// these methods are only for `StrDoc`
 impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
   #[doc(hidden)]
@@ -397,7 +411,8 @@ impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
     let end = self.inner.end_byte();
     let (mut leading, mut trailing) = (start, end);
     let mut lines_before = before + 1;
-    while leading > 0 {
+    let leading_limit = start.saturating_sub(MAX_CONTEXT_BYTES_PER_LINE * (before + 1));
+    while leading > leading_limit {
       if bytes[leading - 1] == b'\n' {
         lines_before -= 1;
         if lines_before == 0 {
@@ -406,10 +421,19 @@ impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
       }
       leading -= 1;
     }
+    // the cap above can land mid-codepoint; nudge forward to the next char
+    // boundary so the slice below never panics (this only ever shortens the
+    // leading context, never lengthens it past the cap).
+    while leading < start && !source.is_char_boundary(leading) {
+      leading += 1;
+    }
     let mut lines_after = after + 1;
     // tree-sitter will append line ending to source so trailing can be out of bound
     trailing = trailing.min(bytes.len());
-    while trailing < bytes.len() {
+    let trailing_limit = end
+      .saturating_add(MAX_CONTEXT_BYTES_PER_LINE * (after + 1))
+      .min(bytes.len());
+    while trailing < trailing_limit {
       if bytes[trailing] == b'\n' {
         lines_after -= 1;
         if lines_after == 0 {
@@ -417,6 +441,10 @@ impl<'r, L: LanguageExt> crate::Node<'r, StrDoc<L>> {
         }
       }
       trailing += 1;
+    }
+    // same char-boundary nudge as leading, but backward so we still respect the cap.
+    while trailing > end && !source.is_char_boundary(trailing) {
+      trailing -= 1;
     }
     // lines_before means we matched all context, offset is `before` itself
     let offset = if lines_before == 0 {


### PR DESCRIPTION
## Summary

Minified/bundled source files routinely have a single "line" spanning the entire file (no `\n` at all). `display_context` (used to build the `lines` field shown around every match, both in `--json` output and the terminal printer) walks byte-by-byte from a match looking for line boundaries with no upper bound on how far it walks — so on such files this walk degenerates to O(file size) *per match*, and a file with many matches on that one line (a very common real-world case for tools that scan `node_modules`/vendored bundles) produces `lines` context output that is O(matches × file size).

### Repro

A synthetic 213KB single-line file with 5000 `instanceof` matches produced a **1.07GB** `--json=stream` report — each of the 5000 match objects embeds the *entire* 213KB line verbatim in its `lines` field (a >5000x amplification from input to output size).

## Fix (first commit)

Cap how far the leading/trailing walk goes in `display_context`, scaled by the requested `before`/`after` line counts (1000 bytes per requested line by default) so legitimate multi-line `-A`/`-B`/`-C` context on normal code isn't cut short. Added a char-boundary nudge after the capped walk, since an arbitrary byte-distance cutoff (unlike the existing newline-based stopping conditions) can land mid-codepoint.

With the fix, the same synthetic repro produces **14.4MB** (74x smaller) with identical match count and content; a normal short-line file's `lines` output is byte-for-byte unchanged (well under the cap).

## New flag (second commit)

Added `--max-context-bytes NUM` (flows through `ContextArgs`, both output paths) so the cap is user-configurable instead of a fixed constant — default matches the previous hardcoded value. Verified it scales monotonically: 50 → 4.87MB, default (1000) → 14.37MB, 5000 → 53.79MB on the same synthetic repro.

## Testing

- `cargo test -p ast-grep-core` (154 tests) and `cargo test -p ast-grep` (full CLI suite) — all pass, including the existing `test_display_context`/`test_multi_line_context`.
- Ran our own project's full custom ast-grep rule set (46 rules) against the **entire `node_modules`** of a real monorepo (1126 packages, ~1.2GB, no filtering of minified/bundled files needed) as a stress test: completed with **0 crashes**, **161,239 matches** (identical count to a pre-fix run against the same tree, confirming no matches lost), **905MB** output — vs. the pre-fix binary's ~16GB for the identical scan.
- Spot-checked the small number of remaining large `lines` fields in that 905MB output: all had single-digit-or-zero `leading`/`trailing` char counts, with the size coming entirely from a legitimately large *matched* span (e.g. `no-classes` matching a genuinely large class body) — confirming the cap holds and isn't defeated by some other code path.

## Disclosure

This fix (root cause investigation, patch, and verification) was developed with Claude's (Anthropic) assistance — reviewed and tested locally (synthetic repro measurements, full test suite runs, full node_modules stress test) before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--max-context-bytes` option to limit the amount of surrounding text shown for matches.
  * Added support for configuring this limit in colored and JSON output.
  * Applied the setting consistently across search, scan, match, and diff results.

* **Bug Fixes**
  * Improved context rendering for long lines while preventing invalid text slicing and related crashes.
  * Preserved valid UTF-8 boundaries when limiting displayed context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->