### PR TITLE
fix: match root metavariables against comments

### DIFF
--- a/crates/core/src/match_tree/match_node.rs
+++ b/crates/core/src/match_tree/match_node.rs
@@ -5,6 +5,25 @@ use crate::meta_var::MetaVariable;
 use crate::{Doc, Node};
 use std::iter::Peekable;
 
+pub(super) fn match_root_node_impl<'tree, D: Doc>(
+  goal: &PatternNode,
+  candidate: &Node<'tree, D>,
+  agg: &mut impl Aggregator<'tree, D>,
+  strictness: &MatchStrictness,
+) -> MatchOneNode {
+  // Smart matching ignores comments inside structured patterns, but a root
+  // metavariable represents the candidate itself and must still bind extras.
+  if let PatternNode::MetaVar { meta_var } = goal
+    && matches!(strictness, MatchStrictness::Smart)
+  {
+    return match agg.match_meta_var(meta_var, candidate) {
+      Some(()) => MatchOneNode::MatchedBoth,
+      None => MatchOneNode::NoMatch,
+    };
+  }
+  match_node_impl(goal, candidate, agg, strictness)
+}
+
 pub(super) fn match_node_impl<'tree, D: Doc>(
   goal: &PatternNode,
   candidate: &Node<'tree, D>,

--- a/crates/core/src/match_tree/mod.rs
+++ b/crates/core/src/match_tree/mod.rs
@@ -1,7 +1,7 @@
 mod match_node;
 mod strictness;
 
-use match_node::match_node_impl;
+use match_node::match_root_node_impl;
 use strictness::MatchOneNode;
 pub use strictness::MatchStrictness;
 
@@ -52,7 +52,7 @@ impl<'t, D: Doc> Aggregator<'t, D> for ComputeEnd {
 
 pub fn match_end_non_recursive(goal: &Pattern, candidate: Node<impl Doc>) -> Option<usize> {
   let mut end = ComputeEnd(0);
-  match match_node_impl(&goal.node, &candidate, &mut end, &goal.strictness) {
+  match match_root_node_impl(&goal.node, &candidate, &mut end, &goal.strictness) {
     MatchOneNode::MatchedBoth => Some(end.0),
     _ => None,
   }
@@ -120,7 +120,7 @@ pub fn match_node_non_recursive<'tree, D: Doc>(
   candidate: Node<'tree, D>,
   env: &mut Cow<MetaVarEnv<'tree, D>>,
 ) -> Option<Node<'tree, D>> {
-  match match_node_impl(&goal.node, &candidate, env, &goal.strictness) {
+  match match_root_node_impl(&goal.node, &candidate, env, &goal.strictness) {
     MatchOneNode::MatchedBoth => Some(candidate),
     _ => None,
   }
@@ -153,6 +153,7 @@ pub fn does_node_match_exactly<D: Doc>(goal: &Node<D>, candidate: &Node<D>) -> b
 mod test {
   use super::*;
   use crate::language::Tsx;
+  use crate::matcher::KindMatcher;
   use crate::meta_var::MetaVarEnv;
   use crate::tree_sitter::StrDoc;
   use crate::{Node, Root};
@@ -197,6 +198,51 @@ mod test {
   fn test_simple_match() {
     test_match("const a = 123", "const a=123");
     test_non_match("const a = 123", "var a = 123");
+  }
+
+  #[test]
+  fn test_root_metavar_matches_comment() {
+    let goal = Pattern::new("$COMMENT", Tsx);
+    let cand = Root::str(
+      "class MyClass { /** @memberof MyClass.prototype */ get myProp() { return 1; } }",
+      Tsx,
+    );
+    let comment = cand
+      .root()
+      .find(KindMatcher::new("comment", Tsx))
+      .expect("should find comment")
+      .get_node()
+      .clone();
+    assert!(comment.is_extra(), "test requires an extra comment node");
+    assert_eq!(
+      match_end_non_recursive(&goal, comment.clone()),
+      Some(comment.range().end)
+    );
+
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    let matched = match_node_non_recursive(&goal, comment.clone(), &mut env);
+    assert!(matched.is_some(), "root metavariable should match comment");
+    assert_eq!(
+      env
+        .get_match("COMMENT")
+        .expect("should capture comment")
+        .text(),
+      "/** @memberof MyClass.prototype */"
+    );
+
+    let dropped = Pattern::new("$_", Tsx);
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    assert!(match_node_non_recursive(&dropped, comment.clone(), &mut env).is_some());
+
+    let relaxed = Pattern::new("$COMMENT", Tsx).with_strictness(MatchStrictness::Relaxed);
+    let mut env = Cow::Owned(MetaVarEnv::new());
+    assert!(match_node_non_recursive(&relaxed, comment, &mut env).is_none());
+  }
+
+  #[test]
+  fn test_nested_smart_metavar_skips_comment() {
+    let env = test_match("$A($B)", "foo(/* before */ bar /* after */)");
+    assert_eq!(env["B"], "bar");
   }
 
   #[test]


### PR DESCRIPTION
Fixes #2867.

Smart strictness skips extra comment nodes while matching structured patterns. That skip was also applied when the whole pattern was a metavariable, so a root `$COMMENT` could not match a comment candidate.

This keeps comment skipping for nested metavariables while allowing a Smart root metavariable to bind the candidate itself. Both normal matching and match-length calculation use the same root path.

Tests cover:

- named and dropped root metavariables on an extra TSX comment
- match-length consistency
- unchanged Relaxed behavior
- nested Smart metavariables continuing to skip comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Smart mode matching for root-level metavariables, ensuring they capture complete candidate nodes, including comments.
  * Preserved existing matching behavior for other root patterns.
  * Improved handling of dropped metavariables and strictness rules when comments or extra nodes are present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->