### PR TITLE
fix: exit quietly on broken pipe instead of erroring

### DIFF
--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -327,12 +327,8 @@ pub fn exit_with_error(error: Error) -> Result<ExitCode> {
     eprintln!("{error_fmt}");
     std::process::exit(e.exit_code())
   }
-  // The only pipe ast-grep writes is its own stdout, so a BrokenPipe in the
-  // error chain means a downstream reader (e.g. `sg ... | head`) closed early:
-  // normal termination, not a failure. Exit quietly instead of printing
-  // "Broken pipe (os error 32)". Domain errors carry an ErrorContext and exit
-  // above, so this never swallows a meaningful error. Revisit if ast-grep ever
-  // writes into a child process's piped stdin.
+  // A closed pipe (e.g. `sg ... | head`) is not an error.
+  // See: https://github.com/ast-grep/ast-grep/pull/2887
   if error
     .chain()
     .filter_map(|e| e.downcast_ref::<std::io::Error>())

--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -327,6 +327,19 @@ pub fn exit_with_error(error: Error) -> Result<ExitCode> {
     eprintln!("{error_fmt}");
     std::process::exit(e.exit_code())
   }
+  // The only pipe ast-grep writes is its own stdout, so a BrokenPipe in the
+  // error chain means a downstream reader (e.g. `sg ... | head`) closed early:
+  // normal termination, not a failure. Exit quietly instead of printing
+  // "Broken pipe (os error 32)". Domain errors carry an ErrorContext and exit
+  // above, so this never swallows a meaningful error. Revisit if ast-grep ever
+  // writes into a child process's piped stdin.
+  if error
+    .chain()
+    .filter_map(|e| e.downcast_ref::<std::io::Error>())
+    .any(|e| e.kind() == std::io::ErrorKind::BrokenPipe)
+  {
+    return Ok(ExitCode::SUCCESS);
+  }
   // use anyhow's default error reporting
   Err(error)
 }
@@ -480,5 +493,19 @@ mod test {
     // Check that it's considered a soft error with exit code 0
     assert_eq!(ErrorContext::ExitInteractiveEditing.exit_code(), 0);
     assert!(ErrorContext::ExitInteractiveEditing.is_soft_error());
+  }
+
+  #[test]
+  fn test_broken_pipe_exits_quietly() {
+    let io_err = std::io::Error::from(std::io::ErrorKind::BrokenPipe);
+    let error = anyhow::Error::new(io_err).context("while printing matches");
+    assert!(exit_with_error(error).is_ok());
+  }
+
+  #[test]
+  fn test_other_io_error_is_reported() {
+    let io_err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+    let error = anyhow::Error::new(io_err);
+    assert!(exit_with_error(error).is_err());
   }
 }

--- a/crates/cli/src/utils/error_context.rs
+++ b/crates/cli/src/utils/error_context.rs
@@ -499,7 +499,10 @@ mod test {
   fn test_broken_pipe_exits_quietly() {
     let io_err = std::io::Error::from(std::io::ErrorKind::BrokenPipe);
     let error = anyhow::Error::new(io_err).context("while printing matches");
-    assert!(exit_with_error(error).is_ok());
+    assert!(matches!(
+      exit_with_error(error),
+      Ok(code) if code == std::process::ExitCode::SUCCESS
+    ));
   }
 
   #[test]


### PR DESCRIPTION
- Related to: #2403 (exit-code audit -- the broken pipe was one path that spuriously returned exit 1)

ast-grep prints `Error: Broken pipe (os error 32)` and exits 1 whenever a downstream reader closes the pipe before ast-grep finishes writing -- `sg ... | head`, a `tail`, or a pager the user quits. The write returns a `BrokenPipe` `io::Error` that propagates to `main`, where anyhow's default reporting renders it as an error. Closing a pipe early is normal shell usage, so routine truncation looks like a tool failure and pollutes scripts with a nonzero exit. Automated tooling is especially affected: AI coding agents commonly read the error, assume a fault in their own setup or command parameters, and start investigating a non-problem -- the pipeline was correct all along.

In this PR, `exit_with_error` inspects the error chain for a `BrokenPipe` `io::Error` and returns a success exit code when it finds one, so a closed pipe ends the process quietly [[src](https://github.com/ivan-aksamentov/ast-grep/blob/58af46449cb8e0db3322610b2712c778a80d6418/crates/cli/src/utils/error_context.rs#L318-L345)]. Every other error keeps the existing reporting path.

The alternative is to reset the `SIGPIPE` disposition to `SIG_DFL` at startup and let the kernel terminate the process. Detection is preferred here because it needs no new dependency or `unsafe` block, works on every platform including Windows, and drops into the existing `exit_with_error` dispatch beside the clap and `ErrorContext` cases. It is also the route the most widely used Rust CLIs settled on; the prior-art note below gives the per-project evidence.

<details>
<summary>Prior art: how the ecosystem converged on detection</summary>

Both routes work around the same root cause -- the Rust runtime sets `SIGPIPE` to `SIG_IGN`, so a closed pipe surfaces as an `io::Error` instead of terminating the process ([rust-lang/rust#46016](https://github.com/rust-lang/rust/issues/46016)). Each tool met this independently and picked one of the two routes:

- **ripgrep** -- detection. It first added a `SIG_DFL` reset in 2017 as an explicit "temporary workaround" whose own comment named `Result`-based handling as the goal ([code](https://github.com/BurntSushi/ripgrep/blob/3065a8c9c839f7e722a73e8375f2e41c7e084737/src/main.rs#L334-L346), [PR #586](https://github.com/BurntSushi/ripgrep/pull/586), [issue #200](https://github.com/BurntSushi/ripgrep/issues/200)), then removed it after a refactor let the write error propagate ([current code](https://github.com/BurntSushi/ripgrep/blob/3fce3b5bb0236da2df6d99672afb8a719642eca7/crates/core/main.rs#L56-L61)).
- **bat** -- detection since 2018; the default error handler exits success on `BrokenPipe` ([code](https://github.com/sharkdp/bat/blob/2fb24157319b7c8477c2abec829264713c1ad3a6/src/error.rs#L60-L62), [commit](https://github.com/sharkdp/bat/commit/1f2bcf57baf92c83f8668f7908532d2b849e83ee), [issue #9](https://github.com/sharkdp/bat/issues/9)).
- **fd** -- detection since 2021; it suppresses the write error when the kind is `BrokenPipe` ([code](https://github.com/sharkdp/fd/blob/ee20f426ddf338ac7ead5c5f00ea49258005caaf/src/walk.rs#L253-L258), [PR #810](https://github.com/sharkdp/fd/pull/810), [issue #737](https://github.com/sharkdp/fd/issues/737)).
- **eza / exa** -- the `SIG_DFL` route ([eza code](https://github.com/eza-community/eza/blob/471bfbc7b03cbac8c738e8d9050edb06ee79132a/src/main.rs#L39-L42)). exa switched from detection to the reset in 2021 to silence the message ([exa commit](https://github.com/ogham/exa/blob/df4fb84ae19267b534beb94560da524fc72f436b/src/main.rs#L53-L55), citing [rust#46016](https://github.com/rust-lang/rust/issues/46016)); eza inherited the choice.

</details>

<details>
<summary>Why ignoring BrokenPipe is safe here (write-path survey)</summary>

The check treats a `BrokenPipe` anywhere in the error chain as success, so it is worth confirming no other context can raise one that reaches `exit_with_error`:

- stdout output (matches, diffs, JSON) is written on the main thread in `consume_items` and returned as `Result` [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/utils/worker.rs#L157)]; a `BrokenPipe` here is a closed reader -- the intended case.
- In-place rewrites (`--update-all`) write regular files, which cannot raise `BrokenPipe` [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/print/interactive_print.rs#L64)].
- `--stdin` reads input; a closed producer yields EOF, not `BrokenPipe` (a write-side error) [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/utils/worker.rs#L65-L66)].
- `$EDITOR` (interactive) is spawned with inherited stdio, so ast-grep never writes into a pipe to it; failures surface as `OpenEditor` [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/print/interactive_print.rs#L390-L402)].
- LSP runs on `tower_lsp_server::Server::serve`, which returns `()` and owns the transport, so client-disconnect errors never reach `exit_with_error` [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/lsp.rs#L31)].
- Domain errors carry an `ErrorContext` and exit through the branch above, so the `BrokenPipe` check only ever sees an un-contextualized stdout write [[src](https://github.com/ast-grep/ast-grep/blob/e8c70a7c7a6f8b73827e507b65201da8cea0ab79/crates/cli/src/utils/error_context.rs#L318-L332)].

The single assumption -- ast-grep's only pipe is its own stdout -- is recorded in a comment at the check. If a feature later writes into a child process's piped stdin, a genuine failure there would need distinguishing (an `io::Error` carries no descriptor identity), and the check should be revisited.

</details>

### Reproduction

The behavior is visible on any high-volume search in this repository whose output is truncated by a closed pipe:

```console
ast-grep run -p '$A' -l rust crates/cli/src/print | head -1
```

```console
ast-grep run -p 'let $V = $E' -l rust crates/cli/src | head -1
```

- Before this PR: the command exits 1 and prints `Error: Broken pipe (os error 32)` to stderr.
- In this PR: the command exits 0 and prints nothing to stderr; the matched output up to the closed pipe is unchanged.

### Work items

- [x] Treat a `BrokenPipe` in the error chain as normal termination in `exit_with_error` and return a success exit code
- [x] Add regression tests: a broken-pipe error exits successfully, and an unrelated io error still propagates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The command now exits quietly when output is interrupted by a broken pipe.
  * Other I/O errors continue to be reported normally.

* **Tests**
  * Added coverage for broken-pipe and standard I/O error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->