### PR TITLE
feat: add min-severity cli

### DIFF
--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -217,6 +217,7 @@ fn no_suppress_all_rule_config(overwrite: &RuleOverwrite) -> RuleConfig<SgLang> 
     .find(NO_SUPPRESS_ALL_ID)
     .severity
     .unwrap_or(Severity::Off);
+  let severity = overwrite.apply_min_severity(severity);
   CombinedScan::no_suppress_all_config(severity, SupportLang::Rust.into())
 }
 
@@ -225,6 +226,7 @@ fn unused_suppression_rule_config(arg: &ScanArg, overwrite: &RuleOverwrite) -> R
     .find(UNUSED_SUPPRESSION_ID)
     .severity
     .unwrap_or_else(|| default_unused_suppression_rule_severity(arg));
+  let severity = overwrite.apply_min_severity(severity);
   CombinedScan::unused_config(severity, SupportLang::Rust.into())
 }
 
@@ -356,7 +358,10 @@ impl StdInWorker for ScanStdin {
     processor: &P::Processor,
   ) -> Result<Vec<P::Processed>> {
     use ast_grep_core::tree_sitter::LanguageExt;
-    let lang = self.rules[0].language;
+    let Some(first_rule) = self.rules.first() else {
+      return Ok(vec![]);
+    };
+    let lang = first_rule.language;
     let combined = CombinedScan::new(self.rules.iter().collect());
     let grep = lang.ast_grep(src);
     let path = Path::new("STDIN");

--- a/crates/cli/src/scan.rs
+++ b/crates/cli/src/scan.rs
@@ -476,6 +476,7 @@ rule:
       },
       overwrite: OverwriteArgs {
         filter: None,
+        min_severity: Severity::Off,
         error: None,
         warning: None,
         info: None,

--- a/crates/cli/src/utils/args.rs
+++ b/crates/cli/src/utils/args.rs
@@ -4,6 +4,7 @@ use crate::utils::ErrorContext as EC;
 use crate::utils::Granularity;
 
 use anyhow::{Context, Result};
+use ast_grep_config::Severity;
 use clap::{Args, ValueEnum};
 use ignore::{
   WalkBuilder, WalkParallel,
@@ -300,6 +301,13 @@ pub struct OverwriteArgs {
   /// set of rule definitions within a project.
   #[clap(long, conflicts_with = "rule", value_name = "REGEX")]
   pub filter: Option<Regex>,
+
+  /// Set the minimum severity of rules to scan.
+  ///
+  /// Rules with severity lower than the specified value will be ignored.
+  #[clap(long, value_name = "SEVERITY", default_value = "off")]
+  pub min_severity: Severity,
+
   /// Set rule severity to error
   ///
   /// This flag sets the specified RULE_ID's severity to error. You can specify multiple rules by using the flag multiple times,
@@ -340,7 +348,7 @@ pub struct OverwriteArgs {
 impl OverwriteArgs {
   /// Returns true if none rule is turned off on CLI nor filtered out
   pub fn include_all_rules(&self) -> bool {
-    self.filter.is_none() && self.off.is_none()
+    self.filter.is_none() && self.off.is_none() && self.min_severity == Severity::Off
   }
 }
 

--- a/crates/cli/src/utils/rule_overwrite.rs
+++ b/crates/cli/src/utils/rule_overwrite.rs
@@ -123,6 +123,14 @@ impl RuleOverwrite {
       .or_else(|| self.default_severity.clone());
     OverwriteResult { severity }
   }
+
+  pub fn apply_min_severity(&self, severity: Severity) -> Severity {
+    if severity >= self.min_severity {
+      severity
+    } else {
+      Severity::Off
+    }
+  }
 }
 
 fn filter_rule_by_regex(

--- a/crates/cli/src/utils/rule_overwrite.rs
+++ b/crates/cli/src/utils/rule_overwrite.rs
@@ -14,6 +14,7 @@ pub struct RuleOverwrite {
   default_severity: Option<Severity>,
   by_rule_id: HashMap<String, Severity>,
   rule_filter: Option<Regex>,
+  min_severity: Severity,
 }
 
 fn read_severity(
@@ -42,6 +43,7 @@ impl RuleOverwrite {
       },
       by_rule_id: HashMap::new(),
       rule_filter: filter.cloned(),
+      min_severity: Severity::Off,
     }
   }
   pub fn new(cli: &OverwriteArgs) -> Result<Self> {
@@ -81,6 +83,7 @@ impl RuleOverwrite {
       default_severity,
       by_rule_id,
       rule_filter: cli.filter.clone(),
+      min_severity: cli.min_severity.clone(),
     })
   }
 
@@ -88,16 +91,28 @@ impl RuleOverwrite {
     &self,
     configs: Vec<RuleConfig<SgLang>>,
   ) -> Result<Vec<RuleConfig<SgLang>>> {
-    let mut configs = if let Some(filter) = &self.rule_filter {
+    let configs = if let Some(filter) = &self.rule_filter {
       filter_rule_by_regex(configs, filter)?
     } else {
       configs
     };
-    for config in &mut configs {
-      let overwrite = self.find(&config.id);
-      overwrite.overwrite(config);
-    }
+    let configs = configs
+      .into_iter()
+      .filter_map(|config| self.process_one_config(config))
+      .collect();
     Ok(configs)
+  }
+
+  fn process_one_config(&self, mut config: RuleConfig<SgLang>) -> Option<RuleConfig<SgLang>> {
+    // overwrite severity
+    let overwrite = self.find(&config.id);
+    overwrite.overwrite(&mut config);
+    // remove rules that are below min_severity
+    if config.severity >= self.min_severity {
+      Some(config)
+    } else {
+      None
+    }
   }
 
   pub fn find(&self, id: &str) -> OverwriteResult {

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -376,6 +376,58 @@ fn test_severity_threshold_uses_overwritten_severity() -> Result<()> {
 }
 
 #[test]
+fn test_min_severity_filters_all_stdin_rules() -> Result<()> {
+  let inline_rule =
+    "{id: hint-rule, severity: hint, language: ts, rule: {pattern: console.log($A)}}";
+  Command::new(cargo_bin!())
+    .args([
+      "scan",
+      "--stdin",
+      "--min-severity=warning",
+      "--inline-rules",
+      inline_rule,
+      "--json=compact",
+    ])
+    .write_stdin("console.log(123)")
+    .assert()
+    .success()
+    .stdout(predicate::eq("[]\n"));
+  Ok(())
+}
+
+#[test]
+fn test_min_severity_filters_builtin_rules() -> Result<()> {
+  let unused = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/rule.yml", RULE1),
+    ("test.ts", "None(123) // ast-grep-ignore"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(unused.path())
+    .args([
+      "scan",
+      "--min-severity=warning",
+      "--hint=unused-suppression",
+    ])
+    .assert()
+    .success()
+    .stdout(contains("unused-suppression").not());
+
+  let suppress_all = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/rule.yml", RULE1),
+    ("test.ts", "Some(123) // ast-grep-ignore"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(suppress_all.path())
+    .args(["scan", "--min-severity=error", "--warning=no-suppress-all"])
+    .assert()
+    .success()
+    .stdout(contains("no-suppress-all").not());
+  Ok(())
+}
+
+#[test]
 fn test_severity_override_with_rule_path() -> Result<()> {
   let dir = setup()?;
   Command::new(cargo_bin!())

--- a/crates/cli/tests/scan_test.rs
+++ b/crates/cli/tests/scan_test.rs
@@ -34,6 +34,32 @@ rule:
   pattern: Some($A)
 ";
 
+const SEVERITY_RULES: &str = "
+id: hint-rule
+message: hint rule
+severity: hint
+language: TypeScript
+rule: { pattern: Some($A) }
+---
+id: info-rule
+message: info rule
+severity: info
+language: TypeScript
+rule: { pattern: Some($A) }
+---
+id: warning-rule
+message: warning rule
+severity: warning
+language: TypeScript
+rule: { pattern: Some($A) }
+---
+id: error-rule
+message: error rule
+severity: error
+language: TypeScript
+rule: { pattern: Some($A) }
+";
+
 const FIXABLE_JS_RULE: &str = "
 id: no-var
 message: use let
@@ -296,6 +322,56 @@ fn test_severity_override() -> Result<()> {
     .assert()
     .success()
     .stdout(contains("warning"));
+  Ok(())
+}
+
+#[test]
+fn test_severity_threshold_filters_output_and_rule_tally() -> Result<()> {
+  let dir = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/severity.yml", SEVERITY_RULES),
+    ("test.ts", "Some(123)"),
+  ])?;
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args([
+      "scan",
+      "--min-severity",
+      "warning",
+      "--color=never",
+      "--report-style=short",
+      "--inspect=summary",
+    ])
+    .assert()
+    .failure()
+    .stdout(contains("error-rule"))
+    .stdout(contains("warning-rule"))
+    .stdout(contains("info-rule").not())
+    .stdout(contains("hint-rule").not())
+    .stderr(contains("effectiveRuleCount=2,skippedRuleCount=2"))
+    .stderr(contains("1 error(s) found in code"));
+  Ok(())
+}
+
+#[test]
+fn test_severity_threshold_uses_overwritten_severity() -> Result<()> {
+  let dir = create_test_files([
+    ("sgconfig.yml", CONFIG),
+    ("rules/severity.yml", SEVERITY_RULES),
+    ("test.ts", "Some(123)"),
+  ])?;
+
+  Command::new(cargo_bin!())
+    .current_dir(dir.path())
+    .args([
+      "scan",
+      "--min-severity=error",
+      "--warning=error-rule",
+      "--json=compact",
+    ])
+    .assert()
+    .success()
+    .stdout(contains("error-rule").not());
   Ok(())
 }
 

--- a/crates/config/src/rule_config.rs
+++ b/crates/config/src/rule_config.rs
@@ -22,10 +22,15 @@ use thiserror::Error;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Clone, Default, JsonSchema, Debug)]
+#[derive(
+  Serialize, Deserialize, Clone, Default, JsonSchema, Debug, PartialOrd, Ord, PartialEq, Eq,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum Severity {
+  /// Turns off the rule.
+  Off,
   #[default]
   /// A kind reminder for code with potential improvement.
   Hint,
@@ -35,8 +40,20 @@ pub enum Severity {
   Warning,
   /// An error that code produces bugs or has logic errors.
   Error,
-  /// Turns off the rule.
-  Off,
+}
+
+impl FromStr for Severity {
+  type Err = String;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s.to_lowercase().as_str() {
+      "hint" => Ok(Severity::Hint),
+      "info" => Ok(Severity::Info),
+      "warning" => Ok(Severity::Warning),
+      "error" => Ok(Severity::Error),
+      "off" => Ok(Severity::Off),
+      _ => Err(format!("Invalid severity level: {}", s)),
+    }
+  }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
fix #2720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--min-severity` option to filter rules by severity: hint, info, warning, error, or off.
  * Severity values are accepted case-insensitively.
  * Rules below the selected threshold are excluded from scans.

* **Bug Fixes**
  * Rule overrides now work correctly with minimum-severity filtering.
  * Scan results and rule counts accurately reflect filtered rules.
  * Scans with no configured rules now complete safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->