### PR TITLE
feat(scan): add --severity threshold to filter findings by minimum level

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -26,6 +26,41 @@ use crate::utils::{Items, PathWorker, StdInWorker, Worker};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+/// Minimum severity level accepted by the `--severity` reporting threshold.
+///
+/// Variants are ordered from least to most severe so that the derived `Ord`
+/// yields `Hint < Info < Warning < Error`.
+#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum SeverityFilter {
+  Hint,
+  Info,
+  Warning,
+  Error,
+}
+
+/// Map a rule's `Severity` to its reporting rank.
+///
+/// `Severity::Off` has no rank because disabled rules never produce findings.
+fn severity_rank(severity: &Severity) -> Option<SeverityFilter> {
+  match severity {
+    Severity::Hint => Some(SeverityFilter::Hint),
+    Severity::Info => Some(SeverityFilter::Info),
+    Severity::Warning => Some(SeverityFilter::Warning),
+    Severity::Error => Some(SeverityFilter::Error),
+    Severity::Off => None,
+  }
+}
+
+/// Whether a rule's findings should be reported under an optional minimum-severity threshold.
+///
+/// With no threshold every finding is reported, preserving the default behavior.
+fn passes_severity_filter(severity: &Severity, threshold: Option<SeverityFilter>) -> bool {
+  match threshold {
+    None => true,
+    Some(min) => matches!(severity_rank(severity), Some(rank) if rank >= min),
+  }
+}
+
 #[derive(Args)]
 pub struct ScanArg {
   /// Scan the codebase with the single rule located at the path RULE_FILE.
@@ -76,6 +111,16 @@ pub struct ScanArg {
   /// Useful for big codebase to fail scan/search fast.
   #[clap(long, conflicts_with = "interactive", value_name = "NUM")]
   max_results: Option<u16>,
+
+  /// Only report findings from rules at or above this severity LEVEL.
+  ///
+  /// LEVEL is one of hint, info, warning or error, in increasing severity.
+  /// Findings from rules whose severity is below the threshold are not printed
+  /// and do not contribute to the final tally or the exit code. This is a
+  /// minimum-severity threshold, mirroring ShellCheck's `--severity` and
+  /// Biome's `--diagnostic-level`. By default every finding is reported.
+  #[clap(long, value_name = "LEVEL")]
+  severity: Option<SeverityFilter>,
 }
 
 impl ScanArg {
@@ -267,6 +312,9 @@ impl PathWorker for ScanWithConfig {
         ret.push(processed);
       }
       for (rule, matches) in scanned.matches {
+        if !passes_severity_filter(&rule.severity, self.arg.severity) {
+          continue;
+        }
         // Atomically reserve slots for matches, truncating if needed
         let matches: Vec<_> = if let Some(counter) = &self.max_item_counter {
           let wanted = matches.len();
@@ -307,6 +355,7 @@ struct ScanStdin {
   // TODO: remove this
   error_count: AtomicUsize,
   max_diagnostics_shown: Option<usize>,
+  severity: Option<SeverityFilter>,
 }
 impl ScanStdin {
   fn try_new(arg: ScanArg) -> Result<Self> {
@@ -325,6 +374,7 @@ impl ScanStdin {
       rules,
       error_count: AtomicUsize::new(0),
       max_diagnostics_shown: arg.max_results.map(usize::from),
+      severity: arg.severity,
     })
   }
 }
@@ -367,6 +417,9 @@ impl StdInWorker for ScanStdin {
     let mut diagnostic_count = 0usize;
     let mut ret = vec![];
     for (rule, matches) in scanned.matches {
+      if !passes_severity_filter(&rule.severity, self.severity) {
+        continue;
+      }
       // Truncate matches if max_diagnostics_shown is set
       let matches: Vec<_> = if let Some(max) = self.max_diagnostics_shown {
         let remaining = max.saturating_sub(diagnostic_count);
@@ -497,6 +550,7 @@ rule:
       },
       format: None,
       max_results: None,
+      severity: None,
     }
   }
 
@@ -514,6 +568,42 @@ rule:
     let project_config = ProjectConfig::setup(Some(dir.path().join("sgconfig.yml"))).unwrap();
     let arg = default_scan_arg();
     assert!(run_with_config(arg, project_config).is_ok());
+  }
+
+  #[test]
+  fn test_passes_severity_filter() {
+    use Severity::*;
+    // No threshold reports everything, including Off (which is filtered elsewhere).
+    for sev in [Hint, Info, Warning, Error, Off] {
+      assert!(passes_severity_filter(&sev, None));
+    }
+    // A threshold keeps its level and everything more severe.
+    assert!(passes_severity_filter(
+      &Error,
+      Some(SeverityFilter::Warning)
+    ));
+    assert!(passes_severity_filter(
+      &Warning,
+      Some(SeverityFilter::Warning)
+    ));
+    assert!(!passes_severity_filter(
+      &Info,
+      Some(SeverityFilter::Warning)
+    ));
+    assert!(!passes_severity_filter(
+      &Hint,
+      Some(SeverityFilter::Warning)
+    ));
+    // The lowest threshold keeps every real severity but never Off.
+    assert!(passes_severity_filter(&Hint, Some(SeverityFilter::Hint)));
+    assert!(passes_severity_filter(&Error, Some(SeverityFilter::Hint)));
+    assert!(!passes_severity_filter(&Off, Some(SeverityFilter::Hint)));
+    // The highest threshold keeps only errors.
+    assert!(passes_severity_filter(&Error, Some(SeverityFilter::Error)));
+    assert!(!passes_severity_filter(
+      &Warning,
+      Some(SeverityFilter::Error)
+    ));
   }
 
   #[test]

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -163,6 +163,51 @@ fn test_sg_scan_multiple_rules_in_one_file() -> Result<()> {
   Ok(())
 }
 
+const SEVERITY_RULES: &str = "
+id: warn-rule
+severity: warning
+language: TypeScript
+rule: { pattern: Some($A) }
+---
+id: hint-rule
+severity: hint
+language: TypeScript
+rule: { pattern: None }
+";
+
+#[test]
+fn test_sg_scan_severity_threshold() -> Result<()> {
+  let dir = create_test_files([
+    ("rule.yml", SEVERITY_RULES),
+    ("test.ts", "Some(123) + None"),
+  ])?;
+  // Without the flag both rules are reported.
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["scan", "-r", "rule.yml", "--color", "never"])
+    .assert()
+    .success()
+    .stdout(contains("warn-rule"))
+    .stdout(contains("hint-rule"));
+  // `--severity warning` keeps warnings but suppresses the lower-severity hint.
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args([
+      "scan",
+      "-r",
+      "rule.yml",
+      "--color",
+      "never",
+      "--severity",
+      "warning",
+    ])
+    .assert()
+    .success()
+    .stdout(contains("warn-rule"))
+    .stdout(contains("hint-rule").not());
+  Ok(())
+}
+
 // see #517, #668
 #[test]
 fn test_sg_scan_py_empty_text() -> Result<()> {


### PR DESCRIPTION
## What

Adds `--severity=<hint|info|warning|error>` to `sg scan`: a minimum-severity **reporting threshold**. Findings from rules whose severity is below the threshold are not printed and do not contribute to the final tally or the exit code.

```bash
sg scan --severity=error     # only errors
sg scan --severity=warning   # warnings + errors
sg scan --severity=info      # info + warnings + errors
sg scan --severity=hint      # everything (current default)
```

Default behavior is unchanged (no flag = report everything).

## Why

Closes #2720. Today `sg scan` reports every finding regardless of severity, and there's no clean way to say "run all rules, but only surface errors (or errors + warnings)" in CI:

- `--error/--warning/--info/--hint` **override** a rule's severity, they don't filter output.
- `--off=RULE_ID` disables rules entirely and requires enumerating every id.
- `--filter=REGEX` filters by rule **id**, not severity.
- `--max-results N` limits **count**, not severity.

The only workaround is piping output through `grep`, which is fragile and format-dependent.

The semantics follow the convention you highlighted in the issue: ShellCheck's `--severity` and Biome's `--diagnostic-level` (minimum severity considered). The threshold is applied on the shared scan path, so text, JSON, SARIF and GitHub reporters all honor it consistently, and the existing exit-code logic stays correct because suppressed findings never increment the error count.

## How it's distinct from `--error/--warning/...`

| Flag | Effect |
| --- | --- |
| `--error=RULE_ID` etc. | Mutates a rule's severity |
| `--off=RULE_ID` | Removes a rule entirely |
| `--filter=REGEX` | Selects rules by id regex |
| `--severity=LEVEL` (this PR) | Filters output/tally by minimum severity, rules untouched |

## Implementation

- New `--severity` flag on `ScanArg`, parsed as a small `clap::ValueEnum` (`hint < info < warning < error`).
- A `passes_severity_filter` helper gates each `(rule, matches)` pair in both the path-based (`ScanWithConfig`) and stdin (`ScanStdin`) scan loops, before the `--max-results` accounting and the error tally.
- `Severity::Off` never produces findings, so it has no rank.

I chose the simplest, uniform interpretation (a rule below the threshold is not reported anywhere) rather than the "report-threshold but keep everything in JSON/SARIF" variant discussed in the thread. Happy to scope it to text/exit-code-only if you'd prefer that direction.

## Tests

- Unit test for `passes_severity_filter` covering every threshold/severity combination.
- Integration test `test_sg_scan_severity_threshold` asserting a `hint` rule is suppressed under `--severity warning` while a `warning` rule is still reported.
- Full `ast-grep` CLI suite passes; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--severity` option for scan commands.
  * Set a minimum severity threshold to show only relevant findings.
  * Applied severity filtering consistently to filesystem and standard-input scans.
  * Filtered findings from displayed results, diagnostic counts, and error-based exit codes.
* **Tests**
  * Added coverage confirming default behavior and warning-level filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->