### PR TITLE
fix: specify correct MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 documentation = "https://ast-grep.github.io/guide/introduction.html"
 homepage = "https://ast-grep.github.io/"
 repository = "https://github.com/ast-grep/ast-grep"
-rust-version = "1.85"
+rust-version = "1.88.0"
 readme = "README.md"
 
 [workspace.dependencies]


### PR DESCRIPTION
See also: https://github.com/ast-grep/ast-grep/issues/2836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust toolchain version to 1.88.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->