### PR TITLE
feat(outline): add Markdown heading support

### DIFF
--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -138,6 +138,40 @@ export function greet(name: string) {
 }
 
 #[test]
+fn test_outline_markdown_headings() -> Result<()> {
+  let dir = create_test_files([(
+    "guide.md",
+    r#"# Introduction
+
+Usage
+=====
+
+###### Details
+
+References
+----------
+
+```markdown
+# Not a heading
+```
+"#,
+  )])?;
+
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args(["outline", "guide.md", "--json=compact"])
+    .assert()
+    .success()
+    .stdout(contains(r#""language":"Markdown""#))
+    .stdout(contains(r#""name":"Introduction""#))
+    .stdout(contains(r#""name":"Usage""#))
+    .stdout(contains(r#""name":"Details""#))
+    .stdout(contains(r#""name":"References""#))
+    .stdout(contains(r#""name":"Not a heading""#).not());
+  Ok(())
+}
+
+#[test]
 fn test_rewrite_js_in_html() -> Result<()> {
   let dir = create_test_files([("a.html", "<script>alert(1)</script>")])?;
   Command::new(cargo_bin!())

--- a/crates/outline/src/default_rule.rs
+++ b/crates/outline/src/default_rule.rs
@@ -30,6 +30,8 @@ pub const DEFAULT_OUTLINE_RULES: &str = concat!(
   include_str!("default_rules/ruby.yml"),
   "\n---\n",
   include_str!("default_rules/php.yml"),
+  "\n---\n",
+  include_str!("default_rules/markdown.yml"),
 );
 
 #[cfg(test)]

--- a/crates/outline/src/default_rules/markdown.yml
+++ b/crates/outline/src/default_rules/markdown.yml
@@ -1,0 +1,31 @@
+id: markdown-atx-heading
+language: Markdown
+role: item
+symbolType: module
+rule:
+  kind: atx_heading
+  has:
+    field: heading_content
+    pattern:
+      context: '# $NAME'
+      selector: inline
+name: '$NAME'
+---
+id: markdown-setext-heading
+language: Markdown
+role: item
+symbolType: module
+rule:
+  kind: setext_heading
+  has:
+    field: heading_content
+    pattern:
+      context: '$NAME'
+      selector: paragraph
+transform:
+  TITLE:
+    replace:
+      source: $NAME
+      replace: '\r?\n$'
+      by: ''
+name: '$TITLE'

--- a/crates/outline/tests/default_outline_rules.rs
+++ b/crates/outline/tests/default_outline_rules.rs
@@ -20,6 +20,7 @@ fn bundled_outline_rules_compile_for_every_language() {
     SupportLang::C,
     SupportLang::Ruby,
     SupportLang::Php,
+    SupportLang::Markdown,
   ];
 
   for language in OUTLINE_LANGUAGES {

--- a/crates/outline/tests/fixtures/markdown_headings.md
+++ b/crates/outline/tests/fixtures/markdown_headings.md
@@ -1,0 +1,18 @@
+# First
+## Second
+### Third
+#### Fourth
+##### Fifth
+###### Sixth
+
+Setext One
+==========
+
+Setext Two
+----------
+
+```markdown
+# Not a heading
+Fake setext
+===========
+```

--- a/crates/outline/tests/markdown_outline_rules.rs
+++ b/crates/outline/tests/markdown_outline_rules.rs
@@ -1,0 +1,24 @@
+use ast_grep_language::SupportLang;
+
+#[allow(dead_code)]
+mod common;
+
+#[test]
+fn markdown_rules_extract_atx_and_setext_headings() {
+  const RULES: &str = include_str!("../src/default_rules/markdown.yml");
+  common::assert_outline_snapshot(
+    SupportLang::Markdown,
+    RULES,
+    include_str!("fixtures/markdown_headings.md"),
+    r#"
+- Module item exported First
+- Module item exported Second
+- Module item exported Third
+- Module item exported Fourth
+- Module item exported Fifth
+- Module item exported Sixth
+- Module item exported Setext One
+- Module item exported Setext Two
+"#,
+  );
+}


### PR DESCRIPTION
## Summary

- bundle default Markdown outline extractors for ATX and setext headings
- support every ATX level and both setext levels without depending on underline length
- add rule-level and end-to-end CLI regression coverage, including fenced-code exclusions

## Testing

- `cargo test -p ast-grep-outline`
- `cargo test -p ast-grep --test run_test`
- `cargo clippy -p ast-grep-outline -p ast-grep --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown support to the outline command.
  * Markdown outlines now recognize ATX and setext headings across heading levels.
  * Heading-like text inside fenced code blocks is correctly excluded.

* **Tests**
  * Added coverage validating Markdown heading extraction and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->