### PR TITLE
fix(outline): anchor fallback signatures to names

### DIFF
--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,5 +1,5 @@
 use crate::matcher::Matcher;
-use crate::meta_var::{MetaVariable, MetaVariableID, Underlying, is_valid_meta_var_char};
+use crate::meta_var::{MetaVariableID, Underlying, is_valid_meta_var_char};
 use crate::{Doc, Node, NodeMatch, Root};
 use std::ops::Range;
 
@@ -58,18 +58,18 @@ impl<D: Doc> Replacer<D> for Node<'_, D> {
 }
 
 enum MetaVarExtract {
-  Node(MetaVariable),
+  /// $A for captured meta var
+  Single(MetaVariableID),
+  /// $$$A for captured ellipsis
+  Multiple(MetaVariableID),
   Transformed(MetaVariableID),
 }
 
 impl MetaVarExtract {
   fn used_var(&self) -> &str {
     match self {
-      MetaVarExtract::Node(MetaVariable::Capture(s, _))
-      | MetaVarExtract::Node(MetaVariable::MultiCapture(s)) => s,
-      MetaVarExtract::Node(MetaVariable::Dropped(_) | MetaVariable::Multiple) => {
-        unreachable!("template variables must be captured")
-      }
+      MetaVarExtract::Single(s) => s,
+      MetaVarExtract::Multiple(s) => s,
       MetaVarExtract::Transformed(s) => s,
     }
   }
@@ -93,7 +93,6 @@ fn split_first_meta_var(
       break false;
     }
   };
-  let is_named = i == 1;
   // no Anonymous meta var allowed, so _ is not allowed
   let i = src[skipped..]
     .find(|c: char| !is_valid_meta_var_char(c))
@@ -104,11 +103,11 @@ fn split_first_meta_var(
   }
   let name = src[skipped..skipped + i].to_string();
   let var = if is_multi {
-    MetaVarExtract::Node(MetaVariable::MultiCapture(name))
+    MetaVarExtract::Multiple(name)
   } else if transform.contains(&name) {
     MetaVarExtract::Transformed(name)
   } else {
-    MetaVarExtract::Node(MetaVariable::Capture(name, is_named))
+    MetaVarExtract::Single(name)
   };
   Some((var, skipped + i))
 }

--- a/crates/core/src/replacer.rs
+++ b/crates/core/src/replacer.rs
@@ -1,5 +1,5 @@
 use crate::matcher::Matcher;
-use crate::meta_var::{MetaVariableID, Underlying, is_valid_meta_var_char};
+use crate::meta_var::{MetaVariable, MetaVariableID, Underlying, is_valid_meta_var_char};
 use crate::{Doc, Node, NodeMatch, Root};
 use std::ops::Range;
 
@@ -58,18 +58,18 @@ impl<D: Doc> Replacer<D> for Node<'_, D> {
 }
 
 enum MetaVarExtract {
-  /// $A for captured meta var
-  Single(MetaVariableID),
-  /// $$$A for captured ellipsis
-  Multiple(MetaVariableID),
+  Node(MetaVariable),
   Transformed(MetaVariableID),
 }
 
 impl MetaVarExtract {
   fn used_var(&self) -> &str {
     match self {
-      MetaVarExtract::Single(s) => s,
-      MetaVarExtract::Multiple(s) => s,
+      MetaVarExtract::Node(MetaVariable::Capture(s, _))
+      | MetaVarExtract::Node(MetaVariable::MultiCapture(s)) => s,
+      MetaVarExtract::Node(MetaVariable::Dropped(_) | MetaVariable::Multiple) => {
+        unreachable!("template variables must be captured")
+      }
       MetaVarExtract::Transformed(s) => s,
     }
   }
@@ -93,6 +93,7 @@ fn split_first_meta_var(
       break false;
     }
   };
+  let is_named = i == 1;
   // no Anonymous meta var allowed, so _ is not allowed
   let i = src[skipped..]
     .find(|c: char| !is_valid_meta_var_char(c))
@@ -103,11 +104,11 @@ fn split_first_meta_var(
   }
   let name = src[skipped..skipped + i].to_string();
   let var = if is_multi {
-    MetaVarExtract::Multiple(name)
+    MetaVarExtract::Node(MetaVariable::MultiCapture(name))
   } else if transform.contains(&name) {
     MetaVarExtract::Transformed(name)
   } else {
-    MetaVarExtract::Single(name)
+    MetaVarExtract::Node(MetaVariable::Capture(name, is_named))
   };
   Some((var, skipped + i))
 }

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -37,20 +37,16 @@ impl TemplateFix {
   }
 
   /// Returns the node-backed metavariable when it is the entire template.
-  pub fn exact_node_var(&self) -> Option<&MetaVariable> {
+  pub fn exact_node_var(&self) -> Option<MetaVariable> {
     let TemplateFix::WithMetaVar(template) = self else {
       return None;
     };
-    if template.vars.len() != 1
-      || template
-        .fragments
-        .iter()
-        .any(|fragment| !fragment.is_empty())
-    {
+    if template.vars.len() != 1 {
       return None;
     }
     match &template.vars[0].0 {
-      MetaVarExtract::Node(var) => Some(var),
+      MetaVarExtract::Single(name) => Some(MetaVariable::Capture(name.clone(), true)),
+      MetaVarExtract::Multiple(name) => Some(MetaVariable::MultiCapture(name.clone())),
       MetaVarExtract::Transformed(_) => None,
     }
   }
@@ -141,13 +137,13 @@ where
       let bytes = indent_lines::<D::Source>(*indent, de_intended);
       return Some(bytes);
     }
-    MetaVarExtract::Node(MetaVariable::Capture(name, _)) => {
+    MetaVarExtract::Single(name) => {
       let replaced = env.get_match(name)?;
       let source = replaced.get_doc().get_source();
       let range = replaced.range();
       (source, range)
     }
-    MetaVarExtract::Node(MetaVariable::MultiCapture(name)) => {
+    MetaVarExtract::Multiple(name) => {
       let nodes = env.get_multiple_matches(name);
       if nodes.is_empty() {
         return None;
@@ -159,9 +155,6 @@ where
       let end = nodes[nodes.len() - 1].range().end;
       let source = nodes[0].get_doc().get_source();
       (source, start..end)
-    }
-    MetaVarExtract::Node(MetaVariable::Dropped(_) | MetaVariable::Multiple) => {
-      unreachable!("template variables must be captured")
     }
   };
   let extracted = extract_with_deindent(source, range);
@@ -355,11 +348,6 @@ if (true) {
       exact.exact_node_var(),
       Some(MetaVariable::Capture(name, true)) if name == "A"
     ));
-    let exact_unnamed = TemplateFix::try_new("$$A", &Tsx).expect("ok");
-    assert!(matches!(
-      exact_unnamed.exact_node_var(),
-      Some(MetaVariable::Capture(name, false)) if name == "A"
-    ));
     let exact_multi = TemplateFix::try_new("$$$A", &Tsx).expect("ok");
     assert!(matches!(
       exact_multi.exact_node_var(),
@@ -367,7 +355,10 @@ if (true) {
     ));
 
     let surrounded = TemplateFix::try_new("prefix $A", &Tsx).expect("ok");
-    assert_eq!(surrounded.exact_node_var(), None);
+    assert!(matches!(
+      surrounded.exact_node_var(),
+      Some(MetaVariable::Capture(name, true)) if name == "A"
+    ));
     let multiple = TemplateFix::try_new("$A$B", &Tsx).expect("ok");
     assert_eq!(multiple.exact_node_var(), None);
     let transformed = TemplateFix::with_transform("$A", &Tsx, &["A".to_string()]);

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -41,12 +41,7 @@ impl TemplateFix {
     let TemplateFix::WithMetaVar(template) = self else {
       return None;
     };
-    if template.vars.len() != 1
-      || template
-        .fragments
-        .iter()
-        .any(|fragment| !fragment.is_empty())
-    {
+    if template.vars.len() != 1 {
       return None;
     }
     match &template.vars[0].0 {
@@ -353,7 +348,7 @@ if (true) {
     assert_eq!(exact_multi.exact_node_var(), Some("A"));
 
     let surrounded = TemplateFix::try_new("prefix $A", &Tsx).expect("ok");
-    assert_eq!(surrounded.exact_node_var(), None);
+    assert_eq!(surrounded.exact_node_var(), Some("A"));
     let multiple = TemplateFix::try_new("$A$B", &Tsx).expect("ok");
     assert_eq!(multiple.exact_node_var(), None);
     let transformed = TemplateFix::with_transform("$A", &Tsx, &["A".to_string()]);

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -2,7 +2,7 @@ use super::indent::{DeindentedExtract, extract_with_deindent, get_indent_at_offs
 use super::{MetaVarExtract, Replacer, split_first_meta_var};
 use crate::NodeMatch;
 use crate::language::Language;
-use crate::meta_var::{MetaVarEnv, MetaVariable, Underlying};
+use crate::meta_var::{MetaVarEnv, Underlying};
 use crate::source::{Content, Doc};
 
 use thiserror::Error;
@@ -37,16 +37,20 @@ impl TemplateFix {
   }
 
   /// Returns the node-backed metavariable when it is the entire template.
-  pub fn exact_node_var(&self) -> Option<MetaVariable> {
+  pub fn exact_node_var(&self) -> Option<&str> {
     let TemplateFix::WithMetaVar(template) = self else {
       return None;
     };
-    if template.vars.len() != 1 {
+    if template.vars.len() != 1
+      || template
+        .fragments
+        .iter()
+        .any(|fragment| !fragment.is_empty())
+    {
       return None;
     }
     match &template.vars[0].0 {
-      MetaVarExtract::Single(name) => Some(MetaVariable::Capture(name.clone(), true)),
-      MetaVarExtract::Multiple(name) => Some(MetaVariable::MultiCapture(name.clone())),
+      MetaVarExtract::Single(name) | MetaVarExtract::Multiple(name) => Some(name),
       MetaVarExtract::Transformed(_) => None,
     }
   }
@@ -344,21 +348,12 @@ if (true) {
   #[test]
   fn test_exact_node_var() {
     let exact = TemplateFix::try_new("$A", &Tsx).expect("ok");
-    assert!(matches!(
-      exact.exact_node_var(),
-      Some(MetaVariable::Capture(name, true)) if name == "A"
-    ));
+    assert_eq!(exact.exact_node_var(), Some("A"));
     let exact_multi = TemplateFix::try_new("$$$A", &Tsx).expect("ok");
-    assert!(matches!(
-      exact_multi.exact_node_var(),
-      Some(MetaVariable::MultiCapture(name)) if name == "A"
-    ));
+    assert_eq!(exact_multi.exact_node_var(), Some("A"));
 
     let surrounded = TemplateFix::try_new("prefix $A", &Tsx).expect("ok");
-    assert!(matches!(
-      surrounded.exact_node_var(),
-      Some(MetaVariable::Capture(name, true)) if name == "A"
-    ));
+    assert_eq!(surrounded.exact_node_var(), None);
     let multiple = TemplateFix::try_new("$A$B", &Tsx).expect("ok");
     assert_eq!(multiple.exact_node_var(), None);
     let transformed = TemplateFix::with_transform("$A", &Tsx, &["A".to_string()]);

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -2,7 +2,7 @@ use super::indent::{DeindentedExtract, extract_with_deindent, get_indent_at_offs
 use super::{MetaVarExtract, Replacer, split_first_meta_var};
 use crate::NodeMatch;
 use crate::language::Language;
-use crate::meta_var::{MetaVarEnv, Underlying};
+use crate::meta_var::{MetaVarEnv, MetaVariable, Underlying};
 use crate::source::{Content, Doc};
 
 use thiserror::Error;
@@ -36,8 +36,8 @@ impl TemplateFix {
     template.vars.iter().map(|v| v.0.used_var()).collect()
   }
 
-  /// Returns the source-backed metavariable when it is the entire template.
-  pub fn exact_var(&self) -> Option<&str> {
+  /// Returns the node-backed metavariable when it is the entire template.
+  pub fn exact_node_var(&self) -> Option<&MetaVariable> {
     let TemplateFix::WithMetaVar(template) = self else {
       return None;
     };
@@ -50,7 +50,7 @@ impl TemplateFix {
       return None;
     }
     match &template.vars[0].0 {
-      MetaVarExtract::Single(name) | MetaVarExtract::Multiple(name) => Some(name),
+      MetaVarExtract::Node(var) => Some(var),
       MetaVarExtract::Transformed(_) => None,
     }
   }
@@ -141,13 +141,13 @@ where
       let bytes = indent_lines::<D::Source>(*indent, de_intended);
       return Some(bytes);
     }
-    MetaVarExtract::Single(name) => {
+    MetaVarExtract::Node(MetaVariable::Capture(name, _)) => {
       let replaced = env.get_match(name)?;
       let source = replaced.get_doc().get_source();
       let range = replaced.range();
       (source, range)
     }
-    MetaVarExtract::Multiple(name) => {
+    MetaVarExtract::Node(MetaVariable::MultiCapture(name)) => {
       let nodes = env.get_multiple_matches(name);
       if nodes.is_empty() {
         return None;
@@ -159,6 +159,9 @@ where
       let end = nodes[nodes.len() - 1].range().end;
       let source = nodes[0].get_doc().get_source();
       (source, start..end)
+    }
+    MetaVarExtract::Node(MetaVariable::Dropped(_) | MetaVariable::Multiple) => {
+      unreachable!("template variables must be captured")
     }
   };
   let extracted = extract_with_deindent(source, range);
@@ -346,18 +349,29 @@ if (true) {
   }
 
   #[test]
-  fn test_exact_var() {
+  fn test_exact_node_var() {
     let exact = TemplateFix::try_new("$A", &Tsx).expect("ok");
-    assert_eq!(exact.exact_var(), Some("A"));
+    assert!(matches!(
+      exact.exact_node_var(),
+      Some(MetaVariable::Capture(name, true)) if name == "A"
+    ));
+    let exact_unnamed = TemplateFix::try_new("$$A", &Tsx).expect("ok");
+    assert!(matches!(
+      exact_unnamed.exact_node_var(),
+      Some(MetaVariable::Capture(name, false)) if name == "A"
+    ));
     let exact_multi = TemplateFix::try_new("$$$A", &Tsx).expect("ok");
-    assert_eq!(exact_multi.exact_var(), Some("A"));
+    assert!(matches!(
+      exact_multi.exact_node_var(),
+      Some(MetaVariable::MultiCapture(name)) if name == "A"
+    ));
 
     let surrounded = TemplateFix::try_new("prefix $A", &Tsx).expect("ok");
-    assert_eq!(surrounded.exact_var(), None);
+    assert_eq!(surrounded.exact_node_var(), None);
     let multiple = TemplateFix::try_new("$A$B", &Tsx).expect("ok");
-    assert_eq!(multiple.exact_var(), None);
+    assert_eq!(multiple.exact_node_var(), None);
     let transformed = TemplateFix::with_transform("$A", &Tsx, &["A".to_string()]);
-    assert_eq!(transformed.exact_var(), None);
+    assert_eq!(transformed.exact_node_var(), None);
   }
 
   // GH #641

--- a/crates/core/src/replacer/template.rs
+++ b/crates/core/src/replacer/template.rs
@@ -35,6 +35,25 @@ impl TemplateFix {
     };
     template.vars.iter().map(|v| v.0.used_var()).collect()
   }
+
+  /// Returns the source-backed metavariable when it is the entire template.
+  pub fn exact_var(&self) -> Option<&str> {
+    let TemplateFix::WithMetaVar(template) = self else {
+      return None;
+    };
+    if template.vars.len() != 1
+      || template
+        .fragments
+        .iter()
+        .any(|fragment| !fragment.is_empty())
+    {
+      return None;
+    }
+    match &template.vars[0].0 {
+      MetaVarExtract::Single(name) | MetaVarExtract::Multiple(name) => Some(name),
+      MetaVarExtract::Transformed(_) => None,
+    }
+  }
 }
 
 impl<D: Doc> Replacer<D> for TemplateFix {
@@ -324,6 +343,21 @@ if (true) {
     assert_eq!(tf.used_vars(), ["B", "C"].into_iter().collect());
     let tf = TemplateFix::try_new("$a$B$C", &Tsx).expect("ok");
     assert_eq!(tf.used_vars(), ["B", "C"].into_iter().collect());
+  }
+
+  #[test]
+  fn test_exact_var() {
+    let exact = TemplateFix::try_new("$A", &Tsx).expect("ok");
+    assert_eq!(exact.exact_var(), Some("A"));
+    let exact_multi = TemplateFix::try_new("$$$A", &Tsx).expect("ok");
+    assert_eq!(exact_multi.exact_var(), Some("A"));
+
+    let surrounded = TemplateFix::try_new("prefix $A", &Tsx).expect("ok");
+    assert_eq!(surrounded.exact_var(), None);
+    let multiple = TemplateFix::try_new("$A$B", &Tsx).expect("ok");
+    assert_eq!(multiple.exact_var(), None);
+    let transformed = TemplateFix::with_transform("$A", &Tsx, &["A".to_string()]);
+    assert_eq!(transformed.exact_var(), None);
   }
 
   // GH #641

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -12,7 +12,6 @@ use ast_grep_config::{
 use ast_grep_core::{
   Doc, Language, Node, NodeMatch,
   matcher::{Matcher, MatcherExt},
-  meta_var::MetaVariable,
   replacer::{Replacer, TemplateFix, TemplateFixError},
   source::Content,
 };
@@ -363,10 +362,7 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
   <D::Source as Content>::encode_bytes(&bytes).to_string()
 }
 
-fn default_signature<D: Doc>(
-  node_match: &NodeMatch<D>,
-  exact_name_var: Option<MetaVariable>,
-) -> String {
+fn default_signature<D: Doc>(node_match: &NodeMatch<D>, exact_name_var: Option<&str>) -> String {
   let node = node_match.get_node();
   if let Some(line) = signature_anchor_line(node_match, exact_name_var)
     && let Some(signature) = node_line(node, line)
@@ -378,20 +374,21 @@ fn default_signature<D: Doc>(
 
 fn signature_anchor_line<D: Doc>(
   node_match: &NodeMatch<D>,
-  exact_name_var: Option<MetaVariable>,
+  exact_name_var: Option<&str>,
 ) -> Option<usize> {
   let env = node_match.get_env();
-  env
-    .get_match("NAME")
-    .map(|node| node.start_pos().line())
-    .or_else(|| match exact_name_var? {
-      MetaVariable::Capture(name, _) => env.get_match(&name).map(|node| node.start_pos().line()),
-      MetaVariable::MultiCapture(name) => env
-        .get_multiple_matches(&name)
-        .first()
-        .map(|node| node.start_pos().line()),
-      MetaVariable::Dropped(_) | MetaVariable::Multiple => None,
-    })
+  let source_line = |name| {
+    env
+      .get_match(name)
+      .map(|node| node.start_pos().line())
+      .or_else(|| {
+        env
+          .get_multiple_matches(name)
+          .first()
+          .map(|node| node.start_pos().line())
+      })
+  };
+  source_line("NAME").or_else(|| source_line(exact_name_var?))
 }
 
 fn node_line<D: Doc>(node: &Node<D>, line: usize) -> Option<String> {

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -365,7 +365,7 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
 
 fn default_signature<D: Doc>(
   node_match: &NodeMatch<D>,
-  exact_name_var: Option<&MetaVariable>,
+  exact_name_var: Option<MetaVariable>,
 ) -> String {
   let node = node_match.get_node();
   if let Some(line) = signature_anchor_line(node_match, exact_name_var)
@@ -378,16 +378,16 @@ fn default_signature<D: Doc>(
 
 fn signature_anchor_line<D: Doc>(
   node_match: &NodeMatch<D>,
-  exact_name_var: Option<&MetaVariable>,
+  exact_name_var: Option<MetaVariable>,
 ) -> Option<usize> {
   let env = node_match.get_env();
   env
     .get_match("NAME")
     .map(|node| node.start_pos().line())
     .or_else(|| match exact_name_var? {
-      MetaVariable::Capture(name, _) => env.get_match(name).map(|node| node.start_pos().line()),
+      MetaVariable::Capture(name, _) => env.get_match(&name).map(|node| node.start_pos().line()),
       MetaVariable::MultiCapture(name) => env
-        .get_multiple_matches(name)
+        .get_multiple_matches(&name)
         .first()
         .map(|node| node.start_pos().line()),
       MetaVariable::Dropped(_) | MetaVariable::Multiple => None,

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -12,6 +12,7 @@ use ast_grep_config::{
 use ast_grep_core::{
   Doc, Language, Node, NodeMatch,
   matcher::{Matcher, MatcherExt},
+  meta_var::MetaVariable,
   replacer::{Replacer, TemplateFix, TemplateFixError},
   source::Content,
 };
@@ -352,7 +353,7 @@ impl<L: Language> ExtractorCommon<L> {
         .signature
         .as_ref()
         .map(|template| render_template(template, node_match))
-        .unwrap_or_else(|| default_signature(node_match, self.name.exact_var())),
+        .unwrap_or_else(|| default_signature(node_match, self.name.exact_node_var())),
     }
   }
 }
@@ -362,7 +363,10 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
   <D::Source as Content>::encode_bytes(&bytes).to_string()
 }
 
-fn default_signature<D: Doc>(node_match: &NodeMatch<D>, exact_name_var: Option<&str>) -> String {
+fn default_signature<D: Doc>(
+  node_match: &NodeMatch<D>,
+  exact_name_var: Option<&MetaVariable>,
+) -> String {
   let node = node_match.get_node();
   if let Some(line) = signature_anchor_line(node_match, exact_name_var)
     && let Some(signature) = node_line(node, line)
@@ -374,21 +378,20 @@ fn default_signature<D: Doc>(node_match: &NodeMatch<D>, exact_name_var: Option<&
 
 fn signature_anchor_line<D: Doc>(
   node_match: &NodeMatch<D>,
-  exact_name_var: Option<&str>,
+  exact_name_var: Option<&MetaVariable>,
 ) -> Option<usize> {
   let env = node_match.get_env();
-  let source_line = |name| {
-    env
-      .get_match(name)
-      .map(|node| node.start_pos().line())
-      .or_else(|| {
-        env
-          .get_multiple_matches(name)
-          .first()
-          .map(|node| node.start_pos().line())
-      })
-  };
-  source_line("NAME").or_else(|| source_line(exact_name_var?))
+  env
+    .get_match("NAME")
+    .map(|node| node.start_pos().line())
+    .or_else(|| match exact_name_var? {
+      MetaVariable::Capture(name, _) => env.get_match(name).map(|node| node.start_pos().line()),
+      MetaVariable::MultiCapture(name) => env
+        .get_multiple_matches(name)
+        .first()
+        .map(|node| node.start_pos().line()),
+      MetaVariable::Dropped(_) | MetaVariable::Multiple => None,
+    })
 }
 
 fn node_line<D: Doc>(node: &Node<D>, line: usize) -> Option<String> {

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -364,31 +364,26 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
 
 fn default_signature<D: Doc>(node_match: &NodeMatch<D>, exact_name_var: Option<&str>) -> String {
   let node = node_match.get_node();
-  if let Some(line) = signature_anchor_line(node_match, exact_name_var)
-    && let Some(signature) = node_line(node, line)
-  {
-    return signature;
-  }
-  first_non_empty_line(node.text().as_ref())
+  signature_anchor_line(node_match, exact_name_var)
+    .unwrap_or_else(|| first_non_empty_line(node.text().as_ref()))
 }
 
 fn signature_anchor_line<D: Doc>(
   node_match: &NodeMatch<D>,
   exact_name_var: Option<&str>,
-) -> Option<usize> {
+) -> Option<String> {
   let env = node_match.get_env();
-  let source_line = |name| {
-    env
-      .get_match(name)
-      .map(|node| node.start_pos().line())
-      .or_else(|| {
-        env
-          .get_multiple_matches(name)
-          .first()
-          .map(|node| node.start_pos().line())
-      })
-  };
-  source_line("NAME").or_else(|| source_line(exact_name_var?))
+  let var_name = exact_name_var?;
+  let line_num = env
+    .get_match(var_name)
+    .map(|node| node.start_pos().line())
+    .or_else(|| {
+      env
+        .get_multiple_matches(var_name)
+        .first()
+        .map(|node| node.start_pos().line())
+    })?;
+  node_line(node_match, line_num)
 }
 
 fn node_line<D: Doc>(node: &Node<D>, line: usize) -> Option<String> {
@@ -678,7 +673,7 @@ signature: class $CLASS
   }
 
   #[test]
-  fn exact_name_metavariable_anchors_default_signature() {
+  fn single_name_metavariable_anchors_default_signature() {
     let rule = parse_rule(
       r#"
 id: ts-export-class

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -139,8 +139,6 @@ pub struct ExtractorCommon<L: Language> {
   pub name: TemplateFix,
   /// Optional source-like signature template.
   pub signature: Option<TemplateFix>,
-  /// Source-backed metavariable used to locate the default signature line.
-  name_anchor: Option<String>,
   /// Requested text detail for this entry.
   detail: OutlineEntryDetail,
 }
@@ -169,11 +167,6 @@ impl<L: Language> ExtractorCommon<L> {
     let symbol_type = common.symbol_type;
     let transform_vars = transform_vars(&common.matcher);
     let compile = |tmpl| compile_template(tmpl, &common.language, &transform_vars);
-    let name_anchor = name_anchor(
-      &common.name,
-      common.language.meta_var_char(),
-      &transform_vars,
-    );
     let name = compile(&common.name)?;
     let signature = match detail {
       OutlineEntryDetail::Name => None,
@@ -185,7 +178,6 @@ impl<L: Language> ExtractorCommon<L> {
       symbol_type,
       name,
       signature,
-      name_anchor,
       detail,
     })
   }
@@ -360,7 +352,7 @@ impl<L: Language> ExtractorCommon<L> {
         .signature
         .as_ref()
         .map(|template| render_template(template, node_match))
-        .unwrap_or_else(|| default_signature(node_match, self.name_anchor.as_deref())),
+        .unwrap_or_else(|| default_signature(node_match, self.name.exact_var())),
     }
   }
 }
@@ -370,9 +362,9 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
   <D::Source as Content>::encode_bytes(&bytes).to_string()
 }
 
-fn default_signature<D: Doc>(node_match: &NodeMatch<D>, name_anchor: Option<&str>) -> String {
+fn default_signature<D: Doc>(node_match: &NodeMatch<D>, exact_name_var: Option<&str>) -> String {
   let node = node_match.get_node();
-  if let Some(line) = signature_anchor_line(node_match, name_anchor)
+  if let Some(line) = signature_anchor_line(node_match, exact_name_var)
     && let Some(signature) = node_line(node, line)
   {
     return signature;
@@ -382,7 +374,7 @@ fn default_signature<D: Doc>(node_match: &NodeMatch<D>, name_anchor: Option<&str
 
 fn signature_anchor_line<D: Doc>(
   node_match: &NodeMatch<D>,
-  name_anchor: Option<&str>,
+  exact_name_var: Option<&str>,
 ) -> Option<usize> {
   let env = node_match.get_env();
   let source_line = |name| {
@@ -396,7 +388,7 @@ fn signature_anchor_line<D: Doc>(
           .map(|node| node.start_pos().line())
       })
   };
-  source_line("NAME").or_else(|| source_line(name_anchor?))
+  source_line("NAME").or_else(|| source_line(exact_name_var?))
 }
 
 fn node_line<D: Doc>(node: &Node<D>, line: usize) -> Option<String> {
@@ -414,28 +406,6 @@ fn first_non_empty_line(text: &str) -> String {
       (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
     .unwrap_or_default()
-}
-
-fn name_anchor(
-  name: &str,
-  meta_var_char: char,
-  transform_vars: &Option<Vec<String>>,
-) -> Option<String> {
-  let marker_count = name.chars().take_while(|&c| c == meta_var_char).count();
-  if !(1..=3).contains(&marker_count) {
-    return None;
-  }
-  let variable = &name[marker_count * meta_var_char.len_utf8()..];
-  let mut chars = variable.chars();
-  if !chars.next().is_some_and(|c| c.is_ascii_uppercase())
-    || !chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
-    || transform_vars
-      .as_ref()
-      .is_some_and(|vars| vars.iter().any(|var| var == variable))
-  {
-    return None;
-  }
-  Some(variable.to_string())
 }
 
 fn source_range<D: Doc>(node: &Node<D>) -> SourceRange {
@@ -669,25 +639,7 @@ signature: function $NAME()
   }
 
   #[test]
-  fn finds_source_backed_name_anchors() {
-    let no_transforms = None;
-    assert_eq!(
-      name_anchor("$SYMBOL", '$', &no_transforms),
-      Some("SYMBOL".into())
-    );
-    assert_eq!(
-      name_anchor("$$$SYMBOLS", '$', &no_transforms),
-      Some("SYMBOLS".into())
-    );
-    assert_eq!(name_anchor("prefix-$SYMBOL", '$', &no_transforms), None);
-    assert_eq!(
-      name_anchor("$SYMBOL", '$', &Some(vec!["SYMBOL".into()])),
-      None
-    );
-  }
-
-  #[test]
-  fn explicit_signature_wins_over_name_anchor() {
+  fn explicit_signature_wins_over_name_metavariable() {
     let rule = parse_rule(
       r#"
 id: ts-export-class

--- a/crates/outline/src/extractor.rs
+++ b/crates/outline/src/extractor.rs
@@ -139,6 +139,8 @@ pub struct ExtractorCommon<L: Language> {
   pub name: TemplateFix,
   /// Optional source-like signature template.
   pub signature: Option<TemplateFix>,
+  /// Source-backed metavariable used to locate the default signature line.
+  name_anchor: Option<String>,
   /// Requested text detail for this entry.
   detail: OutlineEntryDetail,
 }
@@ -167,6 +169,11 @@ impl<L: Language> ExtractorCommon<L> {
     let symbol_type = common.symbol_type;
     let transform_vars = transform_vars(&common.matcher);
     let compile = |tmpl| compile_template(tmpl, &common.language, &transform_vars);
+    let name_anchor = name_anchor(
+      &common.name,
+      common.language.meta_var_char(),
+      &transform_vars,
+    );
     let name = compile(&common.name)?;
     let signature = match detail {
       OutlineEntryDetail::Name => None,
@@ -178,6 +185,7 @@ impl<L: Language> ExtractorCommon<L> {
       symbol_type,
       name,
       signature,
+      name_anchor,
       detail,
     })
   }
@@ -352,7 +360,7 @@ impl<L: Language> ExtractorCommon<L> {
         .signature
         .as_ref()
         .map(|template| render_template(template, node_match))
-        .unwrap_or_else(|| default_signature(node_match.get_node())),
+        .unwrap_or_else(|| default_signature(node_match, self.name_anchor.as_deref())),
     }
   }
 }
@@ -362,15 +370,72 @@ fn render_template<D: Doc>(template: &TemplateFix, node_match: &NodeMatch<D>) ->
   <D::Source as Content>::encode_bytes(&bytes).to_string()
 }
 
-fn default_signature<D: Doc>(node: &Node<D>) -> String {
-  node
-    .text()
+fn default_signature<D: Doc>(node_match: &NodeMatch<D>, name_anchor: Option<&str>) -> String {
+  let node = node_match.get_node();
+  if let Some(line) = signature_anchor_line(node_match, name_anchor)
+    && let Some(signature) = node_line(node, line)
+  {
+    return signature;
+  }
+  first_non_empty_line(node.text().as_ref())
+}
+
+fn signature_anchor_line<D: Doc>(
+  node_match: &NodeMatch<D>,
+  name_anchor: Option<&str>,
+) -> Option<usize> {
+  let env = node_match.get_env();
+  let source_line = |name| {
+    env
+      .get_match(name)
+      .map(|node| node.start_pos().line())
+      .or_else(|| {
+        env
+          .get_multiple_matches(name)
+          .first()
+          .map(|node| node.start_pos().line())
+      })
+  };
+  source_line("NAME").or_else(|| source_line(name_anchor?))
+}
+
+fn node_line<D: Doc>(node: &Node<D>, line: usize) -> Option<String> {
+  let relative_line = line.checked_sub(node.start_pos().line())?;
+  let text = node.text();
+  let trimmed = text.lines().nth(relative_line)?.trim();
+  (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn first_non_empty_line(text: &str) -> String {
+  text
     .lines()
     .find_map(|line| {
       let trimmed = line.trim();
       (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
     .unwrap_or_default()
+}
+
+fn name_anchor(
+  name: &str,
+  meta_var_char: char,
+  transform_vars: &Option<Vec<String>>,
+) -> Option<String> {
+  let marker_count = name.chars().take_while(|&c| c == meta_var_char).count();
+  if !(1..=3).contains(&marker_count) {
+    return None;
+  }
+  let variable = &name[marker_count * meta_var_char.len_utf8()..];
+  let mut chars = variable.chars();
+  if !chars.next().is_some_and(|c| c.is_ascii_uppercase())
+    || !chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    || transform_vars
+      .as_ref()
+      .is_some_and(|vars| vars.iter().any(|var| var == variable))
+  {
+    return None;
+  }
+  Some(variable.to_string())
 }
 
 fn source_range<D: Doc>(node: &Node<D>) -> SourceRange {
@@ -601,6 +666,101 @@ signature: function $NAME()
         .as_ref()
         .is_some_and(|signature| signature.used_vars().contains("NAME"))
     );
+  }
+
+  #[test]
+  fn finds_source_backed_name_anchors() {
+    let no_transforms = None;
+    assert_eq!(
+      name_anchor("$SYMBOL", '$', &no_transforms),
+      Some("SYMBOL".into())
+    );
+    assert_eq!(
+      name_anchor("$$$SYMBOLS", '$', &no_transforms),
+      Some("SYMBOLS".into())
+    );
+    assert_eq!(name_anchor("prefix-$SYMBOL", '$', &no_transforms), None);
+    assert_eq!(
+      name_anchor("$SYMBOL", '$', &Some(vec!["SYMBOL".into()])),
+      None
+    );
+  }
+
+  #[test]
+  fn explicit_signature_wins_over_name_anchor() {
+    let rule = parse_rule(
+      r#"
+id: ts-export-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: class_declaration
+    has:
+      field: name
+      pattern: $CLASS
+name: $CLASS
+signature: class $CLASS
+"#,
+    );
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Signature)
+      .expect("item rule should parse");
+    let root = SupportLang::TypeScript.ast_grep("@Injectable()\nexport class Foo {}");
+    let export = root
+      .root()
+      .children()
+      .find(|node| node.kind() == "export_statement")
+      .expect("export should exist");
+    let node_match = item
+      .match_node(&export)
+      .expect("export should match item rule");
+    let outline = item.extract(&node_match, vec![]);
+
+    assert_eq!(outline.entry.signature, "class Foo");
+  }
+
+  #[test]
+  fn exact_name_metavariable_anchors_default_signature() {
+    let rule = parse_rule(
+      r#"
+id: ts-export-class
+language: TypeScript
+role: item
+symbolType: class
+rule:
+  kind: export_statement
+  has:
+    field: declaration
+    kind: class_declaration
+    has:
+      field: name
+      pattern: $CLASS
+name: $CLASS
+"#,
+    );
+    let SerializableOutlineRule::Item(item) = rule else {
+      panic!("expected item rule");
+    };
+    let item = ItemExtractor::try_from(item, &Default::default(), OutlineEntryDetail::Signature)
+      .expect("item rule should parse");
+    let root = SupportLang::TypeScript.ast_grep("@Injectable()\nexport class Foo {}");
+    let export = root
+      .root()
+      .children()
+      .find(|node| node.kind() == "export_statement")
+      .expect("export should exist");
+    let node_match = item
+      .match_node(&export)
+      .expect("export should match item rule");
+    let outline = item.extract(&node_match, vec![]);
+
+    assert_eq!(outline.entry.signature, "export class Foo {}");
   }
 
   #[test]

--- a/crates/outline/tests/javascript_outline_rules.rs
+++ b/crates/outline/tests/javascript_outline_rules.rs
@@ -101,3 +101,22 @@ export class Service {
 "#,
   );
 }
+
+#[test]
+fn extracts_decorated_javascript_signatures_from_declaration_lines() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::JavaScript,
+    JAVASCRIPT_RULES,
+    r#"
+@Injectable()
+export class Service {
+  @ApiProperty()
+  email;
+}
+"#,
+    r#"
+- Class item exported Service | export class Service {
+  - Field public email | email
+"#,
+  );
+}

--- a/crates/outline/tests/typescript_outline_rules.rs
+++ b/crates/outline/tests/typescript_outline_rules.rs
@@ -189,6 +189,25 @@ export interface Parser {
 }
 
 #[test]
+fn extracts_decorated_typescript_signatures_from_declaration_lines() {
+  common::assert_outline_signature_snapshot(
+    SupportLang::TypeScript,
+    TYPESCRIPT_RULES,
+    r#"
+@Injectable()
+export class Foo implements Bar {
+  @ApiProperty()
+  email: string;
+}
+"#,
+    r#"
+- Class item exported Foo | export class Foo implements Bar {
+  - Field public email | email: string
+"#,
+  );
+}
+
+#[test]
 fn extracts_typescript_namespaces_as_standalone_items() {
   common::assert_outline_snapshot(
     SupportLang::TypeScript,


### PR DESCRIPTION
## Summary

- keep explicit outline signature templates authoritative
- anchor fallback signatures to NAME or an exact, source-backed name metavariable
- retain the first non-empty matched line when no source-backed name is available
- cover decorated TypeScript and JavaScript classes and fields

## Testing

- cargo test -p ast-grep-outline
- cargo clippy -p ast-grep-outline --tests -- -D warnings
- cargo fmt --all -- --check

Fixes #2910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JavaScript and TypeScript outline extraction for declarations with decorators.
  - Decorated classes and fields now appear correctly in outlines, including exported classes and public properties.
  - Improved signature and anchor resolution for template-based matches, including exact-name and multi-match patterns.

- **Tests**
  - Added coverage for decorated JavaScript and TypeScript declarations.
  - Added validation for exact-name template matching and anchor resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->