### PR TITLE
Respect --no-ignore for configured rule directories

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,5 +1,5 @@
 use crate::lang::{CustomLang, LanguageGlobs, SerializableInjection, SgLang};
-use crate::utils::{ErrorContext as EC, RuleOverwrite, RuleTrace};
+use crate::utils::{ErrorContext as EC, NoIgnore, RuleOverwrite, RuleTrace};
 
 use anyhow::{Context, Result};
 use ast_grep_config::{
@@ -88,8 +88,16 @@ impl ProjectConfig {
     &self,
     rule_overwrite: RuleOverwrite,
   ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
-    let global_rules = find_util_rules(self)?;
-    read_directory_yaml(self, global_rules, rule_overwrite)
+    self.find_rules_with_no_ignore(rule_overwrite, &NoIgnore::default())
+  }
+
+  pub fn find_rules_with_no_ignore(
+    &self,
+    rule_overwrite: RuleOverwrite,
+    no_ignore: &NoIgnore,
+  ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
+    let global_rules = find_util_rules(self, no_ignore)?;
+    read_directory_yaml(self, global_rules, rule_overwrite, no_ignore)
   }
 
   /// returns a Result of Result.
@@ -137,23 +145,27 @@ fn register_custom_language(project_dir: &Path, sg_config: AstGrepConfig) -> Res
   Ok(())
 }
 
-fn build_util_walker(base_dir: &Path, util_dirs: &Option<Vec<PathBuf>>) -> Option<WalkBuilder> {
+fn build_util_walker(
+  base_dir: &Path,
+  util_dirs: &Option<Vec<PathBuf>>,
+  no_ignore: &NoIgnore,
+) -> Option<WalkBuilder> {
   let mut util_dirs = util_dirs.as_ref()?.iter();
   let first = util_dirs.next()?;
-  let mut walker = WalkBuilder::new(base_dir.join(first));
+  let mut walker = no_ignore.walk(&[base_dir.join(first)]);
   for dir in util_dirs {
     walker.add(base_dir.join(dir));
   }
   Some(walker)
 }
 
-fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
+fn find_util_rules(config: &ProjectConfig, no_ignore: &NoIgnore) -> Result<GlobalRules> {
   let ProjectConfig {
     project_dir,
     util_dirs,
     ..
   } = config;
-  let Some(mut walker) = build_util_walker(project_dir, util_dirs) else {
+  let Some(mut walker) = build_util_walker(project_dir, util_dirs, no_ignore) else {
     return Ok(GlobalRules::default());
   };
   let mut utils = vec![];
@@ -182,6 +194,7 @@ fn read_directory_yaml(
   config: &ProjectConfig,
   global_rules: GlobalRules,
   rule_overwrite: RuleOverwrite,
+  no_ignore: &NoIgnore,
 ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
   let mut configs = vec![];
   let ProjectConfig {
@@ -191,7 +204,8 @@ fn read_directory_yaml(
   } = config;
   for dir in rule_dirs {
     let dir_path = project_dir.join(dir);
-    let walker = WalkBuilder::new(&dir_path)
+    let walker = no_ignore
+      .walk(&[dir_path.clone()])
       .types(config_file_type())
       .build();
     for dir in walker {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -65,6 +65,7 @@ pub struct ProjectConfig {
   pub test_configs: Option<Vec<TestConfig>>,
   /// util rules directories
   pub util_dirs: Option<Vec<PathBuf>>,
+  no_ignore: NoIgnore,
 }
 
 impl ProjectConfig {
@@ -88,16 +89,13 @@ impl ProjectConfig {
     &self,
     rule_overwrite: RuleOverwrite,
   ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
-    self.find_rules_with_no_ignore(rule_overwrite, &NoIgnore::default())
+    let global_rules = find_util_rules(self)?;
+    read_directory_yaml(self, global_rules, rule_overwrite)
   }
 
-  pub fn find_rules_with_no_ignore(
-    &self,
-    rule_overwrite: RuleOverwrite,
-    no_ignore: &NoIgnore,
-  ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
-    let global_rules = find_util_rules(self, no_ignore)?;
-    read_directory_yaml(self, global_rules, rule_overwrite, no_ignore)
+  pub fn with_no_ignore(mut self, no_ignore: NoIgnore) -> Self {
+    self.no_ignore = no_ignore;
+    self
   }
 
   /// returns a Result of Result.
@@ -115,6 +113,7 @@ impl ProjectConfig {
       outline_rules,
       test_configs: sg_config.test_configs.take(),
       util_dirs: sg_config.util_dirs.take(),
+      no_ignore: NoIgnore::default(),
     };
     // sg_config will not use rule dirs and test configs anymore
     register_custom_language(&config.project_dir, sg_config)?;
@@ -159,10 +158,11 @@ fn build_util_walker(
   Some(walker)
 }
 
-fn find_util_rules(config: &ProjectConfig, no_ignore: &NoIgnore) -> Result<GlobalRules> {
+fn find_util_rules(config: &ProjectConfig) -> Result<GlobalRules> {
   let ProjectConfig {
     project_dir,
     util_dirs,
+    no_ignore,
     ..
   } = config;
   let Some(mut walker) = build_util_walker(project_dir, util_dirs, no_ignore) else {
@@ -194,18 +194,18 @@ fn read_directory_yaml(
   config: &ProjectConfig,
   global_rules: GlobalRules,
   rule_overwrite: RuleOverwrite,
-  no_ignore: &NoIgnore,
 ) -> Result<(RuleCollection<SgLang>, RuleTrace)> {
   let mut configs = vec![];
   let ProjectConfig {
     project_dir,
     rule_dirs,
+    no_ignore,
     ..
   } = config;
   for dir in rule_dirs {
     let dir_path = project_dir.join(dir);
     let walker = no_ignore
-      .walk(&[dir_path.clone()])
+      .walk(std::slice::from_ref(&dir_path))
       .types(config_file_type())
       .build();
     for dir in walker {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -309,6 +309,7 @@ mod test_cli {
     ok("test -U");
     ok("test --update-all");
     ok("test --follow");
+    ok("test --no-ignore hidden --no-ignore=vcs");
     error("test --update-all --skip-snapshot-tests");
     ok("test --color always");
     ok("test --color never");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -158,10 +158,9 @@ impl ScanWithConfig {
       with_rule_stats(rules)?
     } else {
       // NOTE: only query project here since -r does not need project
-      let project_config = project?;
+      let project_config = project?.with_no_ignore(NoIgnore::disregard(&arg.input.no_ignore));
       proj_dir = project_config.project_dir.clone();
-      project_config
-        .find_rules_with_no_ignore(overwrite, &NoIgnore::disregard(&arg.input.no_ignore))?
+      project_config.find_rules(overwrite)?
     };
     let trace = arg.output.inspect.scan_trace(rule_trace);
     trace.print_rules(&configs)?;

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -17,11 +17,11 @@ use crate::print::{
   CloudPrinter, ColoredPrinter, Diff, FileNamePrinter, InteractivePrinter, JSONPrinter, Platform,
   PrintProcessor, Printer, ReportStyle, SimpleFile,
 };
-use crate::utils::RuleOverwrite;
 use crate::utils::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs, filter_file_rule};
 use crate::utils::{ErrorContext as EC, MaxItemCounter};
 use crate::utils::{FileTrace, ScanTrace};
 use crate::utils::{Items, PathWorker, StdInWorker, Worker};
+use crate::utils::{NoIgnore, RuleOverwrite};
 
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -160,7 +160,8 @@ impl ScanWithConfig {
       // NOTE: only query project here since -r does not need project
       let project_config = project?;
       proj_dir = project_config.project_dir.clone();
-      project_config.find_rules(overwrite)?
+      project_config
+        .find_rules_with_no_ignore(overwrite, &NoIgnore::disregard(&arg.input.no_ignore))?
     };
     let trace = arg.output.inspect.scan_trace(rule_trace);
     trace.print_rules(&configs)?;
@@ -433,6 +434,7 @@ fn match_rule_on_file<T>(
 mod test {
   use super::*;
   use crate::print::ColorArg;
+  use crate::utils::IgnoreFile;
   use std::fs::File;
   use std::io::Write;
   use tempfile::TempDir;
@@ -514,6 +516,28 @@ rule:
     let project_config = ProjectConfig::setup(Some(dir.path().join("sgconfig.yml"))).unwrap();
     let arg = default_scan_arg();
     assert!(run_with_config(arg, project_config).is_ok());
+  }
+
+  #[test]
+  fn test_no_ignore_applies_to_rule_dirs() {
+    let dir = create_test_files([("sgconfig.yml", "ruleDirs: [.venv/rules]")]);
+    let virtualenv = dir.path().join(".venv");
+    let rules = virtualenv.join("rules");
+    std::fs::create_dir_all(&rules).unwrap();
+    std::fs::write(virtualenv.join(".gitignore"), "*\n").unwrap();
+    std::fs::write(rules.join("test.yml"), RULE).unwrap();
+
+    let project_config = ProjectConfig::setup(Some(dir.path().join("sgconfig.yml"))).unwrap();
+    let arg = ScanArg {
+      input: InputArgs {
+        no_ignore: vec![IgnoreFile::Hidden, IgnoreFile::Vcs],
+        ..default_scan_arg().input
+      },
+      ..default_scan_arg()
+    };
+
+    let scan = ScanWithConfig::try_new(arg, project_config).unwrap();
+    assert_eq!(scan.configs.total_rule_count(), 1);
   }
 
   #[test]

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -247,7 +247,7 @@ pub enum IgnoreFile {
   Vcs,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct NoIgnore {
   disregard_hidden: bool,
   disregard_parent: bool,

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -6,7 +6,7 @@ mod print_diff;
 mod rule_overwrite;
 mod worker;
 
-pub use args::{ContextArgs, InputArgs, OutputArgs, OverwriteArgs};
+pub use args::{ContextArgs, IgnoreFile, InputArgs, NoIgnore, OutputArgs, OverwriteArgs};
 pub use debug_query::DebugFormat;
 pub use error_context::{ErrorContext, exit_with_error};
 pub use inspect::{FileTrace, Granularity, RuleTrace, RunTrace, ScanTrace};

--- a/crates/cli/src/verify.rs
+++ b/crates/cli/src/verify.rs
@@ -7,7 +7,7 @@ mod test_case;
 use crate::config::ProjectConfig;
 use crate::lang::SgLang;
 use crate::print::ColorArg;
-use crate::utils::{ErrorContext, RuleOverwrite};
+use crate::utils::{ErrorContext, IgnoreFile, NoIgnore, RuleOverwrite};
 use crate::verify::reporter::TestReportStyle;
 use anyhow::{Result, anyhow};
 use ast_grep_config::RuleCollection;
@@ -61,6 +61,7 @@ fn run_test_rule_impl<R: Reporter + Send>(
   reporter: R,
   project: ProjectConfig,
 ) -> Result<ExitCode> {
+  let project = project.with_no_ignore(NoIgnore::disregard(&arg.no_ignore));
   let filter = arg.filter.as_ref();
   let overwrite = RuleOverwrite::new_for_verify(filter, arg.include_off);
   let collections = &project.find_rules(overwrite)?.0;
@@ -200,6 +201,11 @@ pub struct TestArg {
   /// Follow symbolic links while searching test YAML files.
   #[clap(long)]
   follow: bool,
+  /// Do not respect hidden file system or ignore files when discovering rules.
+  ///
+  /// You can suppress multiple ignore files by passing `no-ignore` multiple times.
+  #[clap(long, action = clap::ArgAction::Append, value_name = "FILE_TYPE")]
+  no_ignore: Vec<IgnoreFile>,
   /// Controls output color.
   ///
   /// This flag controls when to use colors. The default setting is 'auto', which
@@ -348,9 +354,50 @@ rule:
       filter: None,
       include_off: false,
       follow: false,
+      no_ignore: vec![],
       color: ColorArg::Never,
     };
     assert!(run_test_rule(arg, Err(anyhow!("error"))).is_err());
+  }
+
+  #[test]
+  fn test_no_ignore_applies_to_verified_rule_dirs() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let virtualenv = dir.path().join(".venv");
+    let rules = virtualenv.join("rules");
+    let tests = dir.path().join("tests");
+    std::fs::create_dir_all(&rules).unwrap();
+    std::fs::create_dir_all(&tests).unwrap();
+    std::fs::write(virtualenv.join(".gitignore"), "*\n").unwrap();
+    std::fs::write(
+      dir.path().join("sgconfig.yml"),
+      "ruleDirs: [.venv/rules]\ntestConfigs:\n- testDir: tests\n",
+    )
+    .unwrap();
+    std::fs::write(rules.join("test.yml"), get_rule_text("kind: number")).unwrap();
+    std::fs::write(
+      tests.join("test.yml"),
+      format!("id: {TEST_RULE}\nvalid: ['hello']\ninvalid: ['123']\n"),
+    )
+    .unwrap();
+
+    let project = ProjectConfig::setup(Some(dir.path().join("sgconfig.yml")))
+      .unwrap()
+      .unwrap();
+    let arg = TestArg {
+      interactive: false,
+      skip_snapshot_tests: true,
+      snapshot_dir: None,
+      test_dir: None,
+      update_all: false,
+      filter: None,
+      include_off: false,
+      follow: false,
+      no_ignore: vec![IgnoreFile::Hidden, IgnoreFile::Vcs],
+      color: ColorArg::Never,
+    };
+
+    assert_eq!(run_test_rule(arg, Ok(project)).unwrap(), ExitCode::SUCCESS);
   }
   const TRANSFORM_TEXT: &str = "
 transform:


### PR DESCRIPTION
Fixes #2803.

Configured rule directories now use the same ignore settings as source traversal, including --no-ignore hidden and --no-ignore vcs. Utility-rule discovery follows the same behavior.

Adds a regression test for rules installed under a Python virtual environment whose internal .gitignore would otherwise hide every configured rule.

Tests: cargo test -p ast-grep --lib test_no_ignore_applies_to_rule_dirs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule discovery now honors the scan’s “no ignore” setting when traversing configured rule directories.
  * The test command now supports `--no-ignore` to include hidden/VCS-related rule directories during discovery.
* **Bug Fixes**
  * Scans and verified test rule discovery no longer miss configured rules when ignore restrictions are disabled.
* **Tests**
  * Added new cases covering rule discovery with ignore handling disabled for both scan and verify flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->