### PR TITLE
Use `std::io::IsTerminal` over `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,6 @@ dependencies = [
  "ast-grep-language",
  "ast-grep-lsp",
  "ast-grep-outline",
- "atty",
  "clap",
  "clap_complete",
  "codespan-reporting",
@@ -287,17 +286,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -869,15 +857,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "httparse"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,7 +35,6 @@ tree-sitter.workspace = true
 
 ansi_term = "0.12.1"
 anyhow.workspace = true
-atty = "0.2.14"
 clap = { version = "4.5.4", features = ["derive"] }
 codespan-reporting = "0.13.0"
 crossterm = "0.29.0"

--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -11,7 +11,7 @@ use codespan_reporting::term::termcolor::{Buffer, ColorChoice, StandardStream, W
 use codespan_reporting::term::{self, DisplayStyle};
 
 use std::borrow::Cow;
-use std::io::Write;
+use std::io::{IsTerminal as _, Write};
 use std::path::Path;
 
 mod markdown;
@@ -50,7 +50,7 @@ impl Heading {
     match self {
       H::Always => true,
       H::Never => false,
-      H::Auto => atty::is(atty::Stream::Stdout),
+      H::Auto => std::io::stdout().is_terminal(),
     }
   }
 }

--- a/crates/cli/src/print/colored_print/styles.rs
+++ b/crates/cli/src/print/colored_print/styles.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use std::borrow::Cow;
 use std::env;
-use std::io::Write;
+use std::io::{IsTerminal as _, Write};
 use std::path::Path;
 
 // warn[rule-id]: rule message here.
@@ -136,7 +136,7 @@ pub fn should_use_color(color: &ColorChoice) -> bool {
     ColorChoice::AlwaysAnsi => true,
     ColorChoice::Never => false,
     // NOTE tty check is added
-    ColorChoice::Auto => atty::is(atty::Stream::Stdout) && env_allows_color(),
+    ColorChoice::Auto => std::io::stdout().is_terminal() && env_allows_color(),
   }
 }
 

--- a/crates/cli/src/print/mod.rs
+++ b/crates/cli/src/print/mod.rs
@@ -11,8 +11,8 @@ use ast_grep_core::{Matcher, NodeMatch as SgNodeMatch, tree_sitter::StrDoc};
 use anyhow::Result;
 use clap::ValueEnum;
 
-use std::borrow::Cow;
 use std::path::Path;
+use std::{borrow::Cow, io::IsTerminal as _};
 
 pub use cloud_print::{CloudPrinter, Platform};
 pub use codespan_reporting::files::SimpleFile;
@@ -173,7 +173,7 @@ impl From<ColorArg> for ColorChoice {
     use ColorArg::*;
     match arg {
       Auto => {
-        if atty::is(atty::Stream::Stdout) {
+        if std::io::stdout().is_terminal() {
           ColorChoice::Auto
         } else {
           ColorChoice::Never


### PR DESCRIPTION
Closes https://github.com/ast-grep/ast-grep/issues/2858

Use [`std::io::IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) over `atty`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic terminal detection for CLI output.
  * Color output now more reliably adapts when commands run in terminals versus redirected output.

* **Chores**
  * Updated terminal detection to use the Rust standard library, with no expected change to user-facing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->