### PR TITLE
feat: highlight only the consumed pattern range

### DIFF
--- a/crates/cli/src/print/colored_print.rs
+++ b/crates/cli/src/print/colored_print.rs
@@ -1,4 +1,4 @@
-use super::{Diff, NodeMatch, PrintProcessor, Printer};
+use super::{Diff, MatchDisplay, NodeMatch, PrintProcessor, Printer};
 use crate::lang::SgLang;
 use crate::utils::DiffStyles;
 use anyhow::Result;
@@ -234,6 +234,10 @@ impl PrintProcessor<Buffer> for ColoredProcessor {
   }
 
   fn print_matches(&self, matches: Vec<NodeMatch>, path: &Path) -> Result<Buffer> {
+    self.print_pattern_matches(matches.into_iter().map(MatchDisplay::from).collect(), path)
+  }
+
+  fn print_pattern_matches(&self, matches: Vec<MatchDisplay>, path: &Path) -> Result<Buffer> {
     if self.heading.should_print() {
       print_matches_with_heading(matches, path, self)
     } else {
@@ -324,7 +328,7 @@ fn print_rule_title<W: WriteColor>(
 }
 
 fn print_matches_with_heading(
-  matches: Vec<NodeMatch>,
+  matches: Vec<MatchDisplay>,
   path: &Path,
   printer: &ColoredProcessor,
 ) -> Result<Buffer> {
@@ -337,7 +341,7 @@ fn print_matches_with_heading(
   let Some(first_match) = matches.next() else {
     return Ok(buffer);
   };
-  let source = first_match.root().get_text();
+  let source = first_match.node_match.root().get_text();
 
   let mut merger = MatchMerger::new(&first_match, printer.context);
 
@@ -352,7 +356,7 @@ fn print_matches_with_heading(
     let display = merger.display(&nm);
     // merge adjacent matches
     if let Some(last_end_offset) = merger.merge_adjacent(&nm) {
-      ret.push_str(&source[last_end_offset..nm.range().start]);
+      ret.push_str(&source[last_end_offset..nm.display_range.start]);
       styles.push_matched_to_ret(&mut ret, &display.matched)?;
       continue;
     }
@@ -374,7 +378,7 @@ fn print_matches_with_heading(
 }
 
 fn print_matches_with_prefix(
-  matches: Vec<NodeMatch>,
+  matches: Vec<MatchDisplay>,
   path: &Path,
   printer: &ColoredProcessor,
 ) -> Result<Buffer> {
@@ -387,7 +391,7 @@ fn print_matches_with_prefix(
   let Some(first_match) = matches.next() else {
     return Ok(buffer);
   };
-  let source = first_match.root().get_text();
+  let source = first_match.node_match.root().get_text();
 
   let mut merger = MatchMerger::new(&first_match, printer.context);
   let display = merger.display(&first_match);
@@ -400,7 +404,7 @@ fn print_matches_with_prefix(
     let display = merger.display(&nm);
     // merge adjacent matches
     if let Some(last_end_offset) = merger.merge_adjacent(&nm) {
-      ret.push_str(&source[last_end_offset..nm.range().start]);
+      ret.push_str(&source[last_end_offset..nm.display_range.start]);
       styles.push_matched_to_ret(&mut ret, &display.matched)?;
       continue;
     }

--- a/crates/cli/src/print/colored_print/match_merger.rs
+++ b/crates/cli/src/print/colored_print/match_merger.rs
@@ -1,4 +1,4 @@
-use super::NodeMatch;
+use super::MatchDisplay;
 use ast_grep_core::tree_sitter::DisplayContext;
 
 /// merging overlapping/adjacent matches
@@ -8,32 +8,36 @@ pub struct MatchMerger<'a> {
   pub last_end_line: usize,
   pub last_trailing: &'a str,
   pub last_end_offset: usize,
+  last_node_end_offset: usize,
   pub context: (u16, u16),
 }
 
 impl<'a> MatchMerger<'a> {
-  pub fn new(nm: &NodeMatch<'a>, (before, after): (u16, u16)) -> Self {
+  pub fn new(nm: &MatchDisplay<'a>, (before, after): (u16, u16)) -> Self {
     let display = nm.display_context(before as usize, after as usize);
     let last_start_line = display.start_line + 1;
-    let last_end_line = nm.end_pos().line() + 1;
+    let last_end_line = nm.display_end_line();
     let last_trailing = display.trailing;
-    let last_end_offset = nm.range().end;
+    let last_end_offset = nm.display_range.end;
+    let last_node_end_offset = nm.node_match.range().end;
     Self {
       last_start_line,
       last_end_line,
       last_end_offset,
+      last_node_end_offset,
       last_trailing,
       context: (before, after),
     }
   }
 
   // merge non-overlapping matches but start/end on the same line
-  pub fn merge_adjacent(&mut self, nm: &NodeMatch<'a>) -> Option<usize> {
+  pub fn merge_adjacent(&mut self, nm: &MatchDisplay<'a>) -> Option<usize> {
     let display = self.display(nm);
     let start_line = display.start_line;
     if start_line <= self.last_end_line + self.context.1 as usize {
       let last_end_offset = self.last_end_offset;
-      self.last_end_offset = nm.range().end;
+      self.last_end_offset = nm.display_range.end;
+      self.last_node_end_offset = nm.node_match.range().end;
       self.last_trailing = display.trailing;
       Some(last_end_offset)
     } else {
@@ -41,30 +45,31 @@ impl<'a> MatchMerger<'a> {
     }
   }
 
-  pub fn conclude_match(&mut self, nm: &NodeMatch<'a>) {
+  pub fn conclude_match(&mut self, nm: &MatchDisplay<'a>) {
     let display = self.display(nm);
     self.last_start_line = display.start_line + 1;
-    self.last_end_line = nm.end_pos().line() + 1;
+    self.last_end_line = nm.display_end_line();
     self.last_trailing = display.trailing;
-    self.last_end_offset = nm.range().end;
+    self.last_end_offset = nm.display_range.end;
+    self.last_node_end_offset = nm.node_match.range().end;
   }
 
   #[inline]
-  pub fn check_overlapping(&self, nm: &NodeMatch<'a>) -> bool {
-    let range = nm.range();
+  pub fn check_overlapping(&self, nm: &MatchDisplay<'a>) -> bool {
+    let range = nm.node_match.range();
 
     // merge overlapping matches.
-    // N.B. range.start == last_end_offset does not mean overlapping
-    if range.start < self.last_end_offset {
+    // N.B. range.start == last_node_end_offset does not mean overlapping
+    if range.start < self.last_node_end_offset {
       // guaranteed by pre-order
-      debug_assert!(range.end <= self.last_end_offset);
+      debug_assert!(range.end <= self.last_node_end_offset);
       true
     } else {
       false
     }
   }
 
-  pub fn display(&self, nm: &NodeMatch<'a>) -> DisplayContext<'a> {
+  pub fn display(&self, nm: &MatchDisplay<'a>) -> DisplayContext<'a> {
     let (before, after) = self.context;
     nm.display_context(before as usize, after as usize)
   }

--- a/crates/cli/src/print/interactive_print.rs
+++ b/crates/cli/src/print/interactive_print.rs
@@ -1,4 +1,4 @@
-use super::{ColoredPrinter, Diff, NodeMatch, PrintProcessor, Printer};
+use super::{ColoredPrinter, Diff, MatchDisplay, NodeMatch, PrintProcessor, Printer};
 use crate::lang::SgLang;
 use crate::utils::ErrorContext as EC;
 use crate::utils::{self, clear};
@@ -223,6 +223,20 @@ where
     Ok(InteractivePayload::Highlights(highlights))
   }
 
+  fn print_pattern_matches(&self, matches: Vec<MatchDisplay>, path: &Path) -> Result<Payload<P>> {
+    let Some(first_match) = matches.first() else {
+      return Ok(InteractivePayload::Nothing);
+    };
+    let first_line = first_match.node_match.start_pos().line();
+    let inner = self.inner.print_pattern_matches(matches, path)?;
+    let highlights = Highlights {
+      inner,
+      first_line,
+      path: path.to_path_buf(),
+    };
+    Ok(InteractivePayload::Highlights(highlights))
+  }
+
   fn print_diffs(&self, diffs: Vec<Diff>, path: &Path) -> Result<Payload<P>> {
     let old_source = get_old_source(diffs.first());
     let mut contents = Vec::with_capacity(diffs.len());
@@ -406,9 +420,10 @@ fn open_in_editor(path: &Path, start_line: usize) -> Result<()> {
 #[cfg(test)]
 mod test {
   use super::*;
+  use crate::print::{ColorArg, Heading};
   use ast_grep_config::{Fixer, GlobalRules, from_yaml_string};
   use ast_grep_core::tree_sitter::{StrDoc, Visitor};
-  use ast_grep_core::{AstGrep, Matcher};
+  use ast_grep_core::{AstGrep, Matcher, Pattern};
   use ast_grep_language::SupportLang;
 
   fn make_rule(rule: &str) -> RuleConfig<SgLang> {
@@ -451,6 +466,35 @@ language: TypeScript
       path: PathBuf::new(),
       contents,
     }
+  }
+
+  #[test]
+  fn test_pattern_match_display() {
+    let lang = SgLang::from(SupportLang::JavaScript);
+    let grep = AstGrep::new("let a = 1 /* comment */;", lang);
+    let pattern = Pattern::new("let a = 1", lang);
+    let matches = grep
+      .root()
+      .find_all(&pattern)
+      .map(|matched| MatchDisplay::generate(matched, &pattern))
+      .collect();
+    let printer = ColoredPrinter::stdout(ColorArg::Ansi).heading(Heading::Never);
+    let processor = InteractiveProcessor::<InnerPrinter> {
+      inner: printer.get_processor(),
+    };
+
+    let InteractivePayload::Highlights(highlights) = processor
+      .print_pattern_matches(matches, Path::new("test.js"))
+      .expect("pattern matches should print")
+    else {
+      panic!("pattern matches should produce highlights");
+    };
+    assert_eq!(highlights.path, Path::new("test.js"));
+    assert_eq!(highlights.first_line, 0);
+    assert_eq!(
+      highlights.inner.as_slice(),
+      b"test.js:1:\x1b[1;31mlet a = 1\x1b[0m /* comment */;\n"
+    );
   }
 
   #[test]

--- a/crates/cli/src/print/mod.rs
+++ b/crates/cli/src/print/mod.rs
@@ -6,7 +6,10 @@ mod json_print;
 
 use crate::lang::SgLang;
 use ast_grep_config::{Fixer, RuleConfig};
-use ast_grep_core::{Matcher, NodeMatch as SgNodeMatch, tree_sitter::StrDoc};
+use ast_grep_core::{
+  Matcher, NodeMatch as SgNodeMatch, Pattern,
+  tree_sitter::{DisplayContext, StrDoc},
+};
 
 use anyhow::Result;
 use clap::ValueEnum;
@@ -25,6 +28,70 @@ pub use json_print::{JSONPrinter, JsonStyle};
 
 type NodeMatch<'a> = SgNodeMatch<'a, StrDoc<SgLang>>;
 
+/// A matched AST node and the source range consumed by its CLI pattern.
+#[derive(Clone)]
+pub struct MatchDisplay<'n> {
+  node_match: NodeMatch<'n>,
+  display_range: std::ops::Range<usize>,
+}
+
+impl<'n> MatchDisplay<'n> {
+  pub(crate) fn generate(node_match: NodeMatch<'n>, pattern: &Pattern) -> Self {
+    let node_range = node_match.range();
+    let end = pattern
+      .get_match_len(node_match.get_node().clone())
+      .map(|len| node_range.start.saturating_add(len).min(node_range.end))
+      .unwrap_or(node_range.end);
+    Self {
+      node_match,
+      display_range: node_range.start..end,
+    }
+  }
+
+  fn display_context(&self, before: usize, after: usize) -> DisplayContext<'n> {
+    let source = self.node_match.root().get_text();
+    let bytes = source.as_bytes();
+    let mut trailing = self.display_range.end;
+    let mut lines_after = after + 1;
+    while trailing < bytes.len() {
+      if bytes[trailing] == b'\n' {
+        lines_after -= 1;
+        if lines_after == 0 {
+          break;
+        }
+      }
+      trailing += 1;
+    }
+    let node_display = self.node_match.display_context(before, 0);
+    DisplayContext {
+      matched: Cow::Borrowed(&source[self.display_range.clone()]),
+      leading: node_display.leading,
+      trailing: &source[self.display_range.end..trailing],
+      start_line: node_display.start_line,
+    }
+  }
+
+  fn display_end_line(&self) -> usize {
+    let source = self.node_match.root().get_text();
+    self.node_match.start_pos().line()
+      + source[self.display_range.clone()]
+        .bytes()
+        .filter(|&byte| byte == b'\n')
+        .count()
+      + 1
+  }
+}
+
+impl<'n> From<NodeMatch<'n>> for MatchDisplay<'n> {
+  fn from(node_match: NodeMatch<'n>) -> Self {
+    let display_range = node_match.range();
+    Self {
+      node_match,
+      display_range,
+    }
+  }
+}
+
 /// A trait to process nodeMatches to diff/match output
 /// it must be Send + 'static to be shared in worker thread
 pub trait PrintProcessor<Output>: Send + Sync + 'static {
@@ -35,6 +102,13 @@ pub trait PrintProcessor<Output>: Send + Sync + 'static {
     rule: &RuleConfig<SgLang>,
   ) -> Result<Output>;
   fn print_matches(&self, matches: Vec<NodeMatch>, path: &Path) -> Result<Output>;
+  fn print_pattern_matches(&self, matches: Vec<MatchDisplay>, path: &Path) -> Result<Output> {
+    let matches = matches
+      .into_iter()
+      .map(|matched| matched.node_match)
+      .collect();
+    self.print_matches(matches, path)
+  }
   fn print_diffs(&self, diffs: Vec<Diff>, path: &Path) -> Result<Output>;
   fn print_rule_diffs(
     &self,

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use ast_grep_config::{Fixer, Rule, parse_selector};
-use ast_grep_core::{MatchStrictness, Matcher, Pattern};
+use ast_grep_core::{MatchStrictness, Pattern};
 use ast_grep_language::{Language, LanguageExt};
 use clap::{Args, Parser, ValueEnum, builder::PossibleValue};
 use ignore::WalkParallel;
@@ -11,8 +11,8 @@ use ignore::WalkParallel;
 use crate::config::ProjectConfig;
 use crate::lang::SgLang;
 use crate::print::{
-  ColoredPrinter, Diff, FileNamePrinter, Heading, InteractivePrinter, JSONPrinter, PrintProcessor,
-  Printer,
+  ColoredPrinter, Diff, FileNamePrinter, Heading, InteractivePrinter, JSONPrinter, MatchDisplay,
+  PrintProcessor, Printer,
 };
 use crate::utils::ErrorContext as EC;
 use crate::utils::{ContextArgs, InputArgs, MatchUnit, OutputArgs, filter_file_pattern};
@@ -407,6 +407,9 @@ impl StdInWorker for RunWithSpecificLang {
     let processed = if let Some(rewrite) = rewrite {
       let diffs = matches.map(|m| Diff::generate(m, &self.rule, rewrite));
       processor.print_diffs(diffs.collect(), path)?
+    } else if let Rule::Pattern(pattern) = &self.rule {
+      let matches = matches.map(|m| MatchDisplay::generate(m, pattern));
+      processor.print_pattern_matches(matches.collect(), path)?
     } else {
       processor.print_matches(matches.collect(), path)?
     };
@@ -415,7 +418,7 @@ impl StdInWorker for RunWithSpecificLang {
 }
 fn match_one_file<T, P: PrintProcessor<T>>(
   processor: &P,
-  match_unit: &MatchUnit<impl Matcher>,
+  match_unit: &MatchUnit<&Rule>,
   rewrite: &Option<Fixer>,
 ) -> Result<Option<T>> {
   let MatchUnit {
@@ -432,6 +435,9 @@ fn match_one_file<T, P: PrintProcessor<T>>(
   let ret = if let Some(rewrite) = rewrite {
     let diffs = matches.map(|m| Diff::generate(m, matcher, rewrite));
     processor.print_diffs(diffs.collect(), path)?
+  } else if let Rule::Pattern(pattern) = matcher {
+    let matches = matches.map(|m| MatchDisplay::generate(m, pattern));
+    processor.print_pattern_matches(matches.collect(), path)?
   } else {
     processor.print_matches(matches.collect(), path)?
   };

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -33,6 +33,99 @@ fn test_simple_specific_lang() -> Result<()> {
 }
 
 #[test]
+fn test_pattern_output_highlights_only_consumed_range() -> Result<()> {
+  let source = "let a = 123 /* comment */;";
+  let highlighted = "\x1b[1;31mlet a = 123\x1b[0m /* comment */;";
+  for heading in ["always", "never"] {
+    Command::new(cargo_bin!())
+      .args([
+        "run",
+        "--stdin",
+        "-p",
+        "let a = 123",
+        "-l",
+        "js",
+        "--heading",
+        heading,
+        "--color",
+        "ansi",
+      ])
+      .write_stdin(source)
+      .assert()
+      .success()
+      .stdout(contains(highlighted));
+  }
+  Ok(())
+}
+
+#[test]
+fn test_pattern_output_uses_consumed_range_for_context() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args([
+      "run",
+      "--stdin",
+      "-p",
+      "struct $A: $B",
+      "-l",
+      "cpp",
+      "--heading",
+      "never",
+      "--color",
+      "ansi",
+    ])
+    .write_stdin("struct A: B {\n  int value;\n};")
+    .assert()
+    .success()
+    .stdout(contains("\x1b[1;31mstruct A: B\x1b[0m {"))
+    .stdout(contains("int value").not());
+  Ok(())
+}
+
+#[test]
+fn test_pattern_output_merges_consumed_ranges() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args([
+      "run",
+      "--stdin",
+      "-p",
+      "let $A = $B",
+      "-l",
+      "js",
+      "--heading",
+      "never",
+      "--color",
+      "ansi",
+    ])
+    .write_stdin("let a = 1 /* first */; let b = 2 /* second */;")
+    .assert()
+    .success()
+    .stdout(
+      "STDIN:1:\x1b[1;31mlet a = 1\x1b[0m /* first */; \x1b[1;31mlet b = 2\x1b[0m /* second */;\n",
+    );
+  Ok(())
+}
+
+#[test]
+fn test_pattern_json_keeps_full_node_range() -> Result<()> {
+  Command::new(cargo_bin!())
+    .args([
+      "run",
+      "--stdin",
+      "-p",
+      "let a = 123",
+      "-l",
+      "js",
+      "--json=compact",
+    ])
+    .write_stdin("let a = 123 /* comment */;")
+    .assert()
+    .success()
+    .stdout(contains(r#""text":"let a = 123 /* comment */;""#))
+    .stdout(contains(r#""end":26"#));
+  Ok(())
+}
+
+#[test]
 fn test_kind_selector() -> Result<()> {
   let dir = create_test_files([("a.js", "test(123)\nconst test = 456")])?;
   Command::new(cargo_bin!())

--- a/crates/core/src/matcher.rs
+++ b/crates/core/src/matcher.rs
@@ -41,7 +41,7 @@ pub trait Matcher {
   }
 
   /// get_match_len will skip trailing anonymous child node to exclude punctuation.
-  // This is not included in NodeMatch since it is only used in replace
+  // This is computed by the matcher because NodeMatch only stores the matched AST node.
   fn get_match_len<D: Doc>(&self, _node: Node<'_, D>) -> Option<usize> {
     None
   }


### PR DESCRIPTION
## Summary

- Use a pattern's actual match end when highlighting colored CLI output.
- Preserve the full AST node range for overlap detection, JSON output, and rewrites.
- Cover heading and prefix output, multiline context, adjacent matches, JSON compatibility, and interactive output.

## Motivation

A pattern can match an AST node that contains trailing syntax not consumed by the pattern. For example, `let a = 123` matches the full JavaScript lexical declaration in `let a = 123 /* comment */;`. Colored output currently highlights the comment and semicolon as part of the match.

This change carries a separate display range for CLI patterns. The colored printer uses that range for highlighting and context, while the original `NodeMatch` remains available wherever the full AST node is part of the existing output contract.

Closes #1795.

## Testing

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features --workspace --release --locked -- -D clippy::all`
- `cargo build --release`
- `cargo llvm-cov --all-features --workspace --lcov --output-path /tmp/ast-grep-1795-lcov.info`
- Release-binary smoke tests for pattern search, rewrite output, configuration-based scanning, and LSP startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added precise highlighting for source text consumed by pattern matches.
  * Pattern matches now display relevant source context, file paths, and match locations in interactive output.
  * Adjacent consumed ranges are merged for clearer highlighting.

* **Bug Fixes**
  * Improved handling of overlapping and adjacent pattern matches.
  * Preserved complete matched-node ranges in compact JSON output.
  * Added support for retaining comments and correct ANSI formatting in highlighted results.

* **Tests**
  * Expanded coverage for pattern highlighting, context handling, range merging, and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->