### PR TITLE
feat(outline): extract embedded language symbols

### DIFF
--- a/crates/cli/src/outline/extract.rs
+++ b/crates/cli/src/outline/extract.rs
@@ -6,7 +6,8 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 
 use anyhow::{Context, Result};
-use ast_grep_core::Language;
+use ast_grep_core::tree_sitter::StrDoc;
+use ast_grep_core::{AstGrep, Language};
 use ast_grep_language::LanguageExt;
 use ast_grep_outline::{
   DEFAULT_OUTLINE_RULES,
@@ -84,16 +85,24 @@ impl OutlineExtractors {
     self.by_lang.keys().copied()
   }
 
-  fn extract<'tree>(
-    &self,
-    lang: SgLang,
-    root: ast_grep_core::Node<'tree, ast_grep_core::tree_sitter::StrDoc<SgLang>>,
-  ) -> Vec<OutlineItem<'static>> {
-    self
+  fn extract(&self, lang: SgLang, grep: &AstGrep<StrDoc<SgLang>>) -> Vec<OutlineItem<'static>> {
+    let mut items: Vec<OutlineItem<'static>> = self
       .by_lang
       .get(&lang)
-      .map(|extractors| extractors.extract(root).map(own_item).collect())
-      .unwrap_or_default()
+      .map(|extractors| extractors.extract(grep.root()).map(own_item).collect())
+      .unwrap_or_default();
+
+    for injected in grep.get_injections(|language| {
+      let lang = language.parse().ok()?;
+      self.by_lang.contains_key(&lang).then_some(lang)
+    }) {
+      let injected_lang = *injected.lang();
+      if let Some(extractors) = self.by_lang.get(&injected_lang) {
+        items.extend(extractors.extract(injected.root()).map(own_item));
+      }
+    }
+    items.sort_by_key(|item| item.entry.range.byte_offset.start);
+    items
   }
 }
 
@@ -126,7 +135,7 @@ pub fn extract_stdin(
   let lang = arg.lang.expect("required by clap");
   let source = io::read_to_string(io::stdin())?;
   let grep = lang.ast_grep(source);
-  let items = extractors.extract(lang, grep.root());
+  let items = extractors.extract(lang, &grep);
   Ok(OutlineFile {
     path: "STDIN".to_string(),
     language: lang.to_string(),
@@ -238,7 +247,7 @@ fn extract_path(
     }
   };
   let grep = lang.ast_grep(source);
-  let items = extractors.extract(lang, grep.root());
+  let items = extractors.extract(lang, &grep);
   if !extractors.show_empty_files && items.is_empty() {
     return Ok(None);
   }
@@ -338,6 +347,61 @@ name: struct
       .collect::<Vec<_>>();
 
     assert_eq!(ids, vec!["config-rust-function", "cli-rust-struct"]);
+  }
+
+  #[test]
+  fn extracts_outline_from_html_injected_script() {
+    let rules = load_outline_rules(true, &[], &[]).expect("builtin rules should load");
+    let extractors =
+      OutlineExtractors::try_from_options(rules, OutlineExtractorOptions::default(), false)
+        .expect("builtin rules should compile");
+    let html: SgLang = "html".parse().unwrap();
+    let grep = html.ast_grep(
+      r#"<main></main>
+<script lang="typescript">
+export function greet(name: string) {
+  return `Hello ${name}`;
+}
+</script>
+<script>
+function stop() {}
+</script>"#,
+    );
+
+    let items = extractors.extract(html, &grep);
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].entry.name, "greet");
+    assert_eq!(items[0].entry.range.start.line, 2);
+    assert_eq!(items[1].entry.name, "stop");
+    assert_eq!(items[1].entry.range.start.line, 7);
+  }
+
+  #[test]
+  fn extracts_injected_outline_from_html_path() {
+    let dir = TempDir::new().expect("temp dir should be created");
+    let path = dir.path().join("component.html");
+    fs::write(
+      &path,
+      r#"<script>
+class Controller {
+  start() {}
+}
+</script>"#,
+    )
+    .expect("HTML file should be written");
+    let rules = load_outline_rules(true, &[], &[]).expect("builtin rules should load");
+    let extractors =
+      OutlineExtractors::try_from_options(rules, OutlineExtractorOptions::default(), false)
+        .expect("builtin rules should compile");
+
+    let file = extract_path(&path, None, &extractors)
+      .expect("HTML extraction should succeed")
+      .expect("injected outline should keep the file");
+
+    assert_eq!(file.language, "Html");
+    assert_eq!(file.items.len(), 1);
+    assert_eq!(file.items[0].entry.name, "Controller");
   }
 
   #[test]

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -119,6 +119,25 @@ export function greet(name: string) {
 }
 
 #[test]
+fn test_outline_javascript_in_html_stdin() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args(["outline", "--stdin", "--lang", "html", "--json=compact"])
+    .write_stdin(
+      r#"<script lang="typescript">
+export function greet(name: string) {
+  return `Hello ${name}`;
+}
+</script>"#,
+    )
+    .assert()
+    .success()
+    .stdout(contains(r#""path":"STDIN""#))
+    .stdout(contains(r#""language":"Html""#))
+    .stdout(contains(r#""name":"greet""#));
+  Ok(())
+}
+
+#[test]
 fn test_rewrite_js_in_html() -> Result<()> {
   let dir = create_test_files([("a.html", "<script>alert(1)</script>")])?;
   Command::new(cargo_bin!())

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -87,6 +87,38 @@ fn test_js_in_html() -> Result<()> {
 }
 
 #[test]
+fn test_outline_javascript_in_vue_as_html() -> Result<()> {
+  let dir = create_test_files([
+    (
+      "sgconfig.yml",
+      r#"ruleDirs: []
+languageGlobs:
+  html:
+    - "*.vue"
+"#,
+    ),
+    (
+      "component.vue",
+      r#"<template><main>Hello</main></template>
+<script lang="typescript">
+export function greet(name: string) {
+  return `Hello ${name}`;
+}
+</script>"#,
+    ),
+  ])?;
+
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["outline", "component.vue", "--json=compact"])
+    .assert()
+    .success()
+    .stdout(contains(r#""language":"Html""#))
+    .stdout(contains(r#""name":"greet""#));
+  Ok(())
+}
+
+#[test]
 fn test_rewrite_js_in_html() -> Result<()> {
   let dir = create_test_files([("a.html", "<script>alert(1)</script>")])?;
   Command::new(cargo_bin!())


### PR DESCRIPTION
## Summary

- Extract outline items from embedded documents using the existing per-language outline rules.
- Merge host and injected items in source order while preserving their original file ranges.
- Add unit and CLI regression coverage for JavaScript and TypeScript in HTML and Vue files.

## Motivation

`ast-grep outline` previously only ran rules for the host document, so HTML files produced no symbols even when their `<script>` elements contained JavaScript or TypeScript declarations. This change reuses the existing language injection support so embedded declarations appear without inventing an outline structure for the parent HTML document.

Closes #2813.

## Testing

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features --workspace --release --locked -- -D clippy::all`
- `cargo test -p ast-grep --test run_test test_outline_javascript_in_vue_as_html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Outline extraction now recognizes code embedded in supported languages within HTML-based files, including Vue components.
  - Combined outlines include items from both the host document and embedded scripts, sorted by their location in the source.
  - The compact JSON outline command now reports embedded functions, such as TypeScript or JavaScript functions, in its output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->