### PR TITLE
Avoid Windows Defender false positive for sg.exe

### DIFF
--- a/crates/cli/src/bin/alias.rs
+++ b/crates/cli/src/bin/alias.rs
@@ -1,8 +1,14 @@
-// The alias command `sg` redirects everything to ast-grep
-// we need this to avoid "multiple build target" warning
-// See https://github.com/rust-lang/cargo/issues/5930
+// Microsoft Defender has quarantined the small Windows forwarding executable as
+// Trojan:Win64/Lazy!MTB, breaking pip and downstream installs. Build `sg.exe` as
+// the complete CLI to avoid that false positive. See #2799 and #2841.
+#[cfg(windows)]
+fn main() -> anyhow::Result<std::process::ExitCode> {
+  ast_grep::execute_main()
+}
+
+// Keep `sg` as a lightweight launcher on Unix.
+#[cfg(not(windows))]
 fn main() -> std::io::Result<()> {
-  // redirect to ast-grep
   use std::env::args;
   use std::process::{Command, Stdio};
   let mut child = Command::new("ast-grep")


### PR DESCRIPTION
Microsoft Defender has quarantined the small Windows forwarding sg.exe as Trojan:Win64/Lazy!MTB, breaking pip and downstream installs. Build sg.exe as the complete CLI on Windows while retaining the lightweight forwarding launcher on Unix. Fixes #2841. References #2799. Checks: cargo fmt, cargo check, and clippy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows startup for the command-line alias by adding a Windows-specific entry point that returns the correct exit status.
  * Windows now delegates alias execution and exits cleanly with an appropriate process result.
  * Non-Windows behavior is preserved as before, continuing to launch the alias through the existing launcher flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->