### PR TITLE
perf(outline): add per-rule stopBy traversal bounds

### DIFF
--- a/crates/outline/src/combined_extractor.rs
+++ b/crates/outline/src/combined_extractor.rs
@@ -22,7 +22,9 @@ use ast_grep_core::{
 };
 use std::collections::HashMap;
 
-use crate::extractor::{ItemExtractor, MemberExtractor, OutlineRuleError, SerializableOutlineRule};
+use crate::extractor::{
+  ItemExtractor, MemberExtractor, OutlineRuleError, OutlineStopBy, SerializableOutlineRule,
+};
 use crate::model::{OutlineItem, OutlineMember};
 use crate::options::OutlineExtractorOptions;
 
@@ -35,6 +37,8 @@ pub struct CombinedExtractors<L: Language> {
   item_extractors: Vec<ItemExtractor<L>>,
   /// Dense node-kind index into `item_extractors`; shared across the whole file.
   item_kind_index: Vec<Vec<usize>>,
+  /// Whether every retained item extractor stops at direct children.
+  all_items_immediate: bool,
   /// Member extractors parsed once and referenced by parent-scoped groups below.
   member_extractors: Vec<MemberExtractor<L>>,
   /// Parent item extractor id to member extractors that may run inside it.
@@ -54,6 +58,24 @@ struct ScopedMemberExtractors<'a, L: Language> {
 struct MemberExtractorIndex {
   /// Sparse node-kind index into `member_extractors` for scoped member traversal.
   kind_mapping: HashMap<u16, Vec<usize>>,
+  /// Whether this parent scope contains an extractor that traverses to the end.
+  has_end: bool,
+}
+
+#[derive(Default)]
+struct TraversalVisitCounter {
+  #[cfg(test)]
+  count: usize,
+}
+
+impl TraversalVisitCounter {
+  #[inline]
+  fn record(&mut self) {
+    #[cfg(test)]
+    {
+      self.count += 1;
+    }
+  }
 }
 
 impl<L: Language> CombinedExtractors<L> {
@@ -105,10 +127,14 @@ impl<L: Language> CombinedExtractors<L> {
     options: OutlineExtractorOptions,
   ) -> Self {
     let item_kind_index = item_kind_index(&item_extractors);
+    let all_items_immediate = item_extractors
+      .iter()
+      .all(|extractor| extractor.common.stop_by == OutlineStopBy::Immediate);
     let member_index_by_parent = member_index_by_parent(&member_extractors);
     Self {
       item_extractors,
       item_kind_index,
+      all_items_immediate,
       member_extractors,
       member_index_by_parent,
       options,
@@ -125,7 +151,11 @@ impl<L: Language> CombinedExtractors<L> {
       })
   }
 
-  fn item_extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &ItemExtractor<L>> {
+  fn item_extractors_for_kind(
+    &self,
+    kind: u16,
+    allow_immediate: bool,
+  ) -> impl Iterator<Item = &ItemExtractor<L>> {
     self
       .item_kind_index
       .get(kind as usize)
@@ -133,6 +163,7 @@ impl<L: Language> CombinedExtractors<L> {
       .unwrap_or(&[])
       .iter()
       .map(|&idx| &self.item_extractors[idx])
+      .filter(move |extractor| allow_immediate || extractor.common.stop_by == OutlineStopBy::End)
   }
 
   pub fn extract<'a, 'tree>(
@@ -142,20 +173,44 @@ impl<L: Language> CombinedExtractors<L> {
   where
     L: LanguageExt,
   {
+    self.item_iter(root)
+  }
+
+  fn item_iter<'a, 'tree>(&'a self, root: Node<'tree, StrDoc<L>>) -> OutlineItemIter<'a, 'tree, L>
+  where
+    L: LanguageExt,
+  {
     OutlineItemIter {
       combined: self,
       traversal: Prune::new(&root),
+      at_source: true,
+      descendant_subtree: None,
+      visit_counter: TraversalVisitCounter::default(),
     }
+  }
+
+  #[cfg(test)]
+  fn extract_with_visit_count<'tree>(
+    &self,
+    root: Node<'tree, StrDoc<L>>,
+  ) -> (Vec<OutlineItem<'tree>>, usize)
+  where
+    L: LanguageExt,
+  {
+    let mut iter = self.item_iter(root);
+    let items = iter.by_ref().collect();
+    (items, iter.visit_counter.count)
   }
 
   fn match_item<'tree>(
     &self,
     node: &Node<'tree, StrDoc<L>>,
+    allow_immediate: bool,
   ) -> Option<(&ItemExtractor<L>, NodeMatch<'tree, StrDoc<L>>)>
   where
     L: LanguageExt,
   {
-    for extractor in self.item_extractors_for_kind(node.kind_id()) {
+    for extractor in self.item_extractors_for_kind(node.kind_id(), allow_immediate) {
       if let Some(matched) = extractor.match_node(node) {
         return Some((extractor, matched));
       }
@@ -165,7 +220,11 @@ impl<L: Language> CombinedExtractors<L> {
 }
 
 impl<'a, L: Language> ScopedMemberExtractors<'a, L> {
-  fn extractors_for_kind(&self, kind: u16) -> impl Iterator<Item = &MemberExtractor<L>> {
+  fn extractors_for_kind(
+    &self,
+    kind: u16,
+    allow_immediate: bool,
+  ) -> impl Iterator<Item = &MemberExtractor<L>> {
     self
       .index
       .kind_mapping
@@ -174,24 +233,36 @@ impl<'a, L: Language> ScopedMemberExtractors<'a, L> {
       .unwrap_or(&[])
       .iter()
       .map(|&idx| &self.extractors[idx])
+      .filter(move |extractor| allow_immediate || extractor.common.stop_by == OutlineStopBy::End)
   }
 
-  fn extract_member<'tree>(&self, node: &Node<'tree, StrDoc<L>>) -> Option<OutlineMember<'tree>>
+  fn extract_member<'tree>(
+    &self,
+    node: &Node<'tree, StrDoc<L>>,
+    allow_immediate: bool,
+  ) -> Option<OutlineMember<'tree>>
   where
     L: LanguageExt,
   {
-    for extractor in self.extractors_for_kind(node.kind_id()) {
+    for extractor in self.extractors_for_kind(node.kind_id(), allow_immediate) {
       if let Some(matched) = extractor.match_node(node) {
         return Some(extractor.extract(&matched));
       }
     }
     None
   }
+
+  fn all_immediate(&self) -> bool {
+    !self.index.has_end
+  }
 }
 
 struct OutlineItemIter<'a, 'tree, L: LanguageExt> {
   combined: &'a CombinedExtractors<L>,
   traversal: Prune<'tree, L>,
+  at_source: bool,
+  descendant_subtree: Option<PruneSubtree<'tree>>,
+  visit_counter: TraversalVisitCounter,
 }
 
 impl<'a, 'tree, L: LanguageExt> Iterator for OutlineItemIter<'a, 'tree, L> {
@@ -209,15 +280,43 @@ impl<'a, 'tree, L: LanguageExt> Iterator for OutlineItemIter<'a, 'tree, L> {
 
 impl<'a, 'tree, L: LanguageExt> OutlineItemIter<'a, 'tree, L> {
   fn visit_current_node(&mut self, node: Node<'tree, StrDoc<L>>) -> Option<OutlineItem<'tree>> {
+    if self
+      .descendant_subtree
+      .is_some_and(|subtree| self.traversal.has_left_subtree(subtree))
+    {
+      self.descendant_subtree = None;
+    }
+    self.visit_counter.record();
+    let is_direct_child = !self.at_source && self.descendant_subtree.is_none();
     let combined = self.combined;
     let item_subtree = self.traversal.current_subtree();
-    let Some((extractor, node_match)) = combined.match_item(&node) else {
-      self.traversal.descend();
+    let Some((extractor, node_match)) = combined.match_item(&node, is_direct_child) else {
+      self.advance_after_no_match(is_direct_child, item_subtree);
       return None;
     };
     let members = self.collect_members_for_item(&extractor.common.rule.id, item_subtree);
     let item = extractor.extract(&node_match, members);
     combined.options.keep_item(&item).then_some(item)
+  }
+
+  fn advance_after_no_match(
+    &mut self,
+    is_direct_child: bool,
+    current_subtree: PruneSubtree<'tree>,
+  ) {
+    if self.at_source {
+      self.at_source = false;
+      self.traversal.descend();
+    } else if is_direct_child {
+      if self.combined.all_items_immediate {
+        self.traversal.skip_subtree();
+      } else {
+        self.traversal.descend();
+        self.descendant_subtree = Some(current_subtree);
+      }
+    } else {
+      self.traversal.descend();
+    }
   }
 
   fn collect_members_for_item(
@@ -235,6 +334,7 @@ impl<'a, 'tree, L: LanguageExt> OutlineItemIter<'a, 'tree, L> {
       member_extractors,
       &self.combined.options,
       item_subtree,
+      &mut self.visit_counter,
     )
   }
 }
@@ -279,17 +379,30 @@ fn collect_scoped_members<'a, 'tree, L: LanguageExt>(
   member_extractors: ScopedMemberExtractors<'a, L>,
   options: &OutlineExtractorOptions,
   item_subtree: PruneSubtree<'tree>,
+  visit_counter: &mut TraversalVisitCounter,
 ) -> Vec<OutlineMember<'tree>> {
   let mut members = vec![];
+  let mut descendant_subtree = None;
   while let Some(node) = traversal.current_node() {
     if traversal.has_left_subtree(item_subtree) {
       break;
     }
-    if let Some(member) = member_extractors.extract_member(&node) {
+    if descendant_subtree.is_some_and(|subtree| traversal.has_left_subtree(subtree)) {
+      descendant_subtree = None;
+    }
+    visit_counter.record();
+    let is_direct_child = descendant_subtree.is_none();
+    if let Some(member) = member_extractors.extract_member(&node, is_direct_child) {
       if options.keep_member(&member) {
         members.push(member);
       }
       traversal.skip_subtree();
+    } else if is_direct_child && member_extractors.all_immediate() {
+      traversal.skip_subtree();
+    } else if is_direct_child {
+      let current_subtree = traversal.current_subtree();
+      traversal.descend();
+      descendant_subtree = Some(current_subtree);
     } else {
       traversal.descend();
     }
@@ -327,6 +440,7 @@ fn member_index_by_parent<L: Language>(
   for (idx, extractor) in member_extractors.iter().enumerate() {
     for parent_id in &extractor.parent_rule_ids {
       let index = mapping.entry(parent_id.clone()).or_default();
+      index.has_end |= extractor.common.stop_by == OutlineStopBy::End;
       let kinds = extractor
         .common
         .rule
@@ -348,6 +462,147 @@ mod tests {
   use crate::options::{OutlineEntryDetail, OutlineExtractorOptions, OutlineFlagFilter};
   use ast_grep_core::tree_sitter::LanguageExt;
   use ast_grep_language::SupportLang;
+
+  #[test]
+  fn immediate_item_scope_prunes_unmatched_direct_child_subtrees() {
+    let source = r#"if (ready) { console.log(ready); }
+function direct() {}"#;
+    let immediate_rules = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: immediate
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let end_rules = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: end
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let immediate = CombinedExtractors::try_from(immediate_rules, &Default::default())
+      .expect("extractors should parse");
+    let end = CombinedExtractors::try_from(end_rules, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(source);
+
+    let (immediate_items, immediate_visits) = immediate.extract_with_visit_count(grep.root());
+    let (end_items, end_visits) = end.extract_with_visit_count(grep.root());
+    let immediate_names = immediate_items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+    let end_names = end_items
+      .iter()
+      .map(|item| item.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(immediate_names, end_names);
+    assert_eq!(immediate_names, vec!["direct"]);
+    assert_eq!(immediate_visits, 3);
+    assert!(end_visits > immediate_visits);
+  }
+
+  #[test]
+  fn immediate_member_scope_prunes_unmatched_direct_child_subtrees() {
+    let source = r#"
+class Box {
+  direct() {}
+  field = { nested: { value: 1 } };
+}
+"#;
+    let immediate_rules = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class-body
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_body
+name: body
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class-body]
+symbolType: method
+stopBy: immediate
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let end_rules = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class-body
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_body
+name: body
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class-body]
+symbolType: method
+stopBy: end
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+"#,
+    )
+    .expect("extractors should deserialize");
+    let immediate = CombinedExtractors::try_from(immediate_rules, &Default::default())
+      .expect("extractors should parse");
+    let end = CombinedExtractors::try_from(end_rules, &Default::default())
+      .expect("extractors should parse");
+    let grep = SupportLang::TypeScript.ast_grep(source);
+
+    let (immediate_items, immediate_visits) = immediate.extract_with_visit_count(grep.root());
+    let (end_items, end_visits) = end.extract_with_visit_count(grep.root());
+    let immediate_members = immediate_items[0]
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>();
+    let end_members = end_items[0]
+      .members
+      .iter()
+      .map(|member| member.entry.name.as_ref())
+      .collect::<Vec<_>>();
+
+    assert_eq!(immediate_members, end_members);
+    assert_eq!(immediate_members, vec!["direct"]);
+    assert!(end_visits > immediate_visits);
+  }
 
   #[test]
   fn combines_extractors_by_item_kind_and_parent_id() {
@@ -386,14 +641,14 @@ name: other
       .expect("extractors should parse");
     let function_kind = SupportLang::TypeScript.kind_to_id("function_declaration");
     let item_extractors = combined
-      .item_extractors_for_kind(function_kind)
+      .item_extractors_for_kind(function_kind, true)
       .collect::<Vec<_>>();
     let member_extractors = combined
       .member_scope_for("ts-function")
       .expect("member extractors should exist");
     let identifier_kind = SupportLang::TypeScript.kind_to_id("identifier");
     let identifier_members = member_extractors
-      .extractors_for_kind(identifier_kind)
+      .extractors_for_kind(identifier_kind, true)
       .collect::<Vec<_>>();
 
     assert!(combined.member_scope_for("missing").is_none());
@@ -401,6 +656,95 @@ name: other
     assert_eq!(item_extractors[0].common.rule.id, "ts-function");
     assert_eq!(identifier_members.len(), 1);
     assert_eq!(identifier_members[0].common.rule.id, "ts-member");
+  }
+
+  #[test]
+  fn stop_by_partitions_use_only_rules_retained_by_options() {
+    let item_extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-import
+language: TypeScript
+role: item
+symbolType: module
+stopBy: immediate
+rule:
+  kind: import_statement
+name: import
+isImport: true
+---
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: end
+rule:
+  kind: function_declaration
+name: function
+isImport: false
+"#,
+    )
+    .expect("extractors should deserialize");
+    let item_options = OutlineExtractorOptions {
+      imports: OutlineFlagFilter::Yes,
+      ..Default::default()
+    };
+    let combined =
+      CombinedExtractors::try_from_rules(item_extractors, item_options, &Default::default())
+        .expect("extractors should parse");
+
+    assert_eq!(combined.item_extractors.len(), 1);
+    assert!(combined.all_items_immediate);
+
+    let member_extractors = parse_outline_rules::<SupportLang>(
+      r#"
+id: ts-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_declaration
+name: class
+---
+id: ts-public-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+stopBy: immediate
+rule:
+  kind: method_definition
+name: method
+isPublic: true
+---
+id: ts-private-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class]
+symbolType: method
+stopBy: end
+rule:
+  kind: method_definition
+name: method
+isPublic: false
+"#,
+    )
+    .expect("extractors should deserialize");
+    let member_options = OutlineExtractorOptions {
+      members: Some(crate::options::OutlineMemberOptions {
+        public: OutlineFlagFilter::Yes,
+        ..Default::default()
+      }),
+      ..Default::default()
+    };
+    let combined =
+      CombinedExtractors::try_from_rules(member_extractors, member_options, &Default::default())
+        .expect("extractors should parse");
+    let scope = combined
+      .member_scope_for("ts-class")
+      .expect("member scope should exist");
+
+    assert_eq!(combined.member_extractors.len(), 1);
+    assert!(scope.all_immediate());
   }
 
   #[test]

--- a/crates/outline/src/default_rules/typescript.yml
+++ b/crates/outline/src/default_rules/typescript.yml
@@ -2,6 +2,7 @@ id: ts-import
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: import_statement
   has:
@@ -15,6 +16,7 @@ id: ts-export-from
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -28,6 +30,7 @@ id: ts-export-list
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   pattern: 'export { $$$SPECIFIERS };'
 name: exports
@@ -38,6 +41,7 @@ id: ts-export-namespace
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -86,6 +90,7 @@ id: ts-export-ambient-module
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -107,6 +112,7 @@ id: ts-ambient-module
 language: TypeScript
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: ambient_declaration
   has:
@@ -125,6 +131,7 @@ id: ts-export-function
 language: TypeScript
 role: item
 symbolType: function
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -140,6 +147,7 @@ id: ts-function
 language: TypeScript
 role: item
 symbolType: function
+stopBy: immediate
 rule:
   kind: function_declaration
   has:
@@ -152,6 +160,7 @@ id: ts-export-class
 language: TypeScript
 role: item
 symbolType: class
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -167,6 +176,7 @@ id: ts-class
 language: TypeScript
 role: item
 symbolType: class
+stopBy: immediate
 rule:
   kind: class_declaration
   has:
@@ -179,6 +189,7 @@ id: ts-export-interface
 language: TypeScript
 role: item
 symbolType: interface
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -194,6 +205,7 @@ id: ts-interface
 language: TypeScript
 role: item
 symbolType: interface
+stopBy: immediate
 rule:
   kind: interface_declaration
   has:
@@ -206,6 +218,7 @@ id: ts-export-type
 language: TypeScript
 role: item
 symbolType: struct
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -221,6 +234,7 @@ id: ts-type
 language: TypeScript
 role: item
 symbolType: struct
+stopBy: immediate
 rule:
   kind: type_alias_declaration
   has:
@@ -233,6 +247,7 @@ id: ts-export-enum
 language: TypeScript
 role: item
 symbolType: enum
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -248,6 +263,7 @@ id: ts-enum
 language: TypeScript
 role: item
 symbolType: enum
+stopBy: immediate
 rule:
   kind: enum_declaration
   has:
@@ -260,6 +276,7 @@ id: ts-export-const
 language: TypeScript
 role: item
 symbolType: constant
+stopBy: immediate
 rule:
   pattern: 'export const $NAME = $VALUE;'
 name: $NAME
@@ -269,6 +286,7 @@ id: ts-export-const-typed
 language: TypeScript
 role: item
 symbolType: constant
+stopBy: immediate
 rule:
   pattern: 'export const $NAME: $TYPE = $VALUE;'
 name: $NAME
@@ -278,6 +296,7 @@ id: ts-export-let
 language: TypeScript
 role: item
 symbolType: variable
+stopBy: immediate
 rule:
   pattern: 'export let $NAME = $VALUE;'
 name: $NAME
@@ -287,6 +306,7 @@ id: ts-export-let-typed
 language: TypeScript
 role: item
 symbolType: variable
+stopBy: immediate
 rule:
   pattern: 'export let $NAME: $TYPE = $VALUE;'
 name: $NAME
@@ -535,6 +555,7 @@ id: tsx-import
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: import_statement
   has:
@@ -548,6 +569,7 @@ id: tsx-export-from
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -561,6 +583,7 @@ id: tsx-export-list
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   pattern: 'export { $$$SPECIFIERS };'
 name: exports
@@ -571,6 +594,7 @@ id: tsx-export-namespace
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -619,6 +643,7 @@ id: tsx-export-ambient-module
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -640,6 +665,7 @@ id: tsx-ambient-module
 language: Tsx
 role: item
 symbolType: module
+stopBy: immediate
 rule:
   kind: ambient_declaration
   has:
@@ -658,6 +684,7 @@ id: tsx-export-function
 language: Tsx
 role: item
 symbolType: function
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -673,6 +700,7 @@ id: tsx-function
 language: Tsx
 role: item
 symbolType: function
+stopBy: immediate
 rule:
   kind: function_declaration
   has:
@@ -685,6 +713,7 @@ id: tsx-export-class
 language: Tsx
 role: item
 symbolType: class
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -700,6 +729,7 @@ id: tsx-class
 language: Tsx
 role: item
 symbolType: class
+stopBy: immediate
 rule:
   kind: class_declaration
   has:
@@ -712,6 +742,7 @@ id: tsx-export-interface
 language: Tsx
 role: item
 symbolType: interface
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -727,6 +758,7 @@ id: tsx-interface
 language: Tsx
 role: item
 symbolType: interface
+stopBy: immediate
 rule:
   kind: interface_declaration
   has:
@@ -739,6 +771,7 @@ id: tsx-export-type
 language: Tsx
 role: item
 symbolType: struct
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -754,6 +787,7 @@ id: tsx-type
 language: Tsx
 role: item
 symbolType: struct
+stopBy: immediate
 rule:
   kind: type_alias_declaration
   has:
@@ -766,6 +800,7 @@ id: tsx-export-enum
 language: Tsx
 role: item
 symbolType: enum
+stopBy: immediate
 rule:
   kind: export_statement
   has:
@@ -781,6 +816,7 @@ id: tsx-enum
 language: Tsx
 role: item
 symbolType: enum
+stopBy: immediate
 rule:
   kind: enum_declaration
   has:
@@ -793,6 +829,7 @@ id: tsx-export-const
 language: Tsx
 role: item
 symbolType: constant
+stopBy: immediate
 rule:
   pattern: 'export const $NAME = $VALUE;'
 name: $NAME
@@ -802,6 +839,7 @@ id: tsx-export-const-typed
 language: Tsx
 role: item
 symbolType: constant
+stopBy: immediate
 rule:
   pattern: 'export const $NAME: $TYPE = $VALUE;'
 name: $NAME
@@ -811,6 +849,7 @@ id: tsx-export-let
 language: Tsx
 role: item
 symbolType: variable
+stopBy: immediate
 rule:
   pattern: 'export let $NAME = $VALUE;'
 name: $NAME
@@ -820,6 +859,7 @@ id: tsx-export-let-typed
 language: Tsx
 role: item
 symbolType: variable
+stopBy: immediate
 rule:
   pattern: 'export let $NAME: $TYPE = $VALUE;'
 name: $NAME

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -48,6 +48,17 @@ impl<L> SerializableOutlineRule<L> {
   }
 }
 
+/// Traversal boundary for one outline extractor.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OutlineStopBy {
+  /// Preserve the existing traversal through all descendants.
+  #[default]
+  End,
+  /// Match only direct children of the current outline source node.
+  Immediate,
+}
+
 /// Shared serializable fields for every outline extractor.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -58,6 +69,9 @@ pub struct SerializableOutlineCommon<L> {
   pub language: L,
   /// LSP-compatible outline category produced by this extractor.
   pub symbol_type: SymbolType,
+  /// Limit this extractor to direct children or keep traversing to the end.
+  #[serde(default)]
+  pub stop_by: OutlineStopBy,
   /// ast-grep rule-core fields used to select candidate syntax.
   #[serde(flatten)]
   pub matcher: SerializableRuleCore,
@@ -135,6 +149,8 @@ pub struct ExtractorCommon<L: Language> {
   pub rule: RuleConfig<L>,
   /// LSP-compatible outline category produced by this extractor.
   pub symbol_type: SymbolType,
+  /// Traversal boundary for this extractor.
+  pub stop_by: OutlineStopBy,
   /// Name template evaluated from metavariables or transformed metavariables.
   pub name: TemplateFix,
   /// Optional source-like signature template.
@@ -165,6 +181,7 @@ impl<L: Language> ExtractorCommon<L> {
     detail: OutlineEntryDetail,
   ) -> Result<Self, OutlineRuleError> {
     let symbol_type = common.symbol_type;
+    let stop_by = common.stop_by;
     let transform_vars = transform_vars(&common.matcher);
     let compile = |tmpl| compile_template(tmpl, &common.language, &transform_vars);
     let name = compile(&common.name)?;
@@ -176,6 +193,7 @@ impl<L: Language> ExtractorCommon<L> {
     Ok(Self {
       rule,
       symbol_type,
+      stop_by,
       name,
       signature,
       detail,
@@ -417,6 +435,7 @@ id: rust-struct
 language: Rust
 role: item
 symbolType: struct
+stopBy: immediate
 rule:
   pattern: $VIS struct $NAME { $$$BODY }
 name: $NAME
@@ -432,6 +451,7 @@ isExported:
     assert_eq!(item.common.id, "rust-struct");
     assert_eq!(item.common.language, SupportLang::Rust);
     assert_eq!(item.common.symbol_type, SymbolType::Struct);
+    assert_eq!(item.common.stop_by, OutlineStopBy::Immediate);
     assert_eq!(item.common.name, "$NAME");
     assert!(matches!(
       item.is_exported,
@@ -449,6 +469,7 @@ language: Rust
 role: member
 parentRuleIds: [rust-struct]
 symbolType: field
+stopBy: end
 rule:
   pattern: '$VIS $NAME: $TYPE'
 name: $NAME
@@ -465,6 +486,7 @@ isPublic:
     assert_eq!(member.common.id, "rust-field");
     assert_eq!(member.parent_rule_ids, vec!["rust-struct"]);
     assert_eq!(member.common.symbol_type, SymbolType::Field);
+    assert_eq!(member.common.stop_by, OutlineStopBy::End);
     assert_eq!(
       member.common.signature.as_deref(),
       Some("$VIS $NAME: $TYPE")
@@ -473,6 +495,67 @@ isPublic:
       member.is_public,
       Some(SerializablePredicate::Rule(_))
     ));
+  }
+
+  #[test]
+  fn defaults_omitted_stop_by_to_end() {
+    let rule = parse_rule(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+rule:
+  kind: function_declaration
+name: function
+"#,
+    );
+
+    assert_eq!(rule.common().stop_by, OutlineStopBy::End);
+  }
+
+  #[test]
+  fn rejects_unknown_outline_stop_by_value() {
+    let result = ast_grep_config::from_str::<SerializableOutlineRule<SupportLang>>(
+      r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: neighbor
+rule:
+  kind: function_declaration
+name: function
+"#,
+    );
+    let Err(err) = result else {
+      panic!("outline stopBy should reject relational stopBy values");
+    };
+
+    let message = err.to_string();
+    assert!(message.contains("unknown variant"));
+    assert!(message.contains("neighbor"));
+  }
+
+  #[test]
+  fn distinguishes_outline_stop_by_from_nested_relational_stop_by() {
+    let rule = parse_rule(
+      r#"
+id: ts-export-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: immediate
+rule:
+  kind: export_statement
+  has:
+    kind: function_declaration
+    stopBy: neighbor
+name: function
+"#,
+    );
+
+    assert_eq!(rule.common().stop_by, OutlineStopBy::Immediate);
   }
 
   #[test]
@@ -714,6 +797,7 @@ pattern: function $NAME() { $$$BODY }
           transform: None,
         },
         rewriters: None,
+        stop_by: OutlineStopBy::End,
         name: "$NAME".into(),
         signature: Some("function $NAME()".into()),
       },
@@ -726,6 +810,7 @@ pattern: function $NAME() { $$$BODY }
     assert_eq!(value["role"], "item");
     assert_eq!(value["id"], "ts-function");
     assert_eq!(value["symbolType"], "function");
+    assert_eq!(value["stopBy"], "end");
     assert_eq!(value["isExported"], true);
   }
 }

--- a/crates/outline/tests/typescript_outline_rules.rs
+++ b/crates/outline/tests/typescript_outline_rules.rs
@@ -5,6 +5,178 @@ mod common;
 const TYPESCRIPT_RULES: &str = include_str!("../src/default_rules/typescript.yml");
 
 #[test]
+fn immediate_item_rules_only_match_direct_children() {
+  common::assert_outline_snapshot(
+    SupportLang::TypeScript,
+    r#"
+id: ts-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: immediate
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+isExported: false
+"#,
+    r#"
+function direct() {}
+if (ready) {
+  function nested() {}
+}
+"#,
+    r#"
+- Function item private direct
+"#,
+  );
+}
+
+#[test]
+fn mixed_item_rules_keep_end_traversal_and_direct_child_precedence() {
+  common::assert_outline_snapshot(
+    SupportLang::TypeScript,
+    r#"
+id: ts-immediate-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: immediate
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: immediate-$NAME
+isExported: false
+---
+id: ts-end-function
+language: TypeScript
+role: item
+symbolType: function
+stopBy: end
+rule:
+  kind: function_declaration
+  has:
+    field: name
+    pattern: $NAME
+name: end-$NAME
+isExported: false
+"#,
+    r#"
+function direct() {}
+if (ready) {
+  function nested() {}
+}
+"#,
+    r#"
+- Function item private immediate-direct
+- Function item private end-nested
+"#,
+  );
+}
+
+#[test]
+fn immediate_member_rules_only_match_direct_children() {
+  common::assert_outline_snapshot(
+    SupportLang::TypeScript,
+    r#"
+id: ts-class-body
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_body
+name: body
+isExported: false
+---
+id: ts-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class-body]
+symbolType: method
+stopBy: immediate
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: $NAME
+"#,
+    r#"
+class Outer {
+  direct() {}
+  field = class Inner {
+    nested() {}
+  };
+}
+"#,
+    r#"
+- Class item private body
+  - Method public direct
+"#,
+  );
+}
+
+#[test]
+fn mixed_member_rules_keep_end_traversal_and_direct_child_precedence() {
+  common::assert_outline_snapshot(
+    SupportLang::TypeScript,
+    r#"
+id: ts-class-body
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: class_body
+name: body
+isExported: false
+---
+id: ts-immediate-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class-body]
+symbolType: method
+stopBy: immediate
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: immediate-$NAME
+---
+id: ts-end-method
+language: TypeScript
+role: member
+parentRuleIds: [ts-class-body]
+symbolType: method
+stopBy: end
+rule:
+  kind: method_definition
+  has:
+    field: name
+    pattern: $NAME
+name: end-$NAME
+"#,
+    r#"
+class Outer {
+  direct() {}
+  field = class Inner {
+    nested() {}
+  };
+}
+"#,
+    r#"
+- Class item private body
+  - Method public immediate-direct
+  - Method public end-nested
+"#,
+  );
+}
+
+#[test]
 fn extracts_typescript_outline_from_realistic_vscode_style_code() {
   common::assert_outline_snapshot(
     SupportLang::TypeScript,


### PR DESCRIPTION
# perf(outline): add per-rule stopBy traversal bounds

## Problem I saw

Outline rules currently keep walking to the end of an item or member scope even when a rule can only match the source node's direct children. That makes those rules visit descendants outside their useful boundary.

## What I changed

### Requirements

1. Item and member rules now accept `stopBy: end` and `stopBy: immediate`. Omitting the field defaults to `end`, preserving the existing behavior. Item bounds are relative to the file root; member bounds are relative to the matched item.
2. An `immediate` rule participates at direct children but not at deeper descendants. In mixed scopes, `end` rules continue participating below direct children, and rule precedence is unchanged wherever both rules are eligible.
3. When every active rule in a scope is `immediate`, traversal skips each unmatched direct child's subtree. The item decision is made after outline options retain their active rules; the member decision is made from the active rules for the enclosing item's rule ID.

The traversal partition stays inside `ast-grep-outline`; this does not change `ast-grep-core`.

### Acceptance

1. Deserialization tests cover item and member rules, explicit `end` and `immediate`, omitted-to-`end` defaulting, rejection of an unknown top-level value, and a nested relational `stopBy: neighbor` alongside the new outline field.
2. Item traversal tests cover immediate-only and mixed immediate/end scopes, including direct-child precedence.
3. Member traversal tests cover the equivalent immediate-only and mixed scopes.
4. Test-only visit counters distinguish pruning from matcher filtering. The immediate-only item fixture visits the program and its two direct children, for 3 visits total, while the equivalent `end` traversal visits more nodes. The member fixture also records fewer visits with `immediate` than with `end` while producing the same member output.
5. Forty empirically qualified TypeScript/TSX item rules are now `immediate`:
   - TypeScript: `ts-import`, `ts-export-from`, `ts-export-list`, `ts-export-namespace`, `ts-export-ambient-module`, `ts-ambient-module`, `ts-export-function`, `ts-function`, `ts-export-class`, `ts-class`, `ts-export-interface`, `ts-interface`, `ts-export-type`, `ts-type`, `ts-export-enum`, `ts-enum`, `ts-export-const`, `ts-export-const-typed`, `ts-export-let`, and `ts-export-let-typed`.
   - TSX: `tsx-import`, `tsx-export-from`, `tsx-export-list`, `tsx-export-namespace`, `tsx-export-ambient-module`, `tsx-ambient-module`, `tsx-export-function`, `tsx-function`, `tsx-export-class`, `tsx-class`, `tsx-export-interface`, `tsx-interface`, `tsx-export-type`, `tsx-type`, `tsx-export-enum`, `tsx-enum`, `tsx-export-const`, `tsx-export-const-typed`, `tsx-export-let`, and `tsx-export-let-typed`.
   - `ts-namespace` and `tsx-namespace` remain `end`; all member rules remain `end`. The wrapper-owned `ts-top-level-arrow-function`, `ts-top-level-const`, `ts-top-level-const-typed`, `ts-top-level-let-uninitialized`, `ts-top-level-let`, `ts-top-level-let-typed`, `tsx-top-level-arrow-function`, `tsx-top-level-const`, `tsx-top-level-const-typed`, `tsx-top-level-let-uninitialized`, `tsx-top-level-let`, and `tsx-top-level-let-typed` rules also remain `end`. The 34 nested relational `stopBy: neighbor` values are unchanged.
6. The `sst/opencode` benchmark used commit `909db63265971d67d2fe4ba7f9d7b74cc33e2fdc`, `--items exports`, release mode, one thread, and three alternating wall-clock runs:

   ```text
   end run 1
   real 2.36
   user 2.11
   sys 0.09

   immediate run 1
   real 2.15
   user 2.08
   sys 0.08

   end run 2
   real 2.30
   user 2.14
   sys 0.08

   immediate run 2
   real 2.19
   user 2.11
   sys 0.08

   end run 3
   real 2.13
   user 2.07
   sys 0.07

   immediate run 3
   real 2.14
   user 2.08
   sys 0.07
   ```

   Every end/immediate pair was byte-identical. Each output contained 5,835 lines and 405,631 bytes with SHA-256 `3ceb0ec056bf4e6e8ff4886cd4e71144f4e2267172fc3c2bffe5f0582b5c70ad`.
7. The separate `microsoft/TypeScript` `src/compiler` check used commit `cc5c6e2d32e2228fff83a66537bbe6042943054d`. The 40-rule aggregate output was byte-identical to the all-`end` baseline: 77 JSON lines, 1,148,510 bytes, SHA-256 `e7dc1eabe6996aad5876b2f4aae3c407935d068dbd8bed6271b0a811a6717a4d`. The individual `ts-namespace` probe did not pass equivalence: immediate traversal removed namespace containers and exposed nested declarations in `factory/utilities.ts`, `parser.ts`, and `checker.ts`. The same rule also changed `sst/opencode` output by exposing the nested `Service` interface in `packages/opencode/test/lib/llm-server.ts`, so both namespace mirrors remain `end`.

## How I checked it

```text
cargo test -p ast-grep-outline
58 passed; 0 failed

cargo test -p ast-grep test_outline
1 passed; 0 failed

cargo test --all-features --workspace
passed with zero failures

cargo fmt --all -- --check
passed

cargo clippy --all-targets --all-features --workspace -- -D clippy::all
passed

cargo clippy --all-targets --all-features --workspace --release --locked -- -D clippy::all
passed
```

Fixes #2825


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable outline traversal boundaries with `stopBy: immediate` and `stopBy: end`.
  * Immediate matching now limits results to direct child items or members, while end matching continues through nested structures.
  * Updated TypeScript and TSX rules to use immediate matching for top-level declarations and imports/exports.

* **Bug Fixes**
  * Improved traversal pruning to avoid unnecessary processing of unrelated nested code.

* **Tests**
  * Added coverage for immediate and end matching across functions, classes, and mixed rule configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->