### PR TITLE
feat(outline): add C# multiline member signatures

### DIFF
--- a/crates/outline/src/default_rules/csharp.yml
+++ b/crates/outline/src/default_rules/csharp.yml
@@ -106,11 +106,35 @@ role: member
 parentRuleIds: [csharp-class, csharp-record, csharp-struct]
 symbolType: constructor
 rule:
-  kind: constructor_declaration
-  has:
-    field: name
-    pattern: $NAME
+  all:
+    - kind: constructor_declaration
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*(\{[\s\S]*$|=>[\s\S]*$|;\s*$)'
+      by: ''
+  SINGLE_LINE:
+    replace:
+      source: $BODYLESS
+      replace: '\s*\n\s*'
+      by: ' '
+  TIGHT_OPEN:
+    replace:
+      source: $SINGLE_LINE
+      replace: '\(\s+'
+      by: '('
+  SIG:
+    replace:
+      source: $TIGHT_OPEN
+      replace: '\s+\)'
+      by: ')'
 name: $NAME
+signature: $SIG
 isPublic:
   has:
     kind: modifier
@@ -122,11 +146,35 @@ role: member
 parentRuleIds: [csharp-class, csharp-record, csharp-struct]
 symbolType: method
 rule:
-  kind: method_declaration
-  has:
-    field: name
-    pattern: $NAME
+  all:
+    - kind: method_declaration
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*(\{[\s\S]*$|=>[\s\S]*$|;\s*$)'
+      by: ''
+  SINGLE_LINE:
+    replace:
+      source: $BODYLESS
+      replace: '\s*\n\s*'
+      by: ' '
+  TIGHT_OPEN:
+    replace:
+      source: $SINGLE_LINE
+      replace: '\(\s+'
+      by: '('
+  SIG:
+    replace:
+      source: $TIGHT_OPEN
+      replace: '\s+\)'
+      by: ')'
 name: $NAME
+signature: $SIG
 isPublic:
   has:
     kind: modifier
@@ -138,11 +186,35 @@ role: member
 parentRuleIds: [csharp-interface]
 symbolType: method
 rule:
-  kind: method_declaration
-  has:
-    field: name
-    pattern: $NAME
+  all:
+    - kind: method_declaration
+    - pattern: $DECL
+    - has:
+        field: name
+        pattern: $NAME
+transform:
+  BODYLESS:
+    replace:
+      source: $DECL
+      replace: '\s*(\{[\s\S]*$|=>[\s\S]*$|;\s*$)'
+      by: ''
+  SINGLE_LINE:
+    replace:
+      source: $BODYLESS
+      replace: '\s*\n\s*'
+      by: ' '
+  TIGHT_OPEN:
+    replace:
+      source: $SINGLE_LINE
+      replace: '\(\s+'
+      by: '('
+  SIG:
+    replace:
+      source: $TIGHT_OPEN
+      replace: '\s+\)'
+      by: ')'
 name: $NAME
+signature: $SIG
 isPublic: true
 ---
 id: csharp-member-property

--- a/crates/outline/tests/c_family_outline_rules.rs
+++ b/crates/outline/tests/c_family_outline_rules.rs
@@ -55,12 +55,12 @@ public class CommandDispatcher
         this.service = service;
     }
 
-    public Task DispatchAsync(
+    public async Task DispatchAsync(
         Command command,
         CancellationToken cancellationToken
     )
     {
-        return Task.CompletedTask;
+        await Task.CompletedTask;
     }
 }
 "#,
@@ -69,7 +69,7 @@ public class CommandDispatcher
   - Method public DispatchAsync | Task DispatchAsync(Command command, CancellationToken cancellationToken)
 - Class item exported CommandDispatcher | public class CommandDispatcher
   - Constructor public CommandDispatcher | public CommandDispatcher(IService service)
-  - Method public DispatchAsync | public Task DispatchAsync(Command command, CancellationToken cancellationToken)
+  - Method public DispatchAsync | public async Task DispatchAsync(Command command, CancellationToken cancellationToken)
 "#,
   );
 }

--- a/crates/outline/tests/c_family_outline_rules.rs
+++ b/crates/outline/tests/c_family_outline_rules.rs
@@ -32,6 +32,49 @@ public enum Mode { Fast, Slow }
 }
 
 #[test]
+fn csharp_rules_extract_multiline_member_signatures() {
+  const RULES: &str = include_str!("../src/default_rules/csharp.yml");
+  common::assert_outline_signature_snapshot(
+    SupportLang::CSharp,
+    RULES,
+    r#"
+public interface IDispatcher
+{
+    Task DispatchAsync(
+        Command command,
+        CancellationToken cancellationToken
+    );
+}
+
+public class CommandDispatcher
+{
+    public CommandDispatcher(
+        IService service
+    )
+    {
+        this.service = service;
+    }
+
+    public Task DispatchAsync(
+        Command command,
+        CancellationToken cancellationToken
+    )
+    {
+        return Task.CompletedTask;
+    }
+}
+"#,
+    r#"
+- Interface item exported IDispatcher | public interface IDispatcher
+  - Method public DispatchAsync | Task DispatchAsync(Command command, CancellationToken cancellationToken)
+- Class item exported CommandDispatcher | public class CommandDispatcher
+  - Constructor public CommandDispatcher | public CommandDispatcher(IService service)
+  - Method public DispatchAsync | public Task DispatchAsync(Command command, CancellationToken cancellationToken)
+"#,
+  );
+}
+
+#[test]
 fn c_rules_parse_and_extract_native_shapes() {
   const RULES: &str = include_str!("../src/default_rules/c.yml");
   common::assert_outline_snapshot(


### PR DESCRIPTION
## Summary

- Add C# builtin outline signatures for constructors, class, struct, record, and interface methods.
- Collapse multiline C# member declarations into one-line signatures after stripping bodies.
- Add regression coverage for multiline C# member signatures.

## Motivation

Without explicit C# member signatures, expanded outline output falls back to the first non-empty source line, so methods with multiline parameter lists lose their full parameter list.

Closes #2846.

## Testing

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features --workspace --release --locked -- -D clippy::all`
- `cargo test -p ast-grep-outline --test c_family_outline_rules csharp_rules_extract_multiline_member_signatures`
- `cargo test -p ast-grep-outline --test c_family_outline_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * C# code outlines now display normalized signatures for constructors, class, record, struct, and interface methods.
  * Multiline declarations are represented more consistently, with method bodies and unnecessary formatting removed.
* **Tests**
  * Added coverage validating normalized signatures across C# constructors and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->